### PR TITLE
Receive http response in steps

### DIFF
--- a/net/socket.cpp
+++ b/net/socket.cpp
@@ -32,6 +32,11 @@ std::string read_all_impl(auto &socket) {
     return data;
 }
 
+std::size_t read_until_impl(auto &socket, std::string &data, std::string_view delimiter) {
+    asio::error_code ec;
+    return asio::read_until(socket, asio::dynamic_buffer(data), delimiter, ec);
+}
+
 } // namespace
 
 struct Socket::Impl {
@@ -60,6 +65,10 @@ std::size_t Socket::write(std::string_view data) {
 
 std::string Socket::read_all() {
     return read_all_impl(impl_->socket);
+}
+
+std::size_t Socket::read_until(std::string &data, std::string_view delimiter) {
+    return read_until_impl(impl_->socket, data, delimiter);
 }
 
 struct SecureSocket::Impl {
@@ -97,6 +106,10 @@ std::size_t SecureSocket::write(std::string_view data) {
 
 std::string SecureSocket::read_all() {
     return read_all_impl(impl_->socket);
+}
+
+std::size_t SecureSocket::read_until(std::string &data, std::string_view delimiter) {
+    return read_until_impl(impl_->socket, data, delimiter);
 }
 
 } // namespace net

--- a/net/socket.cpp
+++ b/net/socket.cpp
@@ -10,36 +10,38 @@
 namespace net {
 namespace {
 
-bool connect_impl(asio::ip::tcp::resolver &resolver,
-        asio::ip::tcp::socket &socket,
-        std::string_view host,
-        std::string_view service) {
-    asio::error_code ec;
-    auto endpoints = resolver.resolve(host, service, ec);
-    asio::connect(socket, endpoints, ec);
-    return !ec;
-}
+struct BaseSocketImpl {
+    bool connect(asio::ip::tcp::resolver &resolver,
+            asio::ip::tcp::socket &socket,
+            std::string_view host,
+            std::string_view service) {
+        asio::error_code ec;
+        auto endpoints = resolver.resolve(host, service, ec);
+        asio::connect(socket, endpoints, ec);
+        return !ec;
+    }
 
-std::size_t write_impl(auto &socket, std::string_view data) {
-    asio::error_code ec;
-    return asio::write(socket, asio::buffer(data), ec);
-}
+    std::size_t write(auto &socket, std::string_view data) {
+        asio::error_code ec;
+        return asio::write(socket, asio::buffer(data), ec);
+    }
 
-std::string read_all_impl(auto &socket) {
-    std::string data;
-    asio::error_code ec;
-    asio::read(socket, asio::dynamic_buffer(data), ec);
-    return data;
-}
+    std::string read_all(auto &socket) {
+        std::string data;
+        asio::error_code ec;
+        asio::read(socket, asio::dynamic_buffer(data), ec);
+        return data;
+    }
 
-std::size_t read_until_impl(auto &socket, std::string &data, std::string_view delimiter) {
-    asio::error_code ec;
-    return asio::read_until(socket, asio::dynamic_buffer(data), delimiter, ec);
-}
+    std::size_t read_until(auto &socket, std::string &data, std::string_view delimiter) {
+        asio::error_code ec;
+        return asio::read_until(socket, asio::dynamic_buffer(data), delimiter, ec);
+    }
+};
 
 } // namespace
 
-struct Socket::Impl {
+struct Socket::Impl : public BaseSocketImpl {
     Impl() : resolver(svc), socket(svc) {}
 
     asio::io_service svc{};
@@ -56,26 +58,26 @@ Socket::Socket(Socket &&) = default;
 Socket &Socket::operator=(Socket &&) = default;
 
 bool Socket::connect(std::string_view host, std::string_view service) {
-    return connect_impl(impl_->resolver, impl_->socket, host, service);
+    return impl_->connect(impl_->resolver, impl_->socket, host, service);
 }
 
 std::size_t Socket::write(std::string_view data) {
-    return write_impl(impl_->socket, data);
+    return impl_->write(impl_->socket, data);
 }
 
 std::string Socket::read_all() {
-    return read_all_impl(impl_->socket);
+    return impl_->read_all(impl_->socket);
 }
 
 std::size_t Socket::read_until(std::string &data, std::string_view delimiter) {
-    return read_until_impl(impl_->socket, data, delimiter);
+    return impl_->read_until(impl_->socket, data, delimiter);
 }
 
-struct SecureSocket::Impl {
+struct SecureSocket::Impl : public BaseSocketImpl {
     Impl() : resolver(svc), ctx(asio::ssl::context::method::sslv23_client), socket(svc, ctx) {}
 
     bool connect(std::string_view host, std::string_view service) {
-        if (connect_impl(resolver, socket.next_layer(), host, service)) {
+        if (BaseSocketImpl::connect(resolver, socket.next_layer(), host, service)) {
             socket.handshake(asio::ssl::stream_base::handshake_type::client);
             return true;
         }
@@ -101,15 +103,15 @@ bool SecureSocket::connect(std::string_view host, std::string_view service) {
 }
 
 std::size_t SecureSocket::write(std::string_view data) {
-    return write_impl(impl_->socket, data);
+    return impl_->write(impl_->socket, data);
 }
 
 std::string SecureSocket::read_all() {
-    return read_all_impl(impl_->socket);
+    return impl_->read_all(impl_->socket);
 }
 
 std::size_t SecureSocket::read_until(std::string &data, std::string_view delimiter) {
-    return read_until_impl(impl_->socket, data, delimiter);
+    return impl_->read_until(impl_->socket, data, delimiter);
 }
 
 } // namespace net

--- a/net/socket.cpp
+++ b/net/socket.cpp
@@ -25,7 +25,7 @@ std::size_t write_impl(auto &socket, std::string_view data) {
     return asio::write(socket, asio::buffer(data), ec);
 }
 
-std::string read_impl(auto &socket) {
+std::string read_all_impl(auto &socket) {
     std::string data;
     asio::error_code ec;
     asio::read(socket, asio::dynamic_buffer(data), ec);
@@ -43,7 +43,7 @@ public:
     }
     std::size_t write(std::string_view data) { return write_impl(socket_, data); }
 
-    std::string read() { return read_impl(socket_); }
+    std::string read_all() { return read_all_impl(socket_); }
 
 private:
     asio::io_service svc_{};
@@ -67,8 +67,8 @@ std::size_t Socket::write(std::string_view data) {
     return impl_->write(data);
 }
 
-std::string Socket::read() {
-    return impl_->read();
+std::string Socket::read_all() {
+    return impl_->read_all();
 }
 
 class SecureSocket::Impl {
@@ -85,7 +85,7 @@ public:
 
     std::size_t write(std::string_view data) { return write_impl(socket_, data); }
 
-    std::string read() { return read_impl(socket_); }
+    std::string read_all() { return read_all_impl(socket_); }
 
 private:
     asio::io_service svc_{};
@@ -110,8 +110,8 @@ std::size_t SecureSocket::write(std::string_view data) {
     return impl_->write(data);
 }
 
-std::string SecureSocket::read() {
-    return impl_->read();
+std::string SecureSocket::read_all() {
+    return impl_->read_all();
 }
 
 } // namespace net

--- a/net/socket.h
+++ b/net/socket.h
@@ -22,7 +22,7 @@ public:
 
     bool connect(std::string_view host, std::string_view service);
     std::size_t write(std::string_view data);
-    std::string read();
+    std::string read_all();
 
 private:
     class Impl;
@@ -39,7 +39,7 @@ public:
 
     bool connect(std::string_view host, std::string_view service);
     std::size_t write(std::string_view data);
-    std::string read();
+    std::string read_all();
 
 private:
     class Impl;

--- a/net/socket.h
+++ b/net/socket.h
@@ -23,7 +23,7 @@ public:
     bool connect(std::string_view host, std::string_view service);
     std::size_t write(std::string_view data);
     std::string read_all();
-    std::size_t read_until(std::string &data, std::string_view delimiter);
+    std::string read_until(std::string_view delimiter);
 
 private:
     struct Impl;
@@ -41,7 +41,7 @@ public:
     bool connect(std::string_view host, std::string_view service);
     std::size_t write(std::string_view data);
     std::string read_all();
-    std::size_t read_until(std::string &data, std::string_view delimiter);
+    std::string read_until(std::string_view delimiter);
 
 private:
     struct Impl;

--- a/net/socket.h
+++ b/net/socket.h
@@ -25,7 +25,7 @@ public:
     std::string read_all();
 
 private:
-    class Impl;
+    struct Impl;
     std::unique_ptr<Impl> impl_;
 };
 
@@ -42,7 +42,7 @@ public:
     std::string read_all();
 
 private:
-    class Impl;
+    struct Impl;
     std::unique_ptr<Impl> impl_;
 };
 

--- a/net/socket.h
+++ b/net/socket.h
@@ -23,6 +23,7 @@ public:
     bool connect(std::string_view host, std::string_view service);
     std::size_t write(std::string_view data);
     std::string read_all();
+    std::size_t read_until(std::string &data, std::string_view delimiter);
 
 private:
     struct Impl;
@@ -40,6 +41,7 @@ public:
     bool connect(std::string_view host, std::string_view service);
     std::size_t write(std::string_view data);
     std::string read_all();
+    std::size_t read_until(std::string &data, std::string_view delimiter);
 
 private:
     struct Impl;

--- a/protocol/http.h
+++ b/protocol/http.h
@@ -42,7 +42,7 @@ public:
     static Response get(SocketType &&socket, uri::Uri const &uri) {
         if (socket.connect(uri.authority.host, Http::use_port(uri) ? uri.authority.port : uri.scheme)) {
             socket.write(Http::create_get_request(uri));
-            return Http::parse_response(socket.read());
+            return Http::parse_response(socket.read_all());
         }
 
         return {Error::Unresolved};

--- a/protocol/http_test.cpp
+++ b/protocol/http_test.cpp
@@ -23,7 +23,7 @@ struct FakeSocket {
         return write_data.size();
     }
 
-    std::string read() { return read_data; }
+    std::string read_all() { return read_data; }
 
     std::string host{};
     std::string service{};

--- a/protocol/http_test.cpp
+++ b/protocol/http_test.cpp
@@ -27,8 +27,13 @@ struct FakeSocket {
 
     std::size_t read_until(std::string &data, std::string_view d) {
         delimiter = d;
-        data = read_data;
-        return read_until_pos;
+        if (auto pos = read_data.find(d); pos != std::string::npos) {
+            pos += d.size();
+            data = read_data.substr(0, pos);
+            read_data.erase(0, pos);
+            return pos;
+        }
+        return 0;
     }
 
     std::string host{};
@@ -36,7 +41,6 @@ struct FakeSocket {
     std::string write_data{};
     std::string read_data{};
     std::string delimiter{};
-    std::size_t read_until_pos{};
     bool connect_result{true};
 };
 

--- a/protocol/http_test.cpp
+++ b/protocol/http_test.cpp
@@ -25,10 +25,18 @@ struct FakeSocket {
 
     std::string read_all() { return read_data; }
 
+    std::size_t read_until(std::string &data, std::string_view d) {
+        delimiter = d;
+        data = read_data;
+        return read_until_pos;
+    }
+
     std::string host{};
     std::string service{};
     std::string write_data{};
     std::string read_data{};
+    std::string delimiter{};
+    std::size_t read_until_pos{};
     bool connect_result{true};
 };
 

--- a/protocol/http_test.cpp
+++ b/protocol/http_test.cpp
@@ -25,15 +25,15 @@ struct FakeSocket {
 
     std::string read_all() { return read_data; }
 
-    std::size_t read_until(std::string &data, std::string_view d) {
+    std::string read_until(std::string_view d) {
         delimiter = d;
+        std::string result{};
         if (auto pos = read_data.find(d); pos != std::string::npos) {
             pos += d.size();
-            data = read_data.substr(0, pos);
+            result = read_data.substr(0, pos);
             read_data.erase(0, pos);
-            return pos;
         }
-        return 0;
+        return result;
     }
 
     std::string host{};


### PR DESCRIPTION
Some refactoring to  parse a http response in steps. The reason for this is to be able to examine the headers before starting to receive and parse the body.