### PR TITLE
etest: Drop support for etest_with_main

### DIFF
--- a/etest/BUILD
+++ b/etest/BUILD
@@ -10,26 +10,9 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
-    name = "etest_with_main",
-    srcs = ["etest_main.cpp"],
-    visibility = ["//visibility:public"],
-    deps = [":etest"],
-)
-
-cc_test(
-    name = "etest_test",
-    size = "small",
-    srcs = ["etest_test.cpp"],
-    deps = [":etest_with_main"],
-)
-
 [cc_test(
     name = src[:-4],
     size = "small",
     srcs = [src],
     deps = [":etest"],
-) for src in glob(
-    include = ["*_test.cpp"],
-    exclude = ["etest_test.cpp"],
-)]
+) for src in glob(["*_test.cpp"])]

--- a/etest/etest.cpp
+++ b/etest/etest.cpp
@@ -9,6 +9,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 namespace etest {
@@ -68,7 +69,8 @@ int run_all_tests() noexcept {
 }
 
 void test(std::string_view name, std::function<void()> body) noexcept {
-    registry().push_back({name, body});
+    // TODO(robinlinden): push_back -> emplace_back once Clang supports it (C++20/p0960). Not supported as of Clang 13.
+    registry().push_back({name, std::move(body)});
 }
 
 void expect(bool b, etest::source_location const &loc) noexcept {

--- a/etest/etest.cpp
+++ b/etest/etest.cpp
@@ -67,9 +67,8 @@ int run_all_tests() noexcept {
     return assertion_failures > 0 ? 1 : 0;
 }
 
-int test(std::string_view name, std::function<void()> body) noexcept {
+void test(std::string_view name, std::function<void()> body) noexcept {
     registry().push_back({name, body});
-    return 0;
 }
 
 void expect(bool b, etest::source_location const &loc) noexcept {

--- a/etest/etest.h
+++ b/etest/etest.h
@@ -20,7 +20,7 @@ concept Printable = requires(std::ostream &os, T t) {
 };
 
 int run_all_tests() noexcept;
-int test(std::string_view name, std::function<void()> body) noexcept;
+void test(std::string_view name, std::function<void()> body) noexcept;
 
 // Weak test requirement. Allows the test to continue even if the check fails.
 void expect(bool, etest::source_location const &loc = etest::source_location::current()) noexcept;

--- a/etest/etest_main.cpp
+++ b/etest/etest_main.cpp
@@ -1,9 +1,0 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
-//
-// SPDX-License-Identifier: BSD-2-Clause
-
-#include "etest/etest.h"
-
-int main() {
-    return etest::run_all_tests();
-}

--- a/etest/etest_test.cpp
+++ b/etest/etest_test.cpp
@@ -1,7 +1,0 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
-//
-// SPDX-License-Identifier: BSD-2-Clause
-
-#include "etest/etest.h"
-
-auto test0 = etest::test("expect true works", [] { etest::expect(true); });


### PR DESCRIPTION
etest_with_main was added because at first I was planning on being fully
compatible with gtest, but I like this more. If a user wants something
like etest_with_main, they can very easily build it on top of etest
themselves.