### PR TITLE
css: Modernize string to int conversion in parser

### DIFF
--- a/css/parser.h
+++ b/css/parser.h
@@ -13,9 +13,9 @@
 #include <fmt/format.h>
 
 #include <array>
+#include <charconv>
 #include <cstring>
 #include <optional>
-#include <stdexcept>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -370,11 +370,11 @@ private:
     }
 
     std::optional<int> to_int(std::string_view str) const {
-        try {
-            return std::stoi(std::string{str});
-        } catch (std::invalid_argument const &) {
+        int result{};
+        if (std::from_chars(str.data(), str.data() + str.size(), result).ec != std::errc{}) {
             return std::nullopt;
         }
+        return result;
     }
 
     template<auto const &array>


### PR DESCRIPTION
std::from_chars is many times faster, doesn't throw, and doesn't depend
on the locale.

This also saves us from having to copy the `std::string_view` into a `std::string` just so `std::stoi` will accept it.

For more information about `std::from_chars` compared to `std::stoi`, see https://www.fluentcpp.com/2018/07/27/how-to-efficiently-convert-a-string-to-an-int-in-c/ and https://stackoverflow.com/questions/55875862/c17-purpose-of-stdfrom-chars-and-stdto-chars

I found this when having issues with valgrind+exceptions when using libc++. :P