### PR TITLE
Add read_bytes function to socket classes

### DIFF
--- a/net/socket.cpp
+++ b/net/socket.cpp
@@ -46,6 +46,21 @@ struct BaseSocketImpl {
         }
         return result;
     }
+
+    std::string read_bytes(auto &socket, std::size_t bytes) {
+        asio::error_code ec;
+        std::string result{};
+        if (buffer.size() >= bytes) {
+            result = buffer.substr(0, bytes);
+            buffer.erase(0, bytes);
+        } else {
+            auto bytes_to_transfer = bytes - buffer.size();
+            asio::read(socket, asio::dynamic_buffer(buffer), asio::transfer_at_least(bytes_to_transfer), ec);
+            result = buffer.substr(0, bytes);
+            buffer.erase(0, bytes);
+        }
+        return result;
+    }
     std::string buffer{};
 };
 
@@ -81,6 +96,10 @@ std::string Socket::read_all() {
 
 std::string Socket::read_until(std::string_view delimiter) {
     return impl_->read_until(impl_->socket, delimiter);
+}
+
+std::string Socket::read_bytes(std::size_t bytes) {
+    return impl_->read_bytes(impl_->socket, bytes);
 }
 
 struct SecureSocket::Impl : public BaseSocketImpl {
@@ -122,6 +141,10 @@ std::string SecureSocket::read_all() {
 
 std::string SecureSocket::read_until(std::string_view delimiter) {
     return impl_->read_until(impl_->socket, delimiter);
+}
+
+std::string SecureSocket::read_bytes(std::size_t bytes) {
+    return impl_->read_bytes(impl_->socket, bytes);
 }
 
 } // namespace net

--- a/net/socket.h
+++ b/net/socket.h
@@ -24,6 +24,7 @@ public:
     std::size_t write(std::string_view data);
     std::string read_all();
     std::string read_until(std::string_view delimiter);
+    std::string read_bytes(std::size_t bytes);
 
 private:
     struct Impl;
@@ -42,6 +43,7 @@ public:
     std::size_t write(std::string_view data);
     std::string read_all();
     std::string read_until(std::string_view delimiter);
+    std::string read_bytes(std::size_t bytes);
 
 private:
     struct Impl;

--- a/protocol/http_test.cpp
+++ b/protocol/http_test.cpp
@@ -39,6 +39,12 @@ struct FakeSocket {
         return result;
     }
 
+    std::string read_bytes(std::size_t bytes) {
+        std::string result = read_data.substr(0, bytes);
+        read_data.erase(0, bytes);
+        return read_data;
+    }
+
     std::string host{};
     std::string service{};
     std::string write_data{};


### PR DESCRIPTION
This PR adds a function for reading a specified number of bytes from a socket. Similar to the other read functions the implementation is quite naive.  Eventually we'll need to add some more logic for handling potential errors and eof.