### PR TITLE
Fix out-of-bounds read in the new HTML tokenizer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,11 +104,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: bazel build ///... --config msvc
+      run: bazel build ///... --config msvc --config debug
     - name: Test
-      run: bazel test ///... --config msvc
+      run: bazel test ///... --config msvc --config debug
     - name: Run
-      run: bazel run browser:tui --config msvc
+      run: bazel run browser:tui --config msvc --config debug
 
   clang-format:
     runs-on: ubuntu-20.04

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -73,7 +73,12 @@ std::string to_string(Token const &token) {
 
 void Tokenizer::run() {
     while (true) {
-        spdlog::trace("Running state {} w/ next char {}", state_, input_[pos_]);
+        if (input_.size() > pos_) {
+            spdlog::trace("Running state {} w/ next char {}", state_, input_[pos_]);
+        } else {
+            spdlog::trace("Running state {} after input end", state_);
+        }
+
         switch (state_) {
             case State::Data: {
                 auto c = consume_next_input_character();


### PR DESCRIPTION
Also set up the MSVC CI configuration so that it detects this kind of issue.

Example of it detecting the issue fixed in this PR here: https://github.com/robinlinden/hastur/actions/runs/1641134299