### PR TITLE
util: Fix UB in trim

### DIFF
--- a/util/string.h
+++ b/util/string.h
@@ -20,12 +20,12 @@ constexpr bool no_case_compare(std::string_view a, std::string_view b) {
 }
 
 inline std::string trim_start(std::string s) {
-    s.erase(begin(s), std::find_if(begin(s), end(s), [](auto ch) { return !std::isspace(ch); }));
+    s.erase(begin(s), std::find_if(begin(s), end(s), [](unsigned char ch) { return !std::isspace(ch); }));
     return s;
 }
 
 inline std::string trim_end(std::string s) {
-    s.erase(std::find_if(rbegin(s), rend(s), [](auto ch) { return !std::isspace(ch); }).base(), end(s));
+    s.erase(std::find_if(rbegin(s), rend(s), [](unsigned char ch) { return !std::isspace(ch); }).base(), end(s));
     return s;
 }
 

--- a/util/string_test.cpp
+++ b/util/string_test.cpp
@@ -54,5 +54,12 @@ int main() {
         expect_eq(trim("\r\n"), "");
     });
 
+    etest::test("trim with non-ascii characters", [] {
+        expect_eq(trim("Ö"), "Ö");
+        expect_eq(trim(" Ö "), "Ö");
+        expect_eq(trim_start(" Ö "), "Ö ");
+        expect_eq(trim_end(" Ö "), " Ö");
+    });
+
     return etest::run_all_tests();
 }


### PR DESCRIPTION
std::isspace accepts an int, but it's UB to pass anything that's not EOF
or representable as an unsigned char.

See: https://en.cppreference.com/w/cpp/string/byte/isspace

Without the fix, the test added fails in a MSVC debug build (due to an assertion checking that the int passed is within the acceptable range), but appears to pass in all CI jobs even without the fix due to none of them being debug builds.

Here is an example of a failed CI run (with --config debug added): https://github.com/robinlinden/hastur/runs/4204736206?check_suite_focus=true