### PR TITLE
Fix so that eof token is emitted from tokenizer

### DIFF
--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -72,14 +72,14 @@ std::string to_string(Token const &token) {
 }
 
 void Tokenizer::run() {
-    while (!is_eof()) {
+    while (true) {
         spdlog::trace("Running state {} w/ next char {}", state_, input_[pos_]);
         switch (state_) {
             case State::Data: {
                 auto c = consume_next_input_character();
                 if (!c) {
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -107,7 +107,7 @@ void Tokenizer::run() {
                     // This is an eof-before-tag-name parse error.
                     emit(CharacterToken{'<'});
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 if (is_ascii_alpha(*c)) {
@@ -136,7 +136,7 @@ void Tokenizer::run() {
                     emit(CharacterToken{'<'});
                     emit(CharacterToken{'/'});
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 if (is_ascii_alpha(*c)) {
@@ -153,7 +153,7 @@ void Tokenizer::run() {
                 if (!c) {
                     // This is an eof-in-tag parse error.
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 auto append_to_tag_name = [&](auto text) {
@@ -260,7 +260,7 @@ void Tokenizer::run() {
                 if (!c) {
                     // This is an eof-in-tag parse error.
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -320,7 +320,7 @@ void Tokenizer::run() {
                 if (!c) {
                     // This is an eof-in-tag parse error.
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -346,7 +346,7 @@ void Tokenizer::run() {
                 if (!c) {
                     // This is an eof-in-tag parse error.
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -372,7 +372,7 @@ void Tokenizer::run() {
                 if (!c) {
                     // This is an eof-in-tag parse error.
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -401,7 +401,7 @@ void Tokenizer::run() {
                 if (!c) {
                     // This is an eof-in-tag parse error.
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -464,7 +464,7 @@ void Tokenizer::run() {
                     // This is an eof-in-comment parse error.
                     emit(std::move(current_token_));
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -489,7 +489,7 @@ void Tokenizer::run() {
                     // This is an eof-in-comment parse error.
                     emit(std::move(current_token_));
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -589,7 +589,7 @@ void Tokenizer::run() {
                     // This is an eof-in-comment parse error.
                     emit(std::move(current_token_));
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -609,7 +609,7 @@ void Tokenizer::run() {
                     // This is an eof-in-comment parse error.
                     emit(std::move(current_token_));
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -636,7 +636,7 @@ void Tokenizer::run() {
                     // This is an eof-in-comment parse error.
                     emit(std::move(current_token_));
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -662,7 +662,7 @@ void Tokenizer::run() {
                     // This is an eof-in-doctype parse error.
                     emit(DoctypeToken{.force_quirks = true});
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 switch (*c) {
@@ -726,7 +726,7 @@ void Tokenizer::run() {
                     std::get<DoctypeToken>(current_token_).force_quirks = true;
                     emit(std::move(current_token_));
                     emit(EndOfFileToken{});
-                    continue;
+                    return;
                 }
 
                 if (is_ascii_upper_alpha(*c)) {

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -44,31 +44,32 @@ int main() {
                         StartTagToken{.tag_name = "html"s},
                         CharacterToken{'\n'},
                         EndTagToken{.tag_name = "html"s},
-                        CharacterToken{'\n'}});
+                        CharacterToken{'\n'},
+                        EndOfFileToken{}});
     });
 
     etest::test("comment, simple", [] {
         auto tokens = run_tokenizer("<!-- Hello -->");
 
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = " Hello "}});
+        expect_eq(tokens, std::vector<Token>{CommentToken{.data = " Hello "}, EndOfFileToken{}});
     });
 
     etest::test("comment, empty", [] {
         auto tokens = run_tokenizer("<!---->");
 
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = ""}});
+        expect_eq(tokens, std::vector<Token>{CommentToken{.data = ""}, EndOfFileToken{}});
     });
 
     etest::test("comment, with dashes and bang", [] {
         auto tokens = run_tokenizer("<!--!-->");
 
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "!"}});
+        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "!"}, EndOfFileToken{}});
     });
 
     etest::test("comment, with new lines", [] {
         auto tokens = run_tokenizer("<!--\nOne\nTwo\n-->");
 
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "\nOne\nTwo\n"}});
+        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "\nOne\nTwo\n"}, EndOfFileToken{}});
     });
 
     etest::test("comment, multiple with new lines", [] {
@@ -79,19 +80,21 @@ int main() {
                         CharacterToken{'\n'},
                         CommentToken{.data = "b"},
                         CharacterToken{'\n'},
-                        CommentToken{.data = "c"}});
+                        CommentToken{.data = "c"},
+                        EndOfFileToken{}});
     });
 
     etest::test("comment, allowed to end with <!", [] {
         auto tokens = run_tokenizer("<!--My favorite operators are > and <!-->");
 
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "My favorite operators are > and <!"}});
+        expect_eq(tokens,
+                std::vector<Token>{CommentToken{.data = "My favorite operators are > and <!"}, EndOfFileToken{}});
     });
 
     etest::test("comment, nested comment", [] {
         auto tokens = run_tokenizer("<!--<!---->");
 
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "<!--"}});
+        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "<!--"}, EndOfFileToken{}});
     });
 
     etest::test("comment, nested comment closed", [] {
@@ -102,40 +105,39 @@ int main() {
                         CharacterToken{' '},
                         CharacterToken{'-'},
                         CharacterToken{'-'},
-                        CharacterToken{'>'}});
+                        CharacterToken{'>'},
+                        EndOfFileToken{}});
     });
 
     etest::test("comment, abrupt closing in comment start", [] {
         auto tokens = run_tokenizer("<!-->");
 
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = ""}});
+        expect_eq(tokens, std::vector<Token>{CommentToken{.data = ""}, EndOfFileToken{}});
     });
 
     etest::test("comment, abrupt closing in comment start dash", [] {
         auto tokens = run_tokenizer("<!--->");
 
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = ""}});
+        expect_eq(tokens, std::vector<Token>{CommentToken{.data = ""}, EndOfFileToken{}});
     });
 
     etest::test("comment, incorrectly closed comment", [] {
         auto tokens = run_tokenizer("<!--abc--!>");
 
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "abc"}});
+        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "abc"}, EndOfFileToken{}});
     });
 
-    // TODO(mkiael): Enable when eof check is fixed
-    // etest::test("comment, end before comment", [] {
-    //    auto tokens = run_tokenizer("<!--");
-    //
-    //    expect_eq(tokens, std::vector<Token>{EndOfFileToken{}});
-    //});
+    etest::test("comment, end before comment", [] {
+        auto tokens = run_tokenizer("<!--");
 
-    // TODO(mkiael): Enable when eof check is fixed
-    // etest::test("comment, eof before comment is closed", [] {
-    //    auto tokens = run_tokenizer("<!--abc");
-    //
-    //    expect_eq(tokens, std::vector<Token>{CommentToken{.data = "abc"}, EndOfFileToken{}});
-    //});
+        expect_eq(tokens, std::vector<Token>{CommentToken{.data = ""}, EndOfFileToken{}});
+    });
+
+    etest::test("comment, eof before comment is closed", [] {
+        auto tokens = run_tokenizer("<!--abc");
+
+        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "abc"}, EndOfFileToken{}});
+    });
 
     return etest::run_all_tests();
 }


### PR DESCRIPTION
Not sure if `while (true)` is a good idea. My gut feeling tells me that a complete tokenizer never should end up in an eternal loop. Opening PR for discussion.