### PR TITLE
Fix parsing of uppercase attribute name

### DIFF
--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -765,7 +765,6 @@ void Tokenizer::run() {
                     continue;
                 }
 
-                // TODO(mkiael): Should append lower case!
                 auto append_to_current_attribute_name = [&](auto text) {
                     if (std::holds_alternative<StartTagToken>(current_token_)) {
                         std::get<StartTagToken>(current_token_).attributes.back().name += text;
@@ -775,7 +774,8 @@ void Tokenizer::run() {
                 };
 
                 if (is_ascii_upper_alpha(*c)) {
-                    append_to_current_attribute_name(*c);
+                    append_to_current_attribute_name(to_lower(*c));
+                    continue;
                 }
 
                 switch (*c) {

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -458,5 +458,34 @@ int main() {
         expect_eq(glyph, "∾̳"sv);
     });
 
+    etest::test("attribute, one attribute single quoted", [] {
+        auto tokens = run_tokenizer("<tag a='b'>");
+
+        expect_token(tokens, StartTagToken{.tag_name = "tag", .attributes = {{"a", "b"}}});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
+    etest::test("attribute, one attribute double quoted", [] {
+        auto tokens = run_tokenizer("<tag a=\"b\">");
+
+        expect_token(tokens, StartTagToken{.tag_name = "tag", .attributes = {{"a", "b"}}});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
+    etest::test("attribute, one uppercase attribute", [] {
+        auto tokens = run_tokenizer("<tag ATTRIB=\"ABC123\">");
+
+        expect_token(tokens, StartTagToken{.tag_name = "tag", .attributes = {{"attrib", "ABC123"}}});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
+    etest::test("attribute, multiple attributes", [] {
+        auto tokens = run_tokenizer("<tag  foo=\"bar\" A='B'  value='321'>");
+
+        expect_token(
+                tokens, StartTagToken{.tag_name = "tag", .attributes = {{"foo", "bar"}, {"a", "B"}, {"value", "321"}}});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
     return etest::run_all_tests();
 }


### PR DESCRIPTION
This PR fixes so that the lowercase version of the input character is appended to the attribute name. Also adds `continue` to break the loop after the character has been appended.