### PR TITLE
html2: Support converting parse tokens into strings

### DIFF
--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -10,6 +10,7 @@
 
 #include <cstring>
 #include <exception>
+#include <sstream>
 
 using namespace std::literals;
 
@@ -32,7 +33,43 @@ constexpr char to_lower(char c) {
     return c + 0x20;
 }
 
+template<class... Ts>
+struct Overloaded : Ts... {
+    using Ts::operator()...;
+};
+
+// Not needed as of C++20, but gcc 10 won't work without it.
+template<class... Ts>
+Overloaded(Ts...) -> Overloaded<Ts...>;
+
 } // namespace
+
+std::string to_string(Token const &token) {
+    auto try_print = []<typename T>(std::ostream &os, std::optional<T> maybe_value) {
+        if (maybe_value) {
+            os << ' ' << *maybe_value;
+        } else {
+            os << " \"\"";
+        }
+    };
+
+    std::stringstream ss;
+    std::visit(Overloaded{
+                       [&](DoctypeToken const &t) {
+                           ss << "Doctype";
+                           try_print(ss, t.name);
+                           try_print(ss, t.public_identifier);
+                           try_print(ss, t.system_identifier);
+                       },
+                       [&ss](StartTagToken const &t) { ss << "StartTag " << t.tag_name << ' ' << t.self_closing; },
+                       [&ss](EndTagToken const &t) { ss << "EndTag " << t.tag_name << ' ' << t.self_closing; },
+                       [&ss](CommentToken const &t) { ss << "Comment " << t.data; },
+                       [&ss](CharacterToken const &t) { ss << "Character " << t.data; },
+                       [&ss](EndOfFileToken const &) { ss << "EndOfFile"; },
+               },
+            token);
+    return ss.str();
+}
 
 void Tokenizer::run() {
     while (!is_eof()) {

--- a/html2/tokenizer.h
+++ b/html2/tokenizer.h
@@ -143,6 +143,8 @@ struct EndOfFileToken {
 
 using Token = std::variant<DoctypeToken, StartTagToken, EndTagToken, CommentToken, CharacterToken, EndOfFileToken>;
 
+std::string to_string(Token const &);
+
 class Tokenizer {
 public:
     Tokenizer(std::string_view input, std::function<void(Token &&)> on_emit)


### PR DESCRIPTION
This is mainly to help me debug when implementing the tree construction for now, but dumping the parse state will be interesting in general later since there will be a ton of things I won't implement until needed.