### PR TITLE
Set tokenizer state

### DIFF
--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -846,8 +846,8 @@ void Tokenizer::run() {
     }
 }
 
-void Tokenizer::emit(Token &&token) const {
-    on_emit_(std::move(token));
+void Tokenizer::emit(Token &&token) {
+    on_emit_(std::move(token), *this);
 }
 
 std::optional<char> Tokenizer::consume_next_input_character() {

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -83,6 +83,10 @@ std::string to_string(Token const &token) {
     return ss.str();
 }
 
+void Tokenizer::set_state(State state) {
+    state_ = state;
+}
+
 void Tokenizer::run() {
     while (true) {
         if (input_.size() > pos_) {

--- a/html2/tokenizer.h
+++ b/html2/tokenizer.h
@@ -147,7 +147,7 @@ std::string to_string(Token const &);
 
 class Tokenizer {
 public:
-    Tokenizer(std::string_view input, std::function<void(Token &&)> on_emit)
+    Tokenizer(std::string_view input, std::function<void(Token &&, Tokenizer &)> on_emit)
         : input_{input}, on_emit_{std::move(on_emit)} {}
 
     void set_state(State);
@@ -162,9 +162,9 @@ private:
 
     std::string temporary_buffer_{};
 
-    std::function<void(Token &&)> on_emit_{};
+    std::function<void(Token &&, Tokenizer &)> on_emit_{};
 
-    void emit(Token &&) const;
+    void emit(Token &&);
     std::optional<char> consume_next_input_character();
     std::optional<char> peek_next_input_character() const;
     bool is_eof() const;

--- a/html2/tokenizer.h
+++ b/html2/tokenizer.h
@@ -149,6 +149,8 @@ class Tokenizer {
 public:
     Tokenizer(std::string_view input, std::function<void(Token &&)> on_emit)
         : input_{input}, on_emit_{std::move(on_emit)} {}
+
+    void set_state(State);
     void run();
 
 private:

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -23,7 +23,7 @@ using namespace html2;
 namespace {
 std::vector<Token> run_tokenizer(std::string_view input) {
     std::vector<Token> tokens;
-    Tokenizer tokenizer{input, [&](Token &&t) {
+    Tokenizer tokenizer{input, [&](Token &&t, Tokenizer &) {
                             tokens.push_back(std::move(t));
                         }};
     tokenizer.run();

--- a/html2/tree_builder.cpp
+++ b/html2/tree_builder.cpp
@@ -14,11 +14,11 @@
 namespace html2 {
 
 void TreeBuilder::run(std::string_view input) {
-    Tokenizer tokenizer{input, std::bind(&TreeBuilder::on_token, this, std::placeholders::_1)};
+    Tokenizer tokenizer{input, std::bind(&TreeBuilder::on_token, this, std::placeholders::_1, std::placeholders::_2)};
     tokenizer.run();
 }
 
-void TreeBuilder::on_token(Token &&token) {
+void TreeBuilder::on_token(Token &&token, Tokenizer &) {
     spdlog::error("{}: {}", mode_, to_string(token));
     switch (mode_) {
         // https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode

--- a/html2/tree_builder.h
+++ b/html2/tree_builder.h
@@ -56,7 +56,7 @@ private:
     std::unique_ptr<dom2::Document> document_{std::make_unique<dom2::Document>()};
     std::stack<std::shared_ptr<dom2::Node>> open_elements_{};
 
-    void on_token(Token &&);
+    void on_token(Token &&, Tokenizer &);
 
     std::shared_ptr<dom2::Element> create_element_for_token(
             Token const &, std::string_view given_namespace, dom2::Node const &intended_parent) const;


### PR DESCRIPTION
This PR adds possibility to set the state of the tokenizer. The tree builder will need to be able to set this during processing of tokens. Will be covered by tests when ongoing work on script tag is done.