### PR TITLE
Use string_view in trim functions

### DIFF
--- a/util/string.h
+++ b/util/string.h
@@ -38,6 +38,11 @@ inline std::pair<std::string_view, std::string_view> split_once(std::string_view
     return {str, ""};
 }
 
+constexpr bool is_whitespace(char ch) {
+    constexpr std::array ws_chars = {' ', '\n', '\r', '\f', '\v', '\t'};
+    return std::any_of(cbegin(ws_chars), cend(ws_chars), [ch](char ws_ch) { return ch == ws_ch; });
+}
+
 inline std::string trim_start(std::string s) {
     s.erase(begin(s), std::find_if(begin(s), end(s), [](unsigned char ch) { return !std::isspace(ch); }));
     return s;

--- a/util/string.h
+++ b/util/string.h
@@ -9,10 +9,10 @@
 #include <range/v3/algorithm/equal.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cctype>
-#include <string>
+#include <iterator>
 #include <string_view>
-#include <utility>
 #include <vector>
 
 namespace util {
@@ -43,19 +43,21 @@ constexpr bool is_whitespace(char ch) {
     return std::any_of(cbegin(ws_chars), cend(ws_chars), [ch](char ws_ch) { return ch == ws_ch; });
 }
 
-inline std::string trim_start(std::string s) {
-    s.erase(begin(s), std::find_if(begin(s), end(s), [](unsigned char ch) { return !std::isspace(ch); }));
+constexpr std::string_view trim_start(std::string_view s) {
+    auto it = std::find_if(cbegin(s), cend(s), [](char ch) { return !is_whitespace(ch); });
+    s.remove_prefix(std::distance(cbegin(s), it));
     return s;
 }
 
-inline std::string trim_end(std::string s) {
-    s.erase(std::find_if(rbegin(s), rend(s), [](unsigned char ch) { return !std::isspace(ch); }).base(), end(s));
+constexpr std::string_view trim_end(std::string_view s) {
+    auto it = std::find_if(crbegin(s), crend(s), [](char ch) { return !is_whitespace(ch); });
+    s.remove_suffix(std::distance(crbegin(s), it));
     return s;
 }
 
-inline std::string trim(std::string s) {
-    s = trim_start(std::move(s));
-    s = trim_end(std::move(s));
+constexpr std::string_view trim(std::string_view s) {
+    s = trim_start(s);
+    s = trim_end(s);
     return s;
 }
 

--- a/util/string_test.cpp
+++ b/util/string_test.cpp
@@ -152,35 +152,35 @@ int main() {
     });
 
     etest::test("trim start", [] {
-        expect_eq(trim_start(" abc "), "abc ");
-        expect_eq(trim_start("\t431\r\n"), "431\r\n");
-        expect_eq(trim_start("  hello world!"), "hello world!");
-        expect_eq(trim_start("word "), "word ");
-        expect_eq(trim_start("\r\n"), "");
+        expect_eq(trim_start(" abc "sv), "abc "sv);
+        expect_eq(trim_start("\t431\r\n"sv), "431\r\n"sv);
+        expect_eq(trim_start("  hello world!"sv), "hello world!"sv);
+        expect_eq(trim_start("word "sv), "word "sv);
+        expect_eq(trim_start("\r\n"sv), ""sv);
     });
 
     etest::test("trim end", [] {
-        expect_eq(trim_end("abc "), "abc");
-        expect_eq(trim_end("53 \r\n"), "53");
-        expect_eq(trim_end("hello world!\t"), "hello world!");
-        expect_eq(trim_end(" word"), " word");
-        expect_eq(trim_end("\r\n"), "");
+        expect_eq(trim_end("abc "sv), "abc"sv);
+        expect_eq(trim_end("53 \r\n"sv), "53"sv);
+        expect_eq(trim_end("hello world!\t"sv), "hello world!"sv);
+        expect_eq(trim_end(" word"sv), " word"sv);
+        expect_eq(trim_end("\r\n"sv), ""sv);
     });
 
     etest::test("trim", [] {
-        expect_eq(trim("abc"), "abc");
-        expect_eq(trim("\t431"), "431");
-        expect_eq(trim("53 \r\n"), "53");
-        expect_eq(trim("\t\thello world\n"), "hello world");
-        expect_eq(trim(" a b c d "), "a b c d");
-        expect_eq(trim("\r\n"), "");
+        expect_eq(trim("abc"sv), "abc"sv);
+        expect_eq(trim("\t431"sv), "431"sv);
+        expect_eq(trim("53 \r\n"sv), "53"sv);
+        expect_eq(trim("\t\thello world\n"sv), "hello world"sv);
+        expect_eq(trim(" a b c d "sv), "a b c d"sv);
+        expect_eq(trim("\r\n"sv), ""sv);
     });
 
     etest::test("trim with non-ascii characters", [] {
-        expect_eq(trim("Ö"), "Ö");
-        expect_eq(trim(" Ö "), "Ö");
-        expect_eq(trim_start(" Ö "), "Ö ");
-        expect_eq(trim_end(" Ö "), " Ö");
+        expect_eq(trim("Ö"sv), "Ö"sv);
+        expect_eq(trim(" Ö "sv), "Ö"sv);
+        expect_eq(trim_start(" Ö "sv), "Ö "sv);
+        expect_eq(trim_end(" Ö "sv), " Ö"sv);
     });
 
     return etest::run_all_tests();

--- a/util/string_test.cpp
+++ b/util/string_test.cpp
@@ -139,6 +139,18 @@ int main() {
         expect_eq(p.second, "");
     });
 
+    etest::test("is whitespace", [] {
+        expect(is_whitespace(' '));
+        expect(is_whitespace('\n'));
+        expect(is_whitespace('\r'));
+        expect(is_whitespace('\f'));
+        expect(is_whitespace('\v'));
+        expect(is_whitespace('\t'));
+
+        expect(!is_whitespace('a'));
+        expect(!is_whitespace('\0'));
+    });
+
     etest::test("trim start", [] {
         expect_eq(trim_start(" abc "), "abc ");
         expect_eq(trim_start("\t431\r\n"), "431\r\n");


### PR DESCRIPTION
This commit changes to use string_view in all trim functions. Also made these function constexpr.