### PR TITLE
build: Enable Bazel's layering check

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -57,6 +57,9 @@ build:clang --per_file_copt='external/boringssl[:/]@-Wno-extra-semi'
 build:clang --per_file_copt='external/boringssl[:/]@-Wno-gnu-binary-literal'
 
 build:clang13 --config=clang
+# Newer Bazel + Clang supports this really cool features where it checks that
+# you're not relying on transitive dependencies, so let's enable that!
+build:clang13 --features layering_check
 build:clang13 --per_file_copt='external/libpng[:/]@-Wno-null-pointer-subtraction'
 build:clang13 --per_file_copt='external/libpng[:/]@-Wno-unused-but-set-variable'
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,8 +20,10 @@ http_archive(
     url = "https://downloads.sourceforge.net/project/asio/asio/1.20.0%20(Stable)/asio-1.20.0.tar.bz2",
 )
 
+# boringssl//:ssl cheats and pulls in private includes from boringssl//:crypto.
 http_archive(
     name = "boringssl",  # OpenSSL + ISC
+    patch_cmds = ["sed -i '32i package(features=[\"-layering_check\"])' BUILD"],
     sha256 = "e168777eb0fc14ea5a65749a2f53c095935a6ea65f38899a289808fb0c221dc4",
     strip_prefix = "boringssl-4fb158925f7753d80fb858cb0239dff893ef9f15",
     url = "https://github.com/google/boringssl/archive/4fb158925f7753d80fb858cb0239dff893ef9f15.tar.gz",

--- a/browser/BUILD
+++ b/browser/BUILD
@@ -24,6 +24,8 @@ cc_test(
     deps = [
         ":engine",
         "//etest",
+        "//protocol",
+        "//uri",
     ],
 )
 
@@ -58,9 +60,11 @@ cc_binary(
         "//layout",
         "//render",
         "//uri",
+        "@fmt",
         "@imgui",
         "@imgui-sfml",
         "@sfml//:graphics",
+        "@sfml//:window",
         "@spdlog",
     ],
 )

--- a/gfx/BUILD
+++ b/gfx/BUILD
@@ -26,6 +26,6 @@ cc_binary(
     srcs = ["gfx_example.cpp"],
     deps = [
         ":gfx",
-        "@sfml//:graphics",
+        "@sfml//:window",
     ],
 )

--- a/gfx/gfx_example.cpp
+++ b/gfx/gfx_example.cpp
@@ -5,7 +5,8 @@
 #include "gfx/color.h"
 #include "gfx/opengl_painter.h"
 
-#include <SFML/Window.hpp>
+#include <SFML/Window/Event.hpp>
+#include <SFML/Window/Window.hpp>
 
 int main() {
     sf::Window window{sf::VideoMode{800, 600}, "gfx"};

--- a/render/BUILD
+++ b/render/BUILD
@@ -6,8 +6,10 @@ cc_library(
     hdrs = ["render.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "//dom",
         "//gfx",
         "//layout",
+        "//style",
         "@spdlog",
     ],
 )

--- a/style/BUILD
+++ b/style/BUILD
@@ -23,6 +23,7 @@ cc_test(
     srcs = ["style_test.cpp"],
     deps = [
         ":style",
+        "//css",
         "//etest",
     ],
 )

--- a/third_party/sfml.BUILD
+++ b/third_party/sfml.BUILD
@@ -105,6 +105,7 @@ cc_library(
     strip_include_prefix = "include/",
     visibility = ["//visibility:public"],
     deps = [
+        ":system",
         ":window",
         "@freetype2",
         "@stb//:image",


### PR DESCRIPTION
This checks that our targets aren't relying on transitive dependencies.