### PR TITLE
Add support for tokenizing non-ascii html entities

### DIFF
--- a/html2/BUILD
+++ b/html2/BUILD
@@ -11,6 +11,7 @@ cc_library(
     deps = [
         "//dom2",
         "//util:string",
+        "//util:unicode",
         "@spdlog",
     ],
 )

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -6,6 +6,7 @@
 
 #include "html2/character_reference.h"
 #include "util/string.h"
+#include "util/unicode.h"
 
 #include <spdlog/spdlog.h>
 
@@ -825,15 +826,11 @@ void Tokenizer::run() {
                 }
 
                 temporary_buffer_.clear();
-                if (maybe_reference->first_codepoint > static_cast<std::uint32_t>(std::numeric_limits<char>::max())) {
-                    std::terminate();
-                }
-
+                temporary_buffer_.append(util::unicode_to_utf8(maybe_reference->first_codepoint));
                 if (maybe_reference->second_codepoint) {
-                    std::terminate();
+                    temporary_buffer_.append(util::unicode_to_utf8(*maybe_reference->second_codepoint));
                 }
 
-                temporary_buffer_.append(1, static_cast<char>(maybe_reference->first_codepoint));
                 flush_code_points_consumed_as_a_character_reference();
                 state_ = return_state_;
                 continue;

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -154,5 +154,32 @@ int main() {
         expect_eq(tokens, std::vector<Token>{CharacterToken{'&'}, CharacterToken{'@'}, EndOfFileToken{}});
     });
 
+    etest::test("character entity reference, reference to non-ascii glyph", [] {
+        auto tokens = run_tokenizer("&div;");
+        expect_eq(tokens, std::vector<Token>{CharacterToken{'\xc3'}, CharacterToken{'\xb7'}, EndOfFileToken{}});
+        std::string glyph{};
+        glyph += std::get<CharacterToken>(tokens[0]).data;
+        glyph += std::get<CharacterToken>(tokens[1]).data;
+        expect_eq(glyph, "÷"sv);
+    });
+
+    etest::test("character entity reference, two unicode code points required", [] {
+        auto tokens = run_tokenizer("&acE;");
+        expect_eq(tokens,
+                std::vector<Token>{CharacterToken{'\xe2'},
+                        CharacterToken{'\x88'},
+                        CharacterToken{'\xbe'},
+                        CharacterToken{'\xcc'},
+                        CharacterToken{'\xb3'},
+                        EndOfFileToken{}});
+        std::string glyph{};
+        glyph += std::get<CharacterToken>(tokens[0]).data;
+        glyph += std::get<CharacterToken>(tokens[1]).data;
+        glyph += std::get<CharacterToken>(tokens[2]).data;
+        glyph += std::get<CharacterToken>(tokens[3]).data;
+        glyph += std::get<CharacterToken>(tokens[4]).data;
+        expect_eq(glyph, "∾̳"sv);
+    });
+
     return etest::run_all_tests();
 }

--- a/util/unicode.h
+++ b/util/unicode.h
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef UTIL_UNICODE_H_
+#define UTIL_UNICODE_H_
+
+#include <cstdint>
+#include <string>
+
+namespace util {
+
+constexpr bool unicode_is_ascii(std::uint32_t code_point) {
+    return code_point <= 0x7f;
+}
+
+constexpr int unicode_utf8_byte_count(std::uint32_t code_point) {
+    if (unicode_is_ascii(code_point)) {
+        return 1;
+    }
+
+    if (code_point <= 0x7ff) {
+        return 2;
+    }
+
+    if (code_point <= 0xffff) {
+        return 3;
+    }
+
+    if (code_point <= 0x10ffff) {
+        return 4;
+    }
+
+    return 0;
+}
+
+inline std::string unicode_to_utf8(std::uint32_t code_point) {
+    switch (unicode_utf8_byte_count(code_point)) {
+        case 1:
+            return {static_cast<char>(code_point & 0x7F)};
+        case 2:
+            return {
+                    static_cast<char>((code_point >> 6 & 0b0001'1111) | 0b1100'0000),
+                    static_cast<char>((code_point & 0b0011'1111) | 0b1000'0000),
+            };
+        case 3:
+            return {
+                    static_cast<char>((code_point >> 12 & 0b0000'1111) | 0b1110'0000),
+                    static_cast<char>((code_point >> 6 & 0b0011'1111) | 0b1000'0000),
+                    static_cast<char>((code_point & 0b0011'1111) | 0b1000'0000),
+            };
+        case 4:
+            return {
+                    static_cast<char>((code_point >> 18 & 0b0000'0111) | 0b1111'0000),
+                    static_cast<char>((code_point >> 12 & 0b0011'1111) | 0b1000'0000),
+                    static_cast<char>((code_point >> 6 & 0b0011'1111) | 0b1000'0000),
+                    static_cast<char>((code_point & 0b0011'1111) | 0b1000'0000),
+            };
+        default:
+            return std::string{};
+    }
+}
+
+} // namespace util
+
+#endif

--- a/util/unicode_test.cpp
+++ b/util/unicode_test.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "util/unicode.h"
+
+#include "etest/etest.h"
+
+#include <string_view>
+
+using namespace std::literals;
+
+using etest::expect_eq;
+using util::unicode_to_utf8;
+using util::unicode_utf8_byte_count;
+
+int main() {
+    etest::test("unicode_utf8_byte_count", [] {
+        expect_eq(unicode_utf8_byte_count(0), 1);
+        expect_eq(unicode_utf8_byte_count(0x7f), 1);
+
+        expect_eq(unicode_utf8_byte_count(0x80), 2);
+        expect_eq(unicode_utf8_byte_count(0x7ff), 2);
+
+        expect_eq(unicode_utf8_byte_count(0x800), 3);
+        expect_eq(unicode_utf8_byte_count(0xffff), 3);
+
+        expect_eq(unicode_utf8_byte_count(0x100000), 4);
+        expect_eq(unicode_utf8_byte_count(0x10ffff), 4);
+
+        // Invalid code points return 0.
+        expect_eq(unicode_utf8_byte_count(0x110000), 0);
+    });
+
+    etest::test("unicode_to_utf8", [] {
+        expect_eq(unicode_to_utf8(0x002f), "/"sv);
+
+        expect_eq(unicode_to_utf8(0x00a3), "£"sv);
+        expect_eq(unicode_to_utf8(0x07f9), "߹"sv);
+
+        expect_eq(unicode_to_utf8(0x0939), "ह"sv);
+        expect_eq(unicode_to_utf8(0x20ac), "€"sv);
+        expect_eq(unicode_to_utf8(0xd55c), "한"sv);
+        expect_eq(unicode_to_utf8(0xfffd), "�"sv);
+
+        expect_eq(unicode_to_utf8(0x10348), "𐍈"sv);
+
+        // Invalid code points return "".
+        expect_eq(unicode_to_utf8(0x110000), ""sv);
+    });
+
+    return etest::run_all_tests();
+}


### PR DESCRIPTION
Maybe writing a unicode code point -> utf8 decoder is a bit silly, but it was fun and it has a tiny API, so we can easily replace it with a library in the future if we feel like it.