### PR TITLE
Fix rendering of anonymous blocks and their children

### DIFF
--- a/browser/gui.cpp
+++ b/browser/gui.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
+#include "css/default.h"
 #include "css/parse.h"
 #include "html/parse.h"
 #include "layout/layout.h"
@@ -197,9 +198,7 @@ int main(int argc, char **argv) {
                         window.setTitle(kBrowserTitle);
                     }
 
-                    std::vector<css::Rule> stylesheet{
-                            {{"head"}, {{"display", "none"}}},
-                    };
+                    auto stylesheet{css::default_style()};
 
                     if (auto style = try_get_text_content(dom, "html.head.style"sv)) {
                         auto new_rules = css::parse(*style);

--- a/browser/tui.cpp
+++ b/browser/tui.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "tui/tui.h"
+#include "css/default.h"
 #include "dom/dom.h"
 #include "html/parse.h"
 #include "layout/layout.h"
@@ -45,8 +46,7 @@ int main(int argc, char **argv) {
     std::cout << dom::to_string(dom);
 
     spdlog::info("Styling tree");
-    std::vector<css::Rule> stylesheet{{{"head"}, {{"display", "none"}}}};
-    auto styled = style::style_tree(dom.html, stylesheet);
+    auto styled = style::style_tree(dom.html, css::default_style());
 
     spdlog::info("Creating layout");
     // 0 as the width is fine as we don't use the measurements when rendering the tui.

--- a/css/BUILD
+++ b/css/BUILD
@@ -2,12 +2,17 @@ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
     name = "css",
-    srcs = ["parse.cpp"],
+    srcs = [
+        "default.cpp",
+        "parse.cpp",
+    ],
     hdrs = [
+        "default.h",
         "parse.h",
         "parser.h",
         "rule.h",
     ],
+    data = ["default.css"],
     visibility = ["//visibility:public"],
     deps = ["//util"],
 )

--- a/css/default.cpp
+++ b/css/default.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "css/default.h"
+
+#include "css/parse.h"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace css {
+
+std::vector<css::Rule> default_style() {
+    auto path = std::filesystem::path("css/default.css");
+    if (!exists(path) || !is_regular_file(path)) {
+        return {};
+    }
+
+    auto file = std::ifstream(path, std::ios::in | std::ios::binary);
+    auto size = file_size(path);
+    auto content = std::string(size, '\0');
+    file.read(content.data(), size);
+    return css::parse(content);
+}
+
+} // namespace css

--- a/css/default.css
+++ b/css/default.css
@@ -1,0 +1,3 @@
+head {
+    display: none;
+}

--- a/css/default.css
+++ b/css/default.css
@@ -1,3 +1,17 @@
 head {
     display: none;
 }
+
+a, abbr, acronym, audio, b, bdi, bdo, big, br, button, canvas, cite, code,
+data, datalist, del, dfn, em, embed, i, iframe, img, input, ins, kbd, label,
+map, mark, meter, noscript, object, output, picture, progress, q, ruby, s,
+samp, script, select, slot, small, span, strong, sub, sup, svg, template,
+textarea, time, u, tt, var, video, wbr {
+    display: inline;
+}
+
+address, article, aside, blockquote, details, dialog, dd, div, dl, dt,
+fieldset, figcaption, figure, footer, form, h1, h2, h3, h4, h5, h6, header,
+hgroup, hr, li, main, nav, ol, p, pre, section, table, ul {
+    display: block;
+}

--- a/css/default.h
+++ b/css/default.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef CSS_DEFAULT_H_
+#define CSS_DEFAULT_H_
+
+#include "css/rule.h"
+
+#include <vector>
+
+namespace css {
+
+std::vector<css::Rule> default_style();
+
+} // namespace css
+
+#endif


### PR DESCRIPTION
Previously they always got a width of 0, so there was nothing to render.

This PR also extracts our default CSS into a real .css-file and sets up the correct display values for elements. At first this was the only content I was going to open a PR for, but fixing the display values broke rendering completely since a lot more things became `display: inline`.