### PR TITLE
layout: Support margins when layouting

### DIFF
--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -8,6 +8,7 @@
 
 using namespace std::literals;
 using etest::expect;
+using etest::expect_eq;
 using etest::require;
 using layout::LayoutType;
 
@@ -486,8 +487,49 @@ int main() {
             .dimensions = {{0, 0, 100, 120}},
             .children = {
                 {&style_root.children[0], LayoutType::Block, {{0, 0, 100, 120}}, {
-                    {&style_root.children[0].children[0], LayoutType::Block, {{10, 10, 80, 100}, {10, 10, 10, 10}}, {}},
+                    {&style_root.children[0].children[0], LayoutType::Block, {{10, 10, 100, 100}, {10, 10, 10, 10}, {}, {0, -20, 0, 0}}, {}},
                     {&style_root.children[0].children[1], LayoutType::Block, {{0, 120, 100, 0}}, {}},
+                }},
+            }
+        };
+
+        expect(layout::create_layout(style_root, 100) == expected_layout);
+    });
+
+    etest::test("margin is taken into account", [] {
+        auto dom_root = dom::create_element_node("html", {}, {
+            dom::create_element_node("body", {}, {
+                dom::create_element_node("p", {}, {}),
+                dom::create_element_node("p", {}, {}),
+            }),
+        });
+
+        auto properties = std::vector{
+                std::pair{"margin-top"s, "10px"s},
+                std::pair{"margin-right"s, "10px"s},
+                std::pair{"margin-bottom"s, "10px"s},
+                std::pair{"margin-left"s, "10px"s},
+        };
+
+        auto style_root = style::StyledNode{
+            .node = dom_root,
+            .properties = {},
+            .children = {
+                {dom_root.children[0], {}, {
+                    {dom_root.children[0].children[0], std::move(properties), {}},
+                    {dom_root.children[0].children[1], {}, {}},
+                }},
+            },
+        };
+
+        auto expected_layout = layout::LayoutBox{
+            .node = &style_root,
+            .type = LayoutType::Block,
+            .dimensions = {{0, 0, 100, 20}},
+            .children = {
+                {&style_root.children[0], LayoutType::Block, {{0, 0, 100, 20}}, {
+                    {&style_root.children[0].children[0], LayoutType::Block, {{10, 10, 100, 0}, {}, {}, {10, -10, 10, 10}}, {}},
+                    {&style_root.children[0].children[1], LayoutType::Block, {{0, 20, 100, 0}}, {}},
                 }},
             }
         };
@@ -570,14 +612,14 @@ int main() {
 
         auto expected =
                 "html\n"
-                "block {0,0,0,30} {0,0,0,0}\n"
+                "block {0,0,0,30} {0,0,0,0} {0,0,0,0}\n"
                 "  body\n"
-                "  block {0,0,0,30} {0,0,0,0}\n"
+                "  block {0,0,0,30} {0,0,0,0} {0,0,0,0}\n"
                 "    p\n"
-                "    block {0,0,0,25} {0,0,0,0}\n"
+                "    block {0,0,0,25} {0,0,0,0} {0,0,0,0}\n"
                 "    p\n"
-                "    block {0,30,0,0} {5,15,0,0}\n";
-        expect(to_string(layout::create_layout(style_root, 0)) == expected);
+                "    block {0,30,0,0} {5,15,0,0} {0,-15,0,0}\n";
+        expect_eq(to_string(layout::create_layout(style_root, 0)), expected);
     });
 
     return etest::run_all_tests();


### PR DESCRIPTION
This doesn't implement all the quirks of it, but it's something to build off of.
`margin-{left,right}: auto` can be used to center block elements, and the right margin is decreased instead of the width.

Resolves #20 