### PR TITLE
build: Enable the disallow_empty_glob deprecation flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,12 @@
 build:debug -c dbg
 build:release -c opt
 
+# Bazel deprecations
+# =========================================================
+# See: https://docs.bazel.build/versions/main/backward-compatibility.html
+
+build --incompatible_disallow_empty_glob
+
 # Compiler configuration
 # =========================================================
 

--- a/third_party/sfml.BUILD
+++ b/third_party/sfml.BUILD
@@ -8,10 +8,7 @@ SFML_DEFINES = [
 
 cc_library(
     name = "system",
-    srcs = glob([
-        "src/SFML/System/*.cpp",
-        "src/SFML/System/*.hpp",
-    ]) + select({
+    srcs = glob(["src/SFML/System/*.cpp"]) + select({
         "@platforms//os:linux": glob([
             "src/SFML/System/Unix/**/*.cpp",
             "src/SFML/System/Unix/**/*.hpp",
@@ -94,16 +91,7 @@ cc_library(
             "src/SFML/Graphics/*.cpp",
             "src/SFML/Graphics/*.hpp",
         ],
-    ) + select({
-        "@platforms//os:linux": glob([
-            "src/SFML/Graphics/Unix/*.cpp",
-            "src/SFML/Graphics/Unix/*.hpp",
-        ]),
-        "@platforms//os:windows": glob([
-            "src/SFML/Graphics/Win32/*.cpp",
-            "src/SFML/Graphics/Win32/*.hpp",
-        ]),
-    }),
+    ),
     hdrs = glob(["include/SFML/Graphics/*"]),
     copts = ["-Iexternal/sfml/src/"],
     defines = SFML_DEFINES,


### PR DESCRIPTION
This helps find issues when setting up build files, which is great!
Look at that mess I had made in the SFML build file. :P