### PR TITLE
Use -fsanitize-link-c++-runtime instead of -lubsan

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -126,7 +126,7 @@ build:ubsan --strip=never
 build:ubsan --copt -fsanitize=undefined
 build:ubsan --copt=-fno-omit-frame-pointer
 build:ubsan --linkopt -fsanitize=undefined
-build:ubsan --linkopt -lubsan
+build:ubsan --linkopt -fsanitize-link-c++-runtime
 build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 
 # Misc configuration


### PR DESCRIPTION
* See: https://github.com/bazelbuild/bazel/issues/11122
* Using explicit lubsan should be avaided, see:
  https://groups.google.com/g/address-sanitizer/c/SD590XDinfQ/m/NMUPj_G0BgAJ