### PR TITLE
Add header for string utility functions

### DIFF
--- a/html/parser.h
+++ b/html/parser.h
@@ -7,6 +7,7 @@
 
 #include "dom/dom.h"
 #include "util/base_parser.h"
+#include "util/string.h"
 
 #include <array>
 #include <cstddef>
@@ -26,7 +27,7 @@ public:
         constexpr auto doctype_prefix = "<!doctype"sv;
         auto peeked = peek(doctype_prefix.size());
         auto doctype = [&]() {
-            if (no_case_compare(doctype_prefix, peeked)) {
+            if (util::no_case_compare(doctype_prefix, peeked)) {
                 return parse_doctype();
             }
             return "quirks"sv;
@@ -138,19 +139,6 @@ private:
         parse_tag_name();
         consume_char(); // >
         return dom::create_element_node(name, std::move(attrs), std::move(children));
-    }
-
-    static constexpr bool no_case_compare(std::string_view a, std::string_view b) {
-        if (a.size() != b.size()) {
-            return false;
-        }
-        for (size_t i = 0; i < a.size(); ++i) {
-            if (std::tolower(a[i]) != std::tolower(b[i])) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     dom::Node parse_node() {

--- a/html2/BUILD
+++ b/html2/BUILD
@@ -5,7 +5,10 @@ cc_library(
     srcs = ["tokenizer.cpp"],
     hdrs = ["tokenizer.h"],
     visibility = ["//visibility:public"],
-    deps = ["@spdlog"],
+    deps = [
+        "//util",
+        "@spdlog",
+    ],
 )
 
 cc_test(

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -4,9 +4,10 @@
 
 #include "html2/tokenizer.h"
 
+#include "util/string.h"
+
 #include <spdlog/spdlog.h>
 
-#include <cctype>
 #include <cstring>
 #include <exception>
 
@@ -14,20 +15,6 @@ using namespace std::literals;
 
 namespace html2 {
 namespace {
-
-constexpr bool no_case_compare(std::string_view a, std::string_view b) {
-    if (a.size() != b.size()) {
-        return false;
-    }
-
-    for (size_t i = 0; i < a.size(); ++i) {
-        if (std::tolower(a[i]) != std::tolower(b[i])) {
-            return false;
-        }
-    }
-
-    return true;
-}
 
 constexpr bool is_ascii_upper_alpha(char c) {
     return c >= 'A' && c <= 'Z';
@@ -376,7 +363,7 @@ void Tokenizer::run() {
             }
 
             case State::MarkupDeclarationOpen:
-                if (no_case_compare(input_.substr(pos_, std::strlen("DOCTYPE")), "doctype"sv)) {
+                if (util::no_case_compare(input_.substr(pos_, std::strlen("DOCTYPE")), "doctype"sv)) {
                     pos_ += std::strlen("DOCTYPE");
                     state_ = State::Doctype;
                     continue;

--- a/util/BUILD
+++ b/util/BUILD
@@ -2,7 +2,10 @@ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
     name = "util",
-    hdrs = ["base_parser.h"],
+    hdrs = [
+        "base_parser.h",
+        "string.h",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -10,6 +13,16 @@ cc_test(
     name = "base_parser_test",
     size = "small",
     srcs = ["base_parser_test.cpp"],
+    deps = [
+        ":util",
+        "//etest",
+    ],
+)
+
+cc_test(
+    name = "string_test",
+    size = "small",
+    srcs = ["string_test.cpp"],
     deps = [
         ":util",
         "//etest",

--- a/util/string.h
+++ b/util/string.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef UTIL_STRING_H_
+#define UTIL_STRING_H_
+
+#include <cctype>
+#include <string_view>
+
+namespace util {
+
+constexpr bool no_case_compare(std::string_view a, std::string_view b) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (std::tolower(a[i]) != std::tolower(b[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace util
+
+#endif

--- a/util/string_test.cpp
+++ b/util/string_test.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2021 Mikael Larsson <c.mikael.larsson@gmail.com>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "util/string.h"
+
+#include "etest/etest.h"
+
+using namespace std::literals;
+
+using etest::expect;
+using util::no_case_compare;
+
+int main() {
+    etest::test("no case compare", [] {
+        expect(no_case_compare("word"sv, "word"sv));
+        expect(no_case_compare("WORD"sv, "WORD"sv));
+        expect(no_case_compare("word"sv, "WORD"sv));
+        expect(no_case_compare("WORD"sv, "word"sv));
+        expect(no_case_compare("Abc-Def_Ghi"sv, "aBc-DEf_gHi"sv));
+        expect(no_case_compare("10 seconds"sv, "10 Seconds"sv));
+        expect(no_case_compare("Abc $#@"sv, "ABC $#@"sv));
+        expect(!no_case_compare(" word"sv, "word"sv));
+        expect(!no_case_compare("word "sv, "word"sv));
+        expect(!no_case_compare("word "sv, "woord"sv));
+    });
+
+    return etest::run_all_tests();
+}


### PR DESCRIPTION
Moved function for case insensitive string comparison to the util library since I'll need it when comparing header names.
Suggestions for where to place this are welcome!