### PR TITLE
Add clang 13 to ci

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,6 +54,10 @@ build:clang --config=gnulike
 build:clang --per_file_copt='external/boringssl[:/]@-Wno-extra-semi'
 build:clang --per_file_copt='external/boringssl[:/]@-Wno-gnu-binary-literal'
 
+build:clang13 --config=clang
+build:clang13 --per_file_copt='external/libpng[:/]@-Wno-null-pointer-subtraction'
+build:clang13 --per_file_copt='external/libpng[:/]@-Wno-unused-but-set-variable'
+
 build:gcc --config=gnulike
 build:gcc --per_file_copt='external/boringssl[:/]@-Wno-cast-function-type'
 build:gcc --per_file_copt='external/boringssl[:/]@-Wno-pedantic'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,48 +10,57 @@ jobs:
       matrix:
         include:
           - name: gcc
-            bazel: --config gcc
-            cc: gcc-10
-            cxx: g++-10
+            compiler: gcc
+            version: 10
 
           - name: clang-10
-            bazel: --config clang
-            cc: clang-10
-            cxx: clang++-10
+            compiler: clang
+            version: 10
 
           - name: clang-12
-            bazel: --config clang
-            cc: clang-12
-            cxx: clang++-12
-            apt: clang-12
+            compiler: clang
+            version: 12
 
           - name: clang-asan
-            bazel: --config clang --config asan
-            cc: clang-12
-            cxx: clang++-12
-            apt: clang-12
+            compiler: clang
+            version: 12
+            bazel-extra: --config asan
 
           - name: clang-ubsan
-            bazel: --config clang --config ubsan
-            cc: clang-12
-            cxx: clang++-12
-            apt: clang-12
+            compiler: clang
+            version: 12
+            bazel-extra: --config ubsan
 
     steps:
+    - name: Prepare clang install
+      if: startsWith(matrix.compiler, 'clang')
+      uses: myci-actions/add-deb-repo@10
+      with:
+        repo: deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${{ matrix.version }} main
+        repo-name: llvm-toolchain-focal-${{ matrix.version }}
+        keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
+    - name: Setup gcc
+      if: startsWith(matrix.compiler, 'gcc')
+      run: |
+        echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+        echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
+    - name: Setup clang
+      if: startsWith(matrix.compiler, 'clang')
+      run: |
+        echo "CC=clang-${{ matrix.version }}" >> $GITHUB_ENV
+        echo "CXX=clang++-${{ matrix.version }}" >> $GITHUB_ENV
     - uses: actions/checkout@v2
     - name: Install
       run: |
           sudo apt update
-          sudo apt install libxrandr-dev libgl-dev ${{ matrix.apt }}
-          echo "CC=${{ matrix.cc }}" >> $GITHUB_ENV
-          echo "CXX=${{ matrix.cxx }}" >> $GITHUB_ENV
+          sudo apt install libxrandr-dev libgl-dev ${{ matrix.compiler }}-${{ matrix.version }}
           wget https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64 --output-document=bazel
     - name: Build
-      run: bazel build //... ${{ matrix.bazel }}
+      run: bazel build //... --config ${{ matrix.compiler }} ${{ matrix.bazel-extra }}
     - name: Test
-      run: bazel test //... ${{ matrix.bazel }}
+      run: bazel test //... --config ${{ matrix.compiler }} ${{ matrix.bazel-extra }}
     - name: Run
-      run: bazel run browser:tui ${{ matrix.bazel }}
+      run: bazel run browser:tui --config ${{ matrix.compiler }} ${{ matrix.bazel-extra }}
 
   windows-msvc:
     runs-on: windows-2019

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,24 +12,32 @@ jobs:
           - name: gcc
             compiler: gcc
             version: 10
+            bazel: --config gcc
 
           - name: clang-10
             compiler: clang
             version: 10
+            bazel: --config clang
 
           - name: clang-12
             compiler: clang
             version: 12
+            bazel: --config clang
+
+          - name: clang-13
+            compiler: clang
+            version: 13
+            bazel: --config clang13
 
           - name: clang-asan
             compiler: clang
-            version: 12
-            bazel-extra: --config asan
+            version: 13
+            bazel: --config clang13 --config asan
 
           - name: clang-ubsan
             compiler: clang
-            version: 12
-            bazel-extra: --config ubsan
+            version: 13
+            bazel: --config clang13 --config ubsan
 
     steps:
     - name: Prepare clang install
@@ -56,11 +64,11 @@ jobs:
           sudo apt install libxrandr-dev libgl-dev ${{ matrix.compiler }}-${{ matrix.version }}
           wget https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64 --output-document=bazel
     - name: Build
-      run: bazel build //... --config ${{ matrix.compiler }} ${{ matrix.bazel-extra }}
+      run: bazel build //... ${{ matrix.bazel }}
     - name: Test
-      run: bazel test //... --config ${{ matrix.compiler }} ${{ matrix.bazel-extra }}
+      run: bazel test //... ${{ matrix.bazel }}
     - name: Run
-      run: bazel run browser:tui --config ${{ matrix.compiler }} ${{ matrix.bazel-extra }}
+      run: bazel run browser:tui ${{ matrix.bazel }}
 
   windows-msvc:
     runs-on: windows-2019


### PR DESCRIPTION
Some refactoring of CI steps to install newer versions of clang on Ubuntu.
Added a new build configuration for clang 13 where a couple of warnings are disabled for libpng.