### PR TITLE
Fix the html2 tokenizer not handling attributes correctly

### DIFF
--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -333,10 +333,10 @@ void Tokenizer::run() {
                         continue;
                     case '\0':
                         // This is an unexpected-null-character parse error.
-                        current_attribute().name += "\xFF\xFD";
+                        current_attribute().value += "\xFF\xFD";
                         continue;
                     default:
-                        current_attribute().name += *c;
+                        current_attribute().value += *c;
                         continue;
                 }
             }

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -363,10 +363,6 @@ void Tokenizer::run() {
                         state_ = State::Data;
                         emit(std::move(current_token_));
                         continue;
-                    case '\0':
-                        // This is an unexpected-null-character parse error.
-                        current_attribute().name += "\xFF\xFD";
-                        continue;
                     default:
                         // This is a missing-whitespace-between-attributes parse error.
                         reconsume_in(State::BeforeAttributeName);


### PR DESCRIPTION
The relevant states are:
https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(double-quoted)-state
https://html.spec.whatwg.org/multipage/parsing.html#after-attribute-value-(quoted)-state

I'm sure more issues like this will pop up once we start using it. Adding all these states gets tedious, so copy-paste errors aren't unlikely. This was found as I was integrating the new parser with the old dom structure and adding tests for it.