### PR TITLE
protocol: Add initial support for decoding a chunked body

### DIFF
--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -14,6 +14,7 @@ cc_library(
     deps = [
         "//net",
         "//uri",
+        "//util",
         "@fmt",
         "@range-v3",
     ],

--- a/protocol/http.h
+++ b/protocol/http.h
@@ -7,12 +7,15 @@
 #define PROTOCOL_HTTP_H_
 
 #include "uri/uri.h"
+#include "util/string.h"
 
+#include <charconv>
 #include <cstddef>
 #include <map>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <utility>
 
 namespace protocol {
@@ -54,11 +57,12 @@ struct Response {
 
 class Http {
 public:
-    template<class SocketType>
-    static Response get(SocketType &&socket, uri::Uri const &uri) {
+    static Response get(auto &&socket, uri::Uri const &uri) {
+        using namespace std::string_view_literals;
+
         if (socket.connect(uri.authority.host, Http::use_port(uri) ? uri.authority.port : uri.scheme)) {
             socket.write(Http::create_get_request(uri));
-            auto data = socket.read_until("\r\n");
+            auto data = socket.read_until("\r\n"sv);
             if (data.empty()) {
                 return {Error::Unresolved};
             }
@@ -66,7 +70,7 @@ public:
             if (!status_line) {
                 return {Error::InvalidResponse};
             }
-            data = socket.read_until("\r\n\r\n");
+            data = socket.read_until("\r\n\r\n"sv);
             if (data.empty()) {
                 return {Error::InvalidResponse};
             }
@@ -74,7 +78,16 @@ public:
             if (headers.size() == 0) {
                 return {Error::InvalidResponse};
             }
-            data = socket.read_all();
+            auto encoding = headers.get("transfer-encoding"sv);
+            if (encoding == "chunked"sv) {
+                if (auto body = Http::get_chunked_body(socket)) {
+                    data = *body;
+                } else {
+                    return {Error::InvalidResponse};
+                }
+            } else {
+                data = socket.read_all();
+            }
             return {Error::Ok, std::move(*status_line), std::move(headers), std::move(data)};
         }
 
@@ -82,6 +95,52 @@ public:
     }
 
 private:
+    static std::optional<std::string> get_chunked_body(auto &socket) {
+        using namespace std::literals;
+
+        std::string body{};
+        while (true) {
+            // Read first part of chunk
+            std::string bytes = socket.read_until("\r\n"sv);
+            bytes = util::trim(bytes);
+            if (bytes.empty()) {
+                break;
+            }
+
+            // TODO(mkiael): Handle chunk extensions
+
+            // Decode chunk size
+            std::size_t chunk_size{};
+            auto result = std::from_chars(bytes.data(), bytes.data() + bytes.size(), chunk_size, 16);
+            if (result.ec != std::errc()) {
+                break;
+            }
+
+            // Check if this is the last chunk
+            if (chunk_size == 0) {
+                // TODO(mkiael): Handle trailer part
+                socket.read_until("\r\n"sv);
+                return body;
+            }
+
+            // Read chunk from socket
+            bytes = socket.read_bytes(chunk_size);
+            if (bytes.size() != chunk_size) {
+                break;
+            }
+
+            // Append chunk to body
+            body += bytes;
+
+            // Read trailing \r\n before continuing with the next chunk
+            bytes = socket.read_bytes(2);
+            if (bytes != "\r\n"s) {
+                break;
+            }
+        }
+        return std::nullopt;
+    }
+
     static bool use_port(uri::Uri const &uri);
     static std::string create_get_request(uri::Uri const &uri);
     static std::optional<StatusLine> parse_status_line(std::string_view status_line);


### PR DESCRIPTION
Initial support for decoding a chunked body. Still missing support for parsing chunk extensions and trailer part.

Part of #28 