### PR TITLE
etest: Report exceptions that escape from the test body

### DIFF
--- a/etest/etest.cpp
+++ b/etest/etest.cpp
@@ -46,8 +46,14 @@ int run_all_tests() noexcept {
 
         try {
             test.body();
+        } catch (test_failure const &) {
+            ++assertion_failures;
+        } catch (std::exception const &e) {
+            ++assertion_failures;
+            test_log << "Unhandled exception in test body: " << e.what() << '\n';
         } catch (...) {
             ++assertion_failures;
+            test_log << "Unhandled unknown exception in test body.\n";
         }
 
         if (before == assertion_failures) {


### PR DESCRIPTION
Before this change, the test
```
etest::test("this throws an exception", [] {
    throw std::runtime_error("rip");
});
```
would report
```
this throws an exception: FAILED
```
and after this change, it reports
```
this throws an exception: FAILED
Unhandled exception in test body: rip
```