### PR TITLE
gfx+render: Move viewport setup from render to gfx

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -246,7 +246,6 @@ geom::Position App::to_document_position(geom::Position window_position) const {
 void App::reset_scroll() {
     painter_.add_translation(0, -scroll_offset_y_);
     scroll_offset_y_ = 0;
-    painter_.set_viewport_size(window_.getSize().x, window_.getSize().y);
 }
 
 void App::scroll(int pixels) {

--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -39,7 +39,7 @@ App::App(std::string browser_title, std::string start_page_hint, bool load_start
       url_buf_{std::move(start_page_hint)} {
     window_.setFramerateLimit(60);
     ImGui::SFML::Init(window_);
-    render::render_setup(window_.getSize().x, window_.getSize().y);
+    painter_.set_viewport_size(window_.getSize().x, window_.getSize().y);
 
     engine_.set_layout_width(window_.getSize().x);
     engine_.set_on_navigation_failure(std::bind(&App::on_navigation_failure, this, std::placeholders::_1));
@@ -67,7 +67,7 @@ int App::run() {
                     break;
                 }
                 case sf::Event::Resized: {
-                    render::render_setup(event.size.width, event.size.height);
+                    painter_.set_viewport_size(event.size.width, event.size.height);
                     engine_.set_layout_width(event.size.width);
                     break;
                 }
@@ -246,7 +246,7 @@ geom::Position App::to_document_position(geom::Position window_position) const {
 void App::reset_scroll() {
     painter_.add_translation(0, -scroll_offset_y_);
     scroll_offset_y_ = 0;
-    render::render_setup(window_.getSize().x, window_.getSize().y);
+    painter_.set_viewport_size(window_.getSize().x, window_.getSize().y);
 }
 
 void App::scroll(int pixels) {

--- a/gfx/gfx.cpp
+++ b/gfx/gfx.cpp
@@ -13,6 +13,15 @@ OpenGLPainter::OpenGLPainter() {
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 }
 
+void OpenGLPainter::set_viewport_size(int width, int height) {
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glOrtho(0, width, height, 0, -1.0, 1.0);
+    glViewport(0, 0, width, height);
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+}
+
 void OpenGLPainter::fill_rect(geom::Rect const &rect, Color color) {
     auto translated{rect.translated(translation_x, translation_y)};
     glColor4ub(color.r, color.g, color.b, color.a);

--- a/gfx/gfx.h
+++ b/gfx/gfx.h
@@ -29,6 +29,7 @@ class IPainter {
 public:
     virtual ~IPainter() = default;
 
+    virtual void set_viewport_size(int width, int height) = 0;
     virtual void add_translation(int dx, int dy) = 0;
     virtual void fill_rect(geom::Rect const &, Color) = 0;
 };
@@ -36,6 +37,8 @@ public:
 class OpenGLPainter final : public IPainter {
 public:
     OpenGLPainter();
+
+    void set_viewport_size(int width, int height) override;
 
     constexpr void add_translation(int dx, int dy) override {
         translation_x += dx;

--- a/render/BUILD
+++ b/render/BUILD
@@ -8,7 +8,6 @@ cc_library(
     deps = [
         "//gfx",
         "//layout",
-        "@glew",
         "@spdlog",
     ],
 )

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -7,7 +7,6 @@
 #include "dom/dom.h"
 #include "style/style.h"
 
-#include <GL/glew.h>
 #include <spdlog/spdlog.h>
 
 #include <charconv>
@@ -66,15 +65,6 @@ bool should_render(layout::LayoutBox const &layout) {
 }
 
 } // namespace
-
-void render_setup(int width, int height) {
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrtho(0, width, height, 0, -1.0, 1.0);
-    glViewport(0, 0, width, height);
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-}
 
 void render_layout(gfx::IPainter &painter, layout::LayoutBox const &layout) {
     if (should_render(layout)) {

--- a/render/render.h
+++ b/render/render.h
@@ -10,7 +10,6 @@
 
 namespace render {
 
-void render_setup(int width, int height);
 void render_layout(gfx::IPainter &, layout::LayoutBox const &);
 
 namespace debug {


### PR DESCRIPTION
It felt a bit weird that render had a function that you needed to call
to get the OpenGL painter to work correctly. This still doesn't feel
perfect, but at least now all OpenGL functionality is gathered in one
place.

After this change, gfx only deals with the graphics abstraction and
render only deals with calling into gfx based on what layout nodes it
encounters.