### PR TITLE
gfx: Port scrolling from an opengl translation to translating the painted rects

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -16,16 +16,6 @@
 #include <imgui_stdlib.h>
 #include <spdlog/spdlog.h>
 
-// MSVC gl.h doesn't include everything it uses.
-#ifdef _MSC_VER
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif // WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif // _MSC_VER
-
-#include <GL/gl.h>
-
 #include <iterator>
 #include <string_view>
 #include <utility>
@@ -257,13 +247,14 @@ layout::Position App::to_document_position(layout::Position window_position) con
 }
 
 void App::reset_scroll() {
+    painter_.add_translation(0, -scroll_offset_y_);
     scroll_offset_y_ = 0;
     render::render_setup(window_.getSize().x, window_.getSize().y);
 }
 
 void App::scroll(int pixels) {
-    glTranslatef(0, static_cast<float>(pixels), 0);
-    scroll_offset_y_ -= pixels;
+    painter_.add_translation(0, pixels);
+    scroll_offset_y_ += pixels;
 }
 
 void App::run_overlay() {

--- a/geom/geom.h
+++ b/geom/geom.h
@@ -29,6 +29,8 @@ struct Rect {
         };
     }
 
+    [[nodiscard]] constexpr Rect translated(int dx, int dy) const { return {x + dx, y + dy, width, height}; }
+
     [[nodiscard]] constexpr bool contains(Position const &p) const {
         bool inside_horizontally = p.x >= x && p.x <= x + width;
         bool inside_vertically = p.y >= y && p.y <= y + height;

--- a/geom/geom_test.cpp
+++ b/geom/geom_test.cpp
@@ -25,6 +25,13 @@ int main() {
         expect(Rect{-10, -10, 30, 30} == r.expanded(EdgeSize{10, 10, 10, 10}));
     });
 
+    etest::test("Rect::translated", [] {
+        Rect r{0, 0, 10, 10};
+        expect(Rect{10, 0, 10, 10} == r.translated(10, 0));
+        expect(Rect{0, 10, 10, 10} == r.translated(0, 10));
+        expect(Rect{-10, -10, 10, 10} == r.translated(-10, -10));
+    });
+
     etest::test("Rect::contains", [] {
         Rect r{0, 0, 10, 10};
         expect(r.contains({0, 0}));

--- a/gfx/gfx.cpp
+++ b/gfx/gfx.cpp
@@ -17,8 +17,9 @@
 namespace gfx {
 
 void OpenGLPainter::fill_rect(geom::Rect const &rect, Color color) {
+    auto translated{rect.translated(translation_x, translation_y)};
     glColor3ub(color.r, color.g, color.b);
-    glRecti(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height);
+    glRecti(translated.x, translated.y, translated.x + translated.width, translated.y + translated.height);
 }
 
 } // namespace gfx

--- a/gfx/gfx.h
+++ b/gfx/gfx.h
@@ -19,12 +19,22 @@ class IPainter {
 public:
     virtual ~IPainter() = default;
 
+    virtual void add_translation(int dx, int dy) = 0;
     virtual void fill_rect(geom::Rect const &, Color) = 0;
 };
 
 class OpenGLPainter final : public IPainter {
 public:
+    constexpr void add_translation(int dx, int dy) override {
+        translation_x += dx;
+        translation_y += dy;
+    }
+
     void fill_rect(geom::Rect const &, Color) override;
+
+private:
+    int translation_x{};
+    int translation_y{};
 };
 
 } // namespace gfx


### PR DESCRIPTION
This is probably slightly less efficient, but it means we will be able to cull all objects outside of our current viewport if we want.