### PR TITLE
Split up `//util`

### DIFF
--- a/css/BUILD
+++ b/css/BUILD
@@ -15,7 +15,7 @@ cc_library(
     data = ["default.css"],
     visibility = ["//visibility:public"],
     deps = [
-        "//util",
+        "//util:base_parser",
         "@fmt",
     ],
 )

--- a/html2/BUILD
+++ b/html2/BUILD
@@ -10,7 +10,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//dom2",
-        "//util",
+        "//util:string",
         "@spdlog",
     ],
 )

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -14,7 +14,7 @@ cc_library(
     deps = [
         "//net",
         "//uri",
-        "//util",
+        "//util:string",
         "@fmt",
         "@range-v3",
     ],

--- a/util/BUILD
+++ b/util/BUILD
@@ -1,13 +1,9 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
-    name = "util",
-    hdrs = [
-        "base_parser.h",
-        "string.h",
-    ],
+    name = "base_parser",
+    hdrs = ["base_parser.h"],
     visibility = ["//visibility:public"],
-    deps = ["@range-v3"],
 )
 
 cc_test(
@@ -15,9 +11,16 @@ cc_test(
     size = "small",
     srcs = ["base_parser_test.cpp"],
     deps = [
-        ":util",
+        ":base_parser",
         "//etest",
     ],
+)
+
+cc_library(
+    name = "string",
+    hdrs = ["string.h"],
+    visibility = ["//visibility:public"],
+    deps = ["@range-v3"],
 )
 
 cc_test(
@@ -25,7 +28,7 @@ cc_test(
     size = "small",
     srcs = ["string_test.cpp"],
     deps = [
-        ":util",
+        ":string",
         "//etest",
     ],
 )

--- a/util/BUILD
+++ b/util/BUILD
@@ -1,34 +1,25 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
-cc_library(
-    name = "base_parser",
-    hdrs = ["base_parser.h"],
-    visibility = ["//visibility:public"],
-)
+dependencies = {
+    "string": ["@range-v3"],
+}
 
-cc_test(
-    name = "base_parser_test",
+[cc_library(
+    name = hdr[:-2],
+    hdrs = [hdr],
+    visibility = ["//visibility:public"],
+    deps = dependencies.get(
+        hdr[:-2],
+        [],
+    ),
+) for hdr in glob(["*.h"])]
+
+[cc_test(
+    name = src[:-4],
     size = "small",
-    srcs = ["base_parser_test.cpp"],
+    srcs = [src],
     deps = [
-        ":base_parser",
+        ":%s" % src[:-9],
         "//etest",
     ],
-)
-
-cc_library(
-    name = "string",
-    hdrs = ["string.h"],
-    visibility = ["//visibility:public"],
-    deps = ["@range-v3"],
-)
-
-cc_test(
-    name = "string_test",
-    size = "small",
-    srcs = ["string_test.cpp"],
-    deps = [
-        ":string",
-        "//etest",
-    ],
-)
+) for src in glob(["*_test.cpp"])]


### PR DESCRIPTION
I didn't like that when using the string utils, you also got very unrelated parsing utils, so this commit splits the monolith util target into 1 target per util.

I also played around a bit with Starlark magic in the build file. Not sure if it simplified it or not, but PTAL! It'll need a minor change if we add utils with .cpp-files, but this works as things are right now.

Now instead of depending on `//util`, you depend on `//util:string` or `//util:base_parser`.