### PR TITLE
http: Replace logging with error codes

### DIFF
--- a/browser/BUILD
+++ b/browser/BUILD
@@ -30,5 +30,6 @@ cc_binary(
         "@imgui",
         "@imgui-sfml",
         "@sfml//:graphics",
+        "@spdlog",
     ],
 )

--- a/browser/tui.cpp
+++ b/browser/tui.cpp
@@ -15,8 +15,8 @@ int main(int argc, char **argv) {
 
     spdlog::info("Fetching HTML from {}", endpoint);
     auto response = http::get(endpoint);
-    if (response.header.empty() || response.body.empty()) {
-        spdlog::error("Got no response from {}", endpoint);
+    if (response.err != http::Error::Ok) {
+        spdlog::error("Got error {} from {}", response.err, endpoint);
         return 1;
     }
 

--- a/http/BUILD
+++ b/http/BUILD
@@ -8,6 +8,5 @@ cc_library(
     deps = [
         "@asio",
         "@fmt",
-        "@spdlog",
     ],
 )

--- a/http/get.h
+++ b/http/get.h
@@ -6,7 +6,14 @@
 
 namespace http {
 
+enum class Error {
+    Ok,
+    Unresolved,
+    Unhandled,
+};
+
 struct Response {
+    Error err;
     std::string header;
     std::string body;
 };


### PR DESCRIPTION
This means fewer dependencies in core libraries and that applications
can choose how to handle and display the different errors themselves.