### PR TITLE
Bless dom with a saner node structure

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -25,11 +25,11 @@ namespace browser::gui {
 namespace {
 
 std::optional<std::string_view> try_get_text_content(dom::Document const &doc, std::string_view path) {
-    auto nodes = dom::nodes_by_path(doc.html, path);
-    if (nodes.empty() || nodes[0]->children.empty() || !std::holds_alternative<dom::Text>(nodes[0]->children[0].data)) {
+    auto nodes = dom::nodes_by_path(doc.html(), path);
+    if (nodes.empty() || nodes[0]->children.empty() || !std::holds_alternative<dom::Text>(nodes[0]->children[0])) {
         return std::nullopt;
     }
-    return std::get<dom::Text>(nodes[0]->children[0].data).text;
+    return std::get<dom::Text>(nodes[0]->children[0]).text;
 }
 
 } // namespace
@@ -112,7 +112,7 @@ int App::run() {
                         break;
                     }
 
-                    auto const *element = std::get_if<dom::Element>(&dom_node->data);
+                    auto const *element = std::get_if<dom::Element>(dom_node);
                     if (!element || element->name != "a"s || !element->attributes.contains("href")) {
                         break;
                     }
@@ -226,12 +226,12 @@ std::string App::get_hovered_element_text(geom::Position p) const {
         return ""s;
     }
 
-    if (std::holds_alternative<dom::Text>(dom_node->data)) {
-        return std::get<dom::Text>(dom_node->data).text;
+    if (std::holds_alternative<dom::Text>(*dom_node)) {
+        return std::get<dom::Text>(*dom_node).text;
     }
 
     // Special handling of <a> because I want to see what link I'm hovering.
-    auto const &element = std::get<dom::Element>(dom_node->data);
+    auto const &element = std::get<dom::Element>(*dom_node);
     if (element.name == "a"s && element.attributes.contains("href")) {
         return element.name + ": " + element.attributes.at("href");
     }

--- a/dom/BUILD
+++ b/dom/BUILD
@@ -5,6 +5,7 @@ cc_library(
     srcs = ["dom.cpp"],
     hdrs = ["dom.h"],
     visibility = ["//visibility:public"],
+    deps = ["@range-v3"],
 )
 
 cc_test(

--- a/dom/dom.cpp
+++ b/dom/dom.cpp
@@ -28,14 +28,15 @@ void print_node(dom::Node const &node, std::ostream &os, uint8_t depth = 0) {
         os << "  ";
     }
     std::visit(Overloaded{
-                       [&os](dom::Element const &element) { os << "tag: " << element.name << '\n'; },
+                       [&os, depth](dom::Element const &element) {
+                           os << "tag: " << element.name << '\n';
+                           for (auto const &child : element.children) {
+                               print_node(child, os, depth + 1);
+                           }
+                       },
                        [&os](dom::Text const &text) { os << "value: " << text.text << '\n'; },
                },
-            node.data);
-
-    for (auto const &child : node.children) {
-        print_node(child, os, depth + 1);
-    }
+            node);
 }
 
 } // namespace
@@ -43,35 +44,50 @@ void print_node(dom::Node const &node, std::ostream &os, uint8_t depth = 0) {
 std::string to_string(Document const &document) {
     std::stringstream ss;
     ss << "doctype: " << document.doctype << '\n';
-    print_node(document.html, ss);
+    print_node(document.html_node, ss);
     return ss.str();
 }
 
-std::vector<Node const *> nodes_by_path(Node const &root, std::string_view path) {
-    std::vector<Node const *> next_search{&root};
-    std::vector<Node const *> searching{};
-    std::vector<Node const *> goal_nodes{};
+std::vector<Element const *> nodes_by_path(std::reference_wrapper<Node const> root, std::string_view path) {
+    if (!std::holds_alternative<Element>(root.get())) {
+        return {};
+    }
+
+    auto const &element = std::get<Element>(root.get());
+    return nodes_by_path(element, path);
+}
+
+std::vector<Element const *> nodes_by_path(std::reference_wrapper<Element const> root, std::string_view path) {
+    std::vector<Element const *> next_search{&root.get()};
+    std::vector<Element const *> searching{};
+    std::vector<Element const *> goal_nodes{};
 
     while (!next_search.empty()) {
         searching.swap(next_search);
         next_search.clear();
 
         for (auto node : searching) {
-            auto const *data = std::get_if<Element>(&node->data);
-            if (!data) {
-                continue;
-            }
-
-            if (path == data->name) {
+            if (path == node->name) {
                 goal_nodes.push_back(node);
                 continue;
             }
 
-            if (path.starts_with(data->name + ".")) {
+            if (path.starts_with(node->name + ".")) {
+                // TODO(robinlinden): This would be so much better with ranges.
+                std::vector<Node const *> node_pointers{};
                 std::transform(cbegin(node->children),
                         cend(node->children),
-                        back_inserter(next_search),
+                        back_inserter(node_pointers),
                         [](Node const &n) -> Node const * { return &n; });
+                std::vector<Node const *> only_elements{};
+                std::remove_copy_if(cbegin(node_pointers),
+                        cend(node_pointers),
+                        back_inserter(only_elements),
+                        [](Node const *n) -> bool { return !std::holds_alternative<Element>(*n); });
+                std::transform(cbegin(only_elements),
+                        cend(only_elements),
+                        back_inserter(next_search),
+                        [](Node const *n) -> Element const * { return std::get_if<Element>(n); });
             }
         }
 

--- a/dom/dom_test.cpp
+++ b/dom/dom_test.cpp
@@ -37,7 +37,7 @@ int main() {
 
         auto const nodes = nodes_by_path(dom_root, "html");
         require(nodes.size() == 1);
-        expect(std::get<dom::Element>(nodes[0]->data).name == "html");
+        expect(nodes[0]->name == "html");
     });
 
     etest::test("path with one element node", [] {
@@ -50,7 +50,7 @@ int main() {
 
         auto const nodes = nodes_by_path(dom_root, "html.body.p");
         require(nodes.size() == 1);
-        expect(std::get<dom::Element>(nodes[0]->data).name == "p");
+        expect(nodes[0]->name == "p");
     });
 
     etest::test("path with multiple element nodes", [] {
@@ -65,11 +65,11 @@ int main() {
         auto const nodes = nodes_by_path(dom_root, "html.body.p");
         require(nodes.size() == 2);
 
-        auto const first = std::get<dom::Element>(nodes[0]->data);
+        auto const first = *nodes[0];
         expect(first.name == "p");
         expect(first.attributes.size() == 0);
 
-        auto const second = std::get<dom::Element>(nodes[1]->data);
+        auto const second = *nodes[1];
         expect(second.name == "p");
         expect(second.attributes.size() == 1);
         expect(second.attributes.at("display") == "none");
@@ -94,12 +94,12 @@ int main() {
         auto const nodes = nodes_by_path(dom_root, "html.body.div.p");
         require(nodes.size() == 2);
 
-        auto const first = std::get<dom::Element>(nodes[0]->data);
+        auto const first = *nodes[0];
         expect(first.name == "p");
         expect(first.attributes.size() == 1);
         expect(first.attributes.at("display") == "none");
 
-        auto const second = std::get<dom::Element>(nodes[1]->data);
+        auto const second = *nodes[1];
         expect(second.name == "p");
         expect(second.attributes.size() == 1);
         expect(second.attributes.at("display") == "block");

--- a/html/parser.h
+++ b/html/parser.h
@@ -34,11 +34,11 @@ public:
         }();
 
         auto children = parse_nodes();
-        if (children.size() == 1 && std::get<dom::Element>(children[0].data).name == "html") {
-            return dom::create_document(doctype, std::move(children[0]));
+        if (children.size() == 1 && std::get<dom::Element>(children[0]).name == "html") {
+            return dom::create_document(doctype, std::move(std::get<dom::Element>(children[0])));
         }
 
-        return dom::create_document(doctype, dom::create_element_node("html", {}, std::move(children)));
+        return dom::create_document(doctype, dom::Element{"html", {}, std::move(children)});
     }
 
 private:

--- a/html/parser_test.cpp
+++ b/html/parser_test.cpp
@@ -13,13 +13,13 @@ using etest::require;
 int main() {
     etest::test("doctype", [] {
         auto document = html::parse("<!doctype html>"sv);
-        expect(document.html.children.size() == 0);
+        expect(document.html().children.size() == 0);
         expect(document.doctype == "html"s);
     });
 
     etest::test("weirdly capitalized doctype", [] {
         auto document = html::parse("<!docTYpe html>"sv);
-        expect(document.html.children.size() == 0);
+        expect(document.html().children.size() == 0);
         expect(document.doctype == "html"s);
     });
 
@@ -30,128 +30,120 @@ int main() {
 
     etest::test("everything is wrapped in a html element", [] {
         auto document = html::parse("<p></p>"sv);
-        auto html = document.html;
-        expect(std::get<dom::Element>(html.data).name == "html"s);
+        auto html = document.html();
+        expect(html.name == "html"s);
         require(html.children.size() == 1);
-        expect(std::get<dom::Element>(html.children[0].data).name == "p"s);
+        expect(std::get<dom::Element>(html.children[0]).name == "p"s);
     });
 
     etest::test("single element", [] {
-        auto html = html::parse("<html></html>"sv).html;
+        auto html = html::parse("<html></html>"sv).html();
         expect(html.children.size() == 0);
-        expect(std::get<dom::Element>(html.data).name == "html"s);
-        expect(std::get<dom::Element>(html.data).attributes.size() == 0);
+        expect(html.name == "html"s);
+        expect(html.attributes.size() == 0);
     });
 
     etest::test("self-closing single element", [] {
-        auto nodes = html::parse("<br>"sv).html.children;
+        auto nodes = html::parse("<br>"sv).html().children;
         require(nodes.size() == 1);
 
-        auto br = nodes[0];
+        auto br = std::get<dom::Element>(nodes[0]);
         expect(br.children.size() == 0);
-        expect(std::get<dom::Element>(br.data).name == "br"s);
-        expect(std::get<dom::Element>(br.data).attributes.size() == 0);
+        expect(br.name == "br"s);
+        expect(br.attributes.size() == 0);
     });
 
     etest::test("self-closing single element with slash", [] {
-        auto nodes = html::parse("<img/>"sv).html.children;
+        auto nodes = html::parse("<img/>"sv).html().children;
         require(nodes.size() == 1);
 
-        auto img = nodes[0];
+        auto img = std::get<dom::Element>(nodes[0]);
         expect(img.children.size() == 0);
-        expect(std::get<dom::Element>(img.data).name == "img"s);
-        expect(std::get<dom::Element>(img.data).attributes.size() == 0);
+        expect(img.name == "img"s);
+        expect(img.attributes.size() == 0);
     });
 
     etest::test("multiple elements", [] {
-        auto nodes = html::parse("<span></span><div></div>"sv).html.children;
+        auto nodes = html::parse("<span></span><div></div>"sv).html().children;
         require(nodes.size() == 2);
 
-        auto span = nodes[0];
+        auto span = std::get<dom::Element>(nodes[0]);
         expect(span.children.size() == 0);
-        expect(std::get<dom::Element>(span.data).name == "span"s);
-        expect(std::get<dom::Element>(span.data).attributes.size() == 0);
+        expect(span.name == "span"s);
+        expect(span.attributes.size() == 0);
 
-        auto div = nodes[1];
+        auto div = std::get<dom::Element>(nodes[1]);
         expect(div.children.size() == 0);
-        expect(std::get<dom::Element>(div.data).name == "div"s);
-        expect(std::get<dom::Element>(div.data).attributes.size() == 0);
+        expect(div.name == "div"s);
+        expect(div.attributes.size() == 0);
     });
 
     etest::test("nested elements", [] {
-        auto html = html::parse("<html><body></body></html>"sv).html;
+        auto html = html::parse("<html><body></body></html>"sv).html();
         require(html.children.size() == 1);
-        expect(std::get<dom::Element>(html.data).name == "html"s);
-        expect(std::get<dom::Element>(html.data).attributes.size() == 0);
+        expect(html.name == "html"s);
+        expect(html.attributes.size() == 0);
 
-        auto body = html.children[0];
-        expect(std::get<dom::Element>(body.data).name == "body"s);
-        expect(std::get<dom::Element>(body.data).attributes.size() == 0);
+        auto body = std::get<dom::Element>(html.children[0]);
+        expect(body.name == "body"s);
+        expect(body.attributes.size() == 0);
     });
 
     etest::test("single-quoted attribute", [] {
-        auto nodes = html::parse("<meta charset='utf-8'/>"sv).html.children;
+        auto nodes = html::parse("<meta charset='utf-8'/>"sv).html().children;
         require(nodes.size() == 1);
 
-        auto meta = nodes[0];
+        auto meta = std::get<dom::Element>(nodes[0]);
         expect(meta.children.size() == 0);
-
-        auto meta_data = std::get<dom::Element>(meta.data);
-        expect(meta_data.name == "meta"s);
-        expect(meta_data.attributes.size() == 1);
-        expect(meta_data.attributes.at("charset") == "utf-8"s);
+        expect(meta.name == "meta"s);
+        expect(meta.attributes.size() == 1);
+        expect(meta.attributes.at("charset") == "utf-8"s);
     });
 
     etest::test("double-quoted attribute", [] {
-        auto nodes = html::parse(R"(<meta charset="utf-8"/>)"sv).html.children;
+        auto nodes = html::parse(R"(<meta charset="utf-8"/>)"sv).html().children;
         require(nodes.size() == 1);
 
-        auto meta = nodes[0];
+        auto meta = std::get<dom::Element>(nodes[0]);
         expect(meta.children.size() == 0);
-
-        auto meta_data = std::get<dom::Element>(meta.data);
-        expect(meta_data.name == "meta"s);
-        expect(meta_data.attributes.size() == 1);
-        expect(meta_data.attributes.at("charset"s) == "utf-8"s);
+        expect(meta.name == "meta"s);
+        expect(meta.attributes.size() == 1);
+        expect(meta.attributes.at("charset"s) == "utf-8"s);
     });
 
     etest::test("multiple attributes", [] {
-        auto nodes = html::parse(R"(<meta name="viewport" content="width=100em, initial-scale=1"/>)"sv).html.children;
+        auto nodes = html::parse(R"(<meta name="viewport" content="width=100em, initial-scale=1"/>)"sv).html().children;
         require(nodes.size() == 1);
 
-        auto meta = nodes[0];
+        auto meta = std::get<dom::Element>(nodes[0]);
         expect(meta.children.size() == 0);
-
-        auto meta_data = std::get<dom::Element>(meta.data);
-        expect(meta_data.name == "meta"s);
-        expect(meta_data.attributes.size() == 2);
-        expect(meta_data.attributes.at("name"s) == "viewport"s);
-        expect(meta_data.attributes.at("content"s) == "width=100em, initial-scale=1"s);
+        expect(meta.name == "meta"s);
+        expect(meta.attributes.size() == 2);
+        expect(meta.attributes.at("name"s) == "viewport"s);
+        expect(meta.attributes.at("content"s) == "width=100em, initial-scale=1"s);
     });
 
     etest::test("multiple nodes with attributes", [] {
-        auto html = html::parse("<html bonus='hello'><body style='fancy'></body></html>"sv).html;
+        auto html = html::parse("<html bonus='hello'><body style='fancy'></body></html>"sv).html();
         require(html.children.size() == 1);
-        auto html_data = std::get<dom::Element>(html.data);
-        expect(html_data.name == "html"s);
-        expect(html_data.attributes.size() == 1);
-        expect(html_data.attributes.at("bonus"s) == "hello"s);
+        expect(html.name == "html"s);
+        expect(html.attributes.size() == 1);
+        expect(html.attributes.at("bonus"s) == "hello"s);
 
-        auto body = html.children[0];
-        auto body_data = std::get<dom::Element>(body.data);
-        expect(body_data.name == "body"s);
-        expect(body_data.attributes.size() == 1);
-        expect(body_data.attributes.at("style"s) == "fancy"s);
+        auto body = std::get<dom::Element>(html.children[0]);
+        expect(body.name == "body"s);
+        expect(body.attributes.size() == 1);
+        expect(body.attributes.at("style"s) == "fancy"s);
     });
 
     etest::test("text node", [] {
-        auto html = html::parse("<html>fantastic, the future is now</html>"sv).html;
+        auto html = html::parse("<html>fantastic, the future is now</html>"sv).html();
         require(html.children.size() == 1);
-        expect(std::get<dom::Element>(html.data).name == "html"s);
-        expect(std::get<dom::Element>(html.data).attributes.size() == 0);
+        expect(html.name == "html"s);
+        expect(html.attributes.size() == 0);
 
-        auto text = html.children[0];
-        expect(std::get<dom::Text>(text.data).text == "fantastic, the future is now"s);
+        auto text = std::get<dom::Text>(html.children[0]);
+        expect(text.text == "fantastic, the future is now"s);
     });
 
     return etest::run_all_tests();

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -63,7 +63,7 @@ std::optional<LayoutBox> create_tree(style::StyledNode const &node) {
                                   return LayoutBox{&node, LayoutType::Inline};
                               },
                       },
-            node.node.get().data);
+            node.node.get());
 }
 
 // TODO(robinlinden):
@@ -84,9 +84,9 @@ int to_px(std::string_view property) {
 void calculate_width(LayoutBox &box, geom::Rect const &parent) {
     assert(box.node != nullptr);
 
-    if (std::holds_alternative<dom::Text>(box.node->node.get().data)) {
+    if (std::holds_alternative<dom::Text>(box.node->node.get())) {
         // TODO(robinlinden): Measure the text for real.
-        auto text_node = std::get<dom::Text>(box.node->node.get().data);
+        auto text_node = std::get<dom::Text>(box.node->node.get());
         auto font_size = style::get_property_or(*box.node, "font-size", "10px");
         box.dimensions.content.width =
                 std::min(parent.width, static_cast<int>(text_node.text.size()) * to_px(font_size) / 2);
@@ -116,7 +116,7 @@ void calculate_position(LayoutBox &box, geom::Rect const &parent) {
 
 void calculate_height(LayoutBox &box) {
     assert(box.node != nullptr);
-    if (std::holds_alternative<dom::Text>(box.node->node.get().data)) {
+    if (std::holds_alternative<dom::Text>(box.node->node.get())) {
         auto font_size = style::get_property_or(*box.node, "font-size", "10px");
         box.dimensions.content.height = to_px(font_size);
     }
@@ -230,7 +230,7 @@ std::string_view to_str(dom::Node const &node) {
                               [](dom::Element const &element) -> std::string_view { return element.name; },
                               [](dom::Text const &text) -> std::string_view { return text.text; },
                       },
-            node.data);
+            node);
 }
 
 std::string to_str(geom::Rect const &rect) {

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -26,13 +26,14 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {},
             .children = {
-                {dom_root.children[0], {}, {}},
-                {dom_root.children[1], {}, {
-                    {dom_root.children[1].children[0], {}, {}},
+                {children[0], {}, {}},
+                {children[1], {}, {
+                    {std::get<dom::Element>(children[1]).children[0], {}, {}},
                 }},
             },
         };
@@ -61,13 +62,14 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {},
             .children = {
-                {dom_root.children[0], {{"display", "none"}}, {}},
-                {dom_root.children[1], {}, {
-                    {dom_root.children[1].children[0], {}, {}},
+                {children[0], {{"display", "none"}}, {}},
+                {children[1], {}, {
+                    {std::get<dom::Element>(children[1]).children[0], {}, {}},
                 }},
             },
         };
@@ -95,13 +97,14 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {},
             .children = {
-                {dom_root.children[0], {{"display", "inline"}}, {}},
-                {dom_root.children[1], {{"display", "inline"}}, {
-                    {dom_root.children[1].children[0], {}, {}},
+                {children[0], {{"display", "inline"}}, {}},
+                {children[1], {{"display", "inline"}}, {
+                    {std::get<dom::Element>(children[1]).children[0], {}, {}},
                 }},
             },
         };
@@ -135,13 +138,14 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {},
             .children = {
-                {dom_root.children[0], {}, {
-                    {dom_root.children[0].children[0], {}, {}},
-                    {dom_root.children[0].children[1], {}, {}},
+                {children[0], {}, {
+                    {std::get<dom::Element>(children[0]).children[0], {}, {}},
+                    {std::get<dom::Element>(children[0]).children[1], {}, {}},
                 }},
             },
         };
@@ -171,12 +175,13 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {{"width", "100px"}},
             .children = {
-                {dom_root.children[0], {}, {
-                    {dom_root.children[0].children[0], {}, {}},
+                {children[0], {}, {
+                    {std::get<dom::Element>(children[0]).children[0], {}, {}},
                 }},
             },
         };
@@ -202,12 +207,13 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {{"min-width", "100px"}},
             .children = {
-                {dom_root.children[0], {{"min-width", "50px"}}, {
-                    {dom_root.children[0].children[0], {}, {}},
+                {children[0], {{"min-width", "50px"}}, {
+                    {std::get<dom::Element>(children[0]).children[0], {}, {}},
                 }},
             },
         };
@@ -235,12 +241,13 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {{"max-width", "100px"}},
             .children = {
-                {dom_root.children[0], {{"max-width", "50px"}}, {
-                    {dom_root.children[0].children[0], {}, {}},
+                {children[0], {{"max-width", "50px"}}, {
+                    {std::get<dom::Element>(children[0]).children[0], {}, {}},
                 }},
             },
         };
@@ -266,12 +273,13 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {{"width", "100px"}},
             .children = {
-                {dom_root.children[0], {{"width", "50px"}}, {
-                    {dom_root.children[0].children[0], {{"width", "25px"}}, {}},
+                {children[0], {{"width", "50px"}}, {
+                    {std::get<dom::Element>(children[0]).children[0], {{"width", "25px"}}, {}},
                 }},
             },
         };
@@ -297,12 +305,13 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {{"width", "100px"}},
             .children = {
-                {dom_root.children[0], {}, {
-                    {dom_root.children[0].children[0], {}, {}},
+                {children[0], {}, {
+                    {std::get<dom::Element>(children[0]).children[0], {}, {}},
                 }},
             },
         };
@@ -328,12 +337,13 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {{"height", "100px"}},
             .children = {
-                {dom_root.children[0], {}, {
-                    {dom_root.children[0].children[0], {}, {}},
+                {children[0], {}, {
+                    {std::get<dom::Element>(children[0]).children[0], {}, {}},
                 }},
             },
         };
@@ -360,13 +370,14 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {},
             .children = {
-                {dom_root.children[0], {}, {
-                    {dom_root.children[0].children[0], {{"height", "25px"}}, {}},
-                    {dom_root.children[0].children[1], {}, {}},
+                {children[0], {}, {
+                    {std::get<dom::Element>(children[0]).children[0], {{"height", "25px"}}, {}},
+                    {std::get<dom::Element>(children[0]).children[1], {}, {}},
                 }},
             },
         };
@@ -394,13 +405,14 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {{"min-height", "400px"}},
             .children = {
-                {dom_root.children[0], {}, {
-                    {dom_root.children[0].children[0], {{"height", "25px"}}, {}},
-                    {dom_root.children[0].children[1], {}, {}},
+                {children[0], {}, {
+                    {std::get<dom::Element>(children[0]).children[0], {{"height", "25px"}}, {}},
+                    {std::get<dom::Element>(children[0]).children[1], {}, {}},
                 }},
             },
         };
@@ -428,13 +440,14 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {{"max-height", "10px"}},
             .children = {
-                {dom_root.children[0], {}, {
-                    {dom_root.children[0].children[0], {{"height", "400px"}}, {}},
-                    {dom_root.children[0].children[1], {}, {}},
+                {children[0], {}, {
+                    {std::get<dom::Element>(children[0]).children[0], {{"height", "400px"}}, {}},
+                    {std::get<dom::Element>(children[0]).children[1], {}, {}},
                 }},
             },
         };
@@ -470,13 +483,14 @@ int main() {
                 std::pair{"padding-left"s, "10px"s},
         };
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {},
             .children = {
-                {dom_root.children[0], {}, {
-                    {dom_root.children[0].children[0], std::move(properties), {}},
-                    {dom_root.children[0].children[1], {}, {}},
+                {children[0], {}, {
+                    {std::get<dom::Element>(children[0]).children[0], std::move(properties), {}},
+                    {std::get<dom::Element>(children[0]).children[1], {}, {}},
                 }},
             },
         };
@@ -511,13 +525,14 @@ int main() {
                 std::pair{"margin-left"s, "10px"s},
         };
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {},
             .children = {
-                {dom_root.children[0], {}, {
-                    {dom_root.children[0].children[0], std::move(properties), {}},
-                    {dom_root.children[0].children[1], {}, {}},
+                {children[0], {}, {
+                    {std::get<dom::Element>(children[0]).children[0], std::move(properties), {}},
+                    {std::get<dom::Element>(children[0]).children[1], {}, {}},
                 }},
             },
         };
@@ -599,13 +614,14 @@ int main() {
             }),
         });
 
+        auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
             .properties = {},
             .children = {
-                {dom_root.children[0], {}, {
-                    {dom_root.children[0].children[0], {{"height", "25px"}}, {}},
-                    {dom_root.children[0].children[1], {{"padding-top", "5px"}, {"padding-right", "15px"}}, {}},
+                {children[0], {}, {
+                    {std::get<dom::Element>(children[0]).children[0], {{"height", "25px"}}, {}},
+                    {std::get<dom::Element>(children[0]).children[1], {{"padding-top", "5px"}, {"padding-right", "15px"}}, {}},
                 }},
             },
         };

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -22,7 +22,7 @@ bool looks_like_hex(std::string_view str) {
 }
 
 bool contains_text(layout::LayoutBox const &layout) {
-    return std::holds_alternative<dom::Text>(layout.node->node.get().data);
+    return std::holds_alternative<dom::Text>(layout.node->node.get());
 }
 
 gfx::Color from_hex_chars(std::string_view hex_chars) {

--- a/style/style.cpp
+++ b/style/style.cpp
@@ -44,14 +44,17 @@ std::vector<std::pair<std::string, std::string>> matching_rules(
     return matched_rules;
 }
 
-StyledNode style_tree(dom::Node const &root, std::vector<css::Rule> const &stylesheet) {
+StyledNode style_tree(std::reference_wrapper<dom::Node const> root, std::vector<css::Rule> const &stylesheet) {
     std::vector<StyledNode> children{};
-    for (auto const &child : root.children) {
-        children.push_back(style_tree(child, stylesheet));
+
+    if (auto const *element = std::get_if<dom::Element>(&root.get())) {
+        for (auto const &child : element->children) {
+            children.push_back(style_tree(child, stylesheet));
+        }
     }
 
-    auto properties = std::holds_alternative<dom::Element>(root.data)
-            ? matching_rules(std::get<dom::Element>(root.data), stylesheet)
+    auto properties = std::holds_alternative<dom::Element>(root.get())
+            ? matching_rules(std::get<dom::Element>(root.get()), stylesheet)
             : std::vector<std::pair<std::string, std::string>>{};
 
     return {

--- a/style/style.h
+++ b/style/style.h
@@ -9,6 +9,7 @@
 #include "dom/dom.h"
 #include "style/styled_node.h"
 
+#include <functional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -21,7 +22,7 @@ bool is_match(dom::Element const &element, std::string_view selector);
 std::vector<std::pair<std::string, std::string>> matching_rules(
         dom::Element const &element, std::vector<css::Rule> const &stylesheet);
 
-StyledNode style_tree(dom::Node const &root, std::vector<css::Rule> const &stylesheet);
+StyledNode style_tree(std::reference_wrapper<dom::Node const> root, std::vector<css::Rule> const &stylesheet);
 
 } // namespace style
 

--- a/style/style_test.cpp
+++ b/style/style_test.cpp
@@ -101,13 +101,14 @@ int main() {
             }
         );
 
+        auto const &root_as_elem = std::get<dom::Element>(root);
         style::StyledNode expected{
             .node = root,
             .properties = {},
             .children = {
-                {root.children[0], {}, {}},
-                {root.children[1], {}, {
-                    {root.children[1].children[0], {}, {}},
+                {root_as_elem.children[0], {}, {}},
+                {root_as_elem.children[1], {}, {
+                    {std::get<dom::Element>(root_as_elem.children[1]).children[0], {}, {}},
                 }},
             },
         };
@@ -142,13 +143,14 @@ int main() {
             },
         };
 
+        auto const &root_as_elem = std::get<dom::Element>(root);
         style::StyledNode expected{
             .node = root,
             .properties = {},
             .children = {
-                {root.children[0], {}, {}},
-                {root.children[1], {{"text-size", "500em"}}, {
-                    {root.children[1].children[0], {{"height", "100px"}}, {}},
+                {root_as_elem.children[0], {}, {}},
+                {root_as_elem.children[1], {{"text-size", "500em"}}, {
+                    {std::get<dom::Element>(root_as_elem.children[1]).children[0], {{"height", "100px"}}, {}},
                 }},
             },
         };

--- a/tui/tui.cpp
+++ b/tui/tui.cpp
@@ -29,7 +29,7 @@ ftxui::Elements parse_children(layout::LayoutBox const &box) {
 ftxui::Element element_from_node(layout::LayoutBox const &box) {
     switch (box.type) {
         case layout::LayoutType::Inline: {
-            if (auto text = std::get_if<dom::Text>(&box.node->node.get().data)) {
+            if (auto text = std::get_if<dom::Text>(&box.node->node.get())) {
                 return hflow(ftxui::paragraph(text->text));
             }
             return hbox(parse_children(box));


### PR DESCRIPTION
This changes it so that Text nodes don't have an always-empty
children member, which means that Node can now be a alias for
std::variant<Element, Text> instead of a type of its own.

I ran into a lot of issues with dom::Node being implicitly constructed
from dom::Element, leading to us returning pointers or references to
temporaries, so the functions I ran into issues with were converted to
use std::reference_wrapper instead of just a plain reference. This means
that it's a compile-time error to pass a temporary.