### PR TITLE
Use system fmt instead of spdlog bundled version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,12 @@ find_package(Asio REQUIRED)
 find_package(fmt REQUIRED)
 find_package(spdlog REQUIRED)
 
+if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY lib)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY lib)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin)
+endif()
+
 # css
 add_library(hastur_css
     css/parse.cpp

--- a/cmake/Findspdlog.cmake
+++ b/cmake/Findspdlog.cmake
@@ -14,8 +14,10 @@ mark_as_advanced(spdlog_INCLUDE_DIR)
 
 if(spdlog_FOUND)
     add_library(spdlog::spdlog INTERFACE IMPORTED)
+    target_link_libraries(spdlog::spdlog INTERFACE fmt::fmt)
     set_target_properties(spdlog::spdlog
         PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES ${spdlog_INCLUDE_DIR}
     )
+    target_compile_definitions(spdlog::spdlog INTERFACE SPDLOG_FMT_EXTERNAL)
 endif()


### PR DESCRIPTION
CMake build fails if distro package does not ship with bundled fmt.