### PR TITLE
style: Add support for applying a stylesheet to the dom

### DIFF
--- a/dom/dom.h
+++ b/dom/dom.h
@@ -40,6 +40,22 @@ inline Node create_element_node(std::string_view name, AttrMap attrs, std::vecto
 
 std::string to_string(Node const &node);
 
+inline bool operator==(dom::Doctype const &a, dom::Doctype const &b) noexcept {
+    return a.doctype == b.doctype;
+}
+
+inline bool operator==(dom::Text const &a, dom::Text const &b) noexcept {
+    return a.text == b.text;
+}
+
+inline bool operator==(dom::Element const &a, dom::Element const &b) noexcept {
+    return a.name == b.name && a.attributes == b.attributes;
+}
+
+inline bool operator==(dom::Node const &a, dom::Node const &b) noexcept {
+    return a.children == b.children && a.data == b.data;
+}
+
 } // namespace dom
 
 #endif

--- a/style/BUILD
+++ b/style/BUILD
@@ -3,7 +3,10 @@ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 cc_library(
     name = "style",
     srcs = ["style.cpp"],
-    hdrs = ["style.h"],
+    hdrs = [
+        "style.h",
+        "styled_node.h",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//css",

--- a/style/style.cpp
+++ b/style/style.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <utility>
 
 namespace style {
 
@@ -28,6 +29,23 @@ std::vector<std::pair<std::string, std::string>> matching_rules(
     }
 
     return matched_rules;
+}
+
+StyledNode style_tree(dom::Node const &root, std::vector<css::Rule> const &stylesheet) {
+    std::vector<StyledNode> children{};
+    for (auto const &child : root.children) {
+        children.push_back(style_tree(child, stylesheet));
+    }
+
+    auto properties = std::holds_alternative<dom::Element>(root.data)
+            ? matching_rules(std::get<dom::Element>(root.data), stylesheet)
+            : std::vector<std::pair<std::string, std::string>>{};
+
+    return {
+        .node = root,
+        .properties = std::move(properties),
+        .children = std::move(children),
+    };
 }
 
 } // namespace style

--- a/style/style.h
+++ b/style/style.h
@@ -3,6 +3,7 @@
 
 #include "css/rule.h"
 #include "dom/dom.h"
+#include "style/styled_node.h"
 
 #include <string_view>
 #include <string>
@@ -16,6 +17,8 @@ bool is_match(dom::Element const &element, std::string_view selector);
 std::vector<std::pair<std::string, std::string>> matching_rules(
         dom::Element const &element,
         std::vector<css::Rule> const &stylesheet);
+
+StyledNode style_tree(dom::Node const &root, std::vector<css::Rule> const &stylesheet);
 
 } // namespace style
 

--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -1,0 +1,24 @@
+#ifndef STYLE_STYLED_NODE_H_
+#define STYLE_STYLED_NODE_H_
+
+#include "dom/dom.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace style {
+
+struct StyledNode {
+    dom::Node const &node;
+    std::vector<std::pair<std::string, std::string>> properties;
+    std::vector<StyledNode> children;
+};
+
+inline bool operator==(style::StyledNode const &a, style::StyledNode const &b) noexcept {
+    return a.node == b.node && a.properties == b.properties && a.children == b.children;
+}
+
+} // namespace style
+
+#endif


### PR DESCRIPTION
@zer0-one PTAL. I've invited you to collaborate on this repo. We'll move it to a separate org later.

This handles taking the prepared css rules and applying them to the dom tree, returning an overlay tree where the nodes are decorated with the styles that matched.

I didn't add it in this PR, but this overlay tree should probably prune all branches with `display: none` set.

Next one will be the layout library that will consume the styled tree and use the height/width, padding, and margin attributes to create a skeleton with known positions and sizes for rendering.