### PR TITLE
ci: Update clang-12 to run everything under Valgrind

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,8 @@ jobs:
           - name: clang-12
             compiler: clang
             version: 12
-            bazel: --config clang
+            bazel: --config clang --run_under="valgrind --leak-check=full --errors-for-leak-kinds=all --error-exitcode=1 --track-origins=yes --show-leak-kinds=all"
+            apt: valgrind
 
           - name: clang-13
             compiler: clang


### PR DESCRIPTION
The clang-12 job was chosen by a fair roll of the dice. :P
 Suggestions on what flags or whatever to pass to valgrind are very welcome!