### PR TITLE
browser/gui: Fix mouse document position being incorrect after scrolling

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -243,7 +243,7 @@ std::string App::get_hovered_element_text(layout::Position p) const {
 }
 
 layout::Position App::to_document_position(layout::Position window_position) const {
-    return {window_position.x, window_position.y + scroll_offset_y_};
+    return {window_position.x, window_position.y - scroll_offset_y_};
 }
 
 void App::reset_scroll() {


### PR DESCRIPTION
This issue was introduced in b39f178426dbcbe40ff744c8628db25b2667068a
where the stored scroll offset was inverted to go with the new IPainter
translation API, but this wasn't taken into account in the mouse
translation calculation.