### PR TITLE
Disable -Wshadow in http:get

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,6 +24,7 @@ build:gnulike --cxxopt='-Wundef'
 build:gnulike --cxxopt='-fno-common'
 build:gnulike --per_file_copt='http:get@-Wno-sign-compare' # asio leaks this into our code.
 build:gnulike --per_file_copt='http:get@-Wno-undef' # asio leaks this into our code.
+build:gnulike --per_file_copt='http:get@-Wno-shadow' # asio leaks this into our code.
 build:gnulike --per_file_copt='external/asio[:/]@-Wno-sign-compare'
 build:gnulike --per_file_copt='external/asio[:/]@-Wno-undef'
 build:gnulike --per_file_copt='external/boringssl[:/]@-Wno-unused-parameter'


### PR DESCRIPTION
* Needed to build with clang-10:
In file included from http/get.cpp:3:
In file included from external/asio/_virtual_includes/asio/asio.hpp:111:
In file included from external/asio/_virtual_includes/asio/asio/ip/basic_resolver.hpp:30:
In file included from external/asio/_virtual_includes/asio/asio/ip/basic_resolver_query.hpp:21:
In file included from external/asio/_virtual_includes/asio/asio/ip/resolver_query_base.hpp:19:
external/asio/_virtual_includes/asio/asio/ip/resolver_base.hpp:68:5: error: declaration shadows a variable in namespace 'asio::ip' [-Werror,-Wshadow]
    v4_mapped = ASIO_OS_DEF(AI_V4MAPPED),
    ^
external/asio/_virtual_includes/asio/asio/ip/address_v6.hpp:295:20: note: previous declaration is here
enum v4_mapped_t { v4_mapped };