### PR TITLE
html2 cleanup + tree constructor test example

### DIFF
--- a/html/parser.cpp
+++ b/html/parser.cpp
@@ -36,7 +36,7 @@ constexpr auto kImmediatelyPopped = std::to_array({"br"sv, "hr"sv, "img"sv, "lin
 
 } // namespace
 
-void Parser::on_token(html2::Token &&token) {
+void Parser::on_token(html2::Tokenizer &, html2::Token &&token) {
     if (auto doctype = std::get_if<html2::DoctypeToken>(&token)) {
         if (doctype->name.has_value()) {
             doc_.doctype = *(doctype->name);

--- a/html/parser.h
+++ b/html/parser.h
@@ -21,14 +21,14 @@ public:
     }
 
 private:
-    Parser(std::string_view input) : tokenizer_{input, std::bind(&Parser::on_token, this, std::placeholders::_1)} {}
+    Parser(std::string_view input) : tokenizer_{input, std::bind_front(&Parser::on_token, this)} {}
 
     [[nodiscard]] dom::Document run() {
         tokenizer_.run();
         return std::move(doc_);
     }
 
-    void on_token(html2::Token &&token);
+    void on_token(html2::Tokenizer &, html2::Token &&token);
 
     void generate_text_node_if_needed();
 

--- a/html2/BUILD
+++ b/html2/BUILD
@@ -20,6 +20,10 @@ data_files = {
     "tokenizer": ["test/simple_page.html"],
 }
 
+dependencies = {
+    "tree_constructor": ["//dom2"],
+}
+
 [cc_test(
     name = src[:-4],
     size = "small",
@@ -28,7 +32,10 @@ data_files = {
         src[:-9],
         [],
     ),
-    deps = [
+    deps = dependencies.get(
+        src[:-9],
+        [],
+    ) + [
         ":html2",
         "//etest",
     ],

--- a/html2/token.cpp
+++ b/html2/token.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "html2/token.h"
+
+#include <optional>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <variant>
+
+namespace html2 {
+namespace {
+
+template<class... Ts>
+struct Overloaded : Ts... {
+    using Ts::operator()...;
+};
+
+// Not needed as of C++20, but gcc 10 won't work without it.
+template<class... Ts>
+Overloaded(Ts...) -> Overloaded<Ts...>;
+
+} // namespace
+
+std::string to_string(Token const &token) {
+    auto try_print = []<typename T>(std::ostream &os, std::optional<T> maybe_value) {
+        if (maybe_value) {
+            os << ' ' << *maybe_value;
+        } else {
+            os << " \"\"";
+        }
+    };
+
+    std::stringstream ss;
+    std::visit(Overloaded{
+                       [&](DoctypeToken const &t) {
+                           ss << "Doctype";
+                           try_print(ss, t.name);
+                           try_print(ss, t.public_identifier);
+                           try_print(ss, t.system_identifier);
+                       },
+                       [&ss](StartTagToken const &t) { ss << "StartTag " << t.tag_name << ' ' << t.self_closing; },
+                       [&ss](EndTagToken const &t) { ss << "EndTag " << t.tag_name << ' ' << t.self_closing; },
+                       [&ss](CommentToken const &t) { ss << "Comment " << t.data; },
+                       [&ss](CharacterToken const &t) { ss << "Character " << t.data; },
+                       [&ss](EndOfFileToken const &) { ss << "EndOfFile"; },
+               },
+            token);
+    return ss.str();
+}
+
+} // namespace html2

--- a/html2/token.h
+++ b/html2/token.h
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef HTML2_TOKEN_H_
+#define HTML2_TOKEN_H_
+
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace html2 {
+
+struct DoctypeToken {
+    std::optional<std::string> name{std::nullopt};
+    std::optional<std::string> public_identifier{std::nullopt};
+    std::optional<std::string> system_identifier{std::nullopt};
+    bool force_quirks{false};
+    [[nodiscard]] bool operator==(DoctypeToken const &) const = default;
+};
+
+struct Attribute {
+    std::string name{};
+    std::string value{};
+    [[nodiscard]] bool operator==(Attribute const &) const = default;
+};
+
+struct StartTagToken {
+    std::string tag_name{};
+    bool self_closing{false};
+    std::vector<Attribute> attributes{};
+    [[nodiscard]] bool operator==(StartTagToken const &) const = default;
+};
+
+struct EndTagToken {
+    std::string tag_name{};
+    bool self_closing{false};
+    std::vector<Attribute> attributes{};
+    [[nodiscard]] bool operator==(EndTagToken const &) const = default;
+};
+
+struct CommentToken {
+    std::string data{};
+    [[nodiscard]] bool operator==(CommentToken const &) const = default;
+};
+
+struct CharacterToken {
+    char data{};
+    [[nodiscard]] bool operator==(CharacterToken const &) const = default;
+};
+
+struct EndOfFileToken {
+    [[nodiscard]] bool operator==(EndOfFileToken const &) const = default;
+};
+
+using Token = std::variant<DoctypeToken, StartTagToken, EndTagToken, CommentToken, CharacterToken, EndOfFileToken>;
+
+std::string to_string(Token const &);
+
+} // namespace html2
+
+#endif

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -1334,7 +1334,7 @@ void Tokenizer::emit(Token &&token) {
     if (std::holds_alternative<StartTagToken>(token)) {
         last_start_tag_name_ = std::get<StartTagToken>(token).tag_name;
     }
-    on_emit_(std::move(token), *this);
+    on_emit_(*this, std::move(token));
 }
 
 std::optional<char> Tokenizer::consume_next_input_character() {

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -45,43 +45,7 @@ constexpr char to_lower(char c) {
     return c + 0x20;
 }
 
-template<class... Ts>
-struct Overloaded : Ts... {
-    using Ts::operator()...;
-};
-
-// Not needed as of C++20, but gcc 10 won't work without it.
-template<class... Ts>
-Overloaded(Ts...) -> Overloaded<Ts...>;
-
 } // namespace
-
-std::string to_string(Token const &token) {
-    auto try_print = []<typename T>(std::ostream &os, std::optional<T> maybe_value) {
-        if (maybe_value) {
-            os << ' ' << *maybe_value;
-        } else {
-            os << " \"\"";
-        }
-    };
-
-    std::stringstream ss;
-    std::visit(Overloaded{
-                       [&](DoctypeToken const &t) {
-                           ss << "Doctype";
-                           try_print(ss, t.name);
-                           try_print(ss, t.public_identifier);
-                           try_print(ss, t.system_identifier);
-                       },
-                       [&ss](StartTagToken const &t) { ss << "StartTag " << t.tag_name << ' ' << t.self_closing; },
-                       [&ss](EndTagToken const &t) { ss << "EndTag " << t.tag_name << ' ' << t.self_closing; },
-                       [&ss](CommentToken const &t) { ss << "Comment " << t.data; },
-                       [&ss](CharacterToken const &t) { ss << "Character " << t.data; },
-                       [&ss](EndOfFileToken const &) { ss << "EndOfFile"; },
-               },
-            token);
-    return ss.str();
-}
 
 void Tokenizer::set_state(State state) {
     state_ = state;

--- a/html2/tokenizer.h
+++ b/html2/tokenizer.h
@@ -101,7 +101,7 @@ enum class State {
 
 class Tokenizer {
 public:
-    Tokenizer(std::string_view input, std::function<void(Token &&, Tokenizer &)> on_emit)
+    Tokenizer(std::string_view input, std::function<void(Tokenizer &, Token &&)> on_emit)
         : input_{input}, on_emit_{std::move(on_emit)} {}
 
     void set_state(State);
@@ -117,7 +117,7 @@ private:
     std::string temporary_buffer_{};
     std::string last_start_tag_name_{};
 
-    std::function<void(Token &&, Tokenizer &)> on_emit_{};
+    std::function<void(Tokenizer &, Token &&)> on_emit_{};
 
     void emit(Token &&);
     std::optional<char> consume_next_input_character();

--- a/html2/tokenizer.h
+++ b/html2/tokenizer.h
@@ -5,13 +5,13 @@
 #ifndef HTML2_TOKENIZER_H_
 #define HTML2_TOKENIZER_H_
 
+#include "html2/token.h"
+
 #include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
-#include <variant>
-#include <vector>
 
 namespace html2 {
 
@@ -98,52 +98,6 @@ enum class State {
     DecimalCharacterReference,
     NumericCharacterReferenceEnd,
 };
-
-struct DoctypeToken {
-    std::optional<std::string> name{std::nullopt};
-    std::optional<std::string> public_identifier{std::nullopt};
-    std::optional<std::string> system_identifier{std::nullopt};
-    bool force_quirks{false};
-    [[nodiscard]] bool operator==(DoctypeToken const &) const = default;
-};
-
-struct Attribute {
-    std::string name{};
-    std::string value{};
-    [[nodiscard]] bool operator==(Attribute const &) const = default;
-};
-
-struct StartTagToken {
-    std::string tag_name{};
-    bool self_closing{false};
-    std::vector<Attribute> attributes{};
-    [[nodiscard]] bool operator==(StartTagToken const &) const = default;
-};
-
-struct EndTagToken {
-    std::string tag_name{};
-    bool self_closing{false};
-    std::vector<Attribute> attributes{};
-    [[nodiscard]] bool operator==(EndTagToken const &) const = default;
-};
-
-struct CommentToken {
-    std::string data{};
-    [[nodiscard]] bool operator==(CommentToken const &) const = default;
-};
-
-struct CharacterToken {
-    char data{};
-    [[nodiscard]] bool operator==(CharacterToken const &) const = default;
-};
-
-struct EndOfFileToken {
-    [[nodiscard]] bool operator==(EndOfFileToken const &) const = default;
-};
-
-using Token = std::variant<DoctypeToken, StartTagToken, EndTagToken, CommentToken, CharacterToken, EndOfFileToken>;
-
-std::string to_string(Token const &);
 
 class Tokenizer {
 public:

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -24,7 +24,7 @@ namespace {
 std::vector<Token> run_tokenizer(std::string_view input) {
     std::vector<Token> tokens;
     Tokenizer{input,
-            [&](Token &&t, Tokenizer &tokenizer) {
+            [&](Tokenizer &tokenizer, Token &&t) {
                 if (std::holds_alternative<StartTagToken>(t)) {
                     if (std::get<StartTagToken>(t).tag_name == "script") {
                         tokenizer.set_state(State::ScriptData);

--- a/html2/tree_constructor.cpp
+++ b/html2/tree_constructor.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
-#include "html2/tree_builder.h"
+#include "html2/tree_constructor.h"
 
 #include "dom2/document_type.h"
 
@@ -13,12 +13,13 @@
 
 namespace html2 {
 
-void TreeBuilder::run(std::string_view input) {
-    Tokenizer tokenizer{input, std::bind(&TreeBuilder::on_token, this, std::placeholders::_1, std::placeholders::_2)};
+void TreeConstructor::run(std::string_view input) {
+    Tokenizer tokenizer{
+            input, std::bind(&TreeConstructor::on_token, this, std::placeholders::_1, std::placeholders::_2)};
     tokenizer.run();
 }
 
-void TreeBuilder::on_token(Token &&token, Tokenizer &) {
+void TreeConstructor::on_token(Token &&token, Tokenizer &) {
     spdlog::error("{}: {}", mode_, to_string(token));
     switch (mode_) {
         // https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode
@@ -141,7 +142,7 @@ void TreeBuilder::on_token(Token &&token, Tokenizer &) {
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#create-an-element-for-the-token
-std::shared_ptr<dom2::Element> TreeBuilder::create_element_for_token(
+std::shared_ptr<dom2::Element> TreeConstructor::create_element_for_token(
         Token const &token, std::string_view given_namespace, dom2::Node const &intended_parent) const {
     (void)intended_parent;
     // TODO(robinlinden): Everything.
@@ -160,7 +161,7 @@ std::shared_ptr<dom2::Element> TreeBuilder::create_element_for_token(
 }
 
 // https://dom.spec.whatwg.org/#concept-create-element
-std::shared_ptr<dom2::Element> TreeBuilder::create_element([[maybe_unused]] dom2::Document const &document,
+std::shared_ptr<dom2::Element> TreeConstructor::create_element([[maybe_unused]] dom2::Document const &document,
         std::string local_name,
         [[maybe_unused]] std::string_view ns,
         [[maybe_unused]] std::optional<std::string_view> prefix,
@@ -178,7 +179,7 @@ std::shared_ptr<dom2::Element> TreeBuilder::create_element([[maybe_unused]] dom2
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#insert-a-foreign-element
-std::shared_ptr<dom2::Element> TreeBuilder::insert_foreign_element(Token const &token, std::string_view ns) {
+std::shared_ptr<dom2::Element> TreeConstructor::insert_foreign_element(Token const &token, std::string_view ns) {
     // 1. Let the adjusted insertion location be the appropriate place for inserting a node.
     auto &adjusted_insertion_location = appropriate_place_for_inserting_a_node();
 
@@ -217,7 +218,7 @@ std::shared_ptr<dom2::Element> TreeBuilder::insert_foreign_element(Token const &
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#appropriate-place-for-inserting-a-node
-dom2::Node &TreeBuilder::appropriate_place_for_inserting_a_node(
+dom2::Node &TreeConstructor::appropriate_place_for_inserting_a_node(
         std::optional<std::reference_wrapper<dom2::Node>> override_target) {
     // 1. If there was an override target specified, then let target be the override target.
     // Otherwise, let target be the current node.

--- a/html2/tree_constructor.cpp
+++ b/html2/tree_constructor.cpp
@@ -10,12 +10,22 @@
 
 #include <exception>
 #include <functional>
+#include <string_view>
+
+using namespace std::literals;
 
 namespace html2 {
 
 void TreeConstructor::run(std::string_view input) {
     Tokenizer tokenizer{input, std::bind_front(&TreeConstructor::on_token, this)};
     tokenizer.run();
+}
+
+void TreeConstructor::run(std::vector<Token> tokens) {
+    auto dummy = Tokenizer(""sv, [](auto &, auto &&) {});
+    for (auto &token : tokens) {
+        on_token(dummy, std::move(token));
+    }
 }
 
 void TreeConstructor::on_token(Tokenizer &, Token &&token) {

--- a/html2/tree_constructor.cpp
+++ b/html2/tree_constructor.cpp
@@ -14,12 +14,11 @@
 namespace html2 {
 
 void TreeConstructor::run(std::string_view input) {
-    Tokenizer tokenizer{
-            input, std::bind(&TreeConstructor::on_token, this, std::placeholders::_1, std::placeholders::_2)};
+    Tokenizer tokenizer{input, std::bind_front(&TreeConstructor::on_token, this)};
     tokenizer.run();
 }
 
-void TreeConstructor::on_token(Token &&token, Tokenizer &) {
+void TreeConstructor::on_token(Tokenizer &, Token &&token) {
     spdlog::error("{}: {}", mode_, to_string(token));
     switch (mode_) {
         // https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode

--- a/html2/tree_constructor.h
+++ b/html2/tree_constructor.h
@@ -56,7 +56,7 @@ private:
     std::unique_ptr<dom2::Document> document_{std::make_unique<dom2::Document>()};
     std::stack<std::shared_ptr<dom2::Node>> open_elements_{};
 
-    void on_token(Token &&, Tokenizer &);
+    void on_token(Tokenizer &, Token &&);
 
     std::shared_ptr<dom2::Element> create_element_for_token(
             Token const &, std::string_view given_namespace, dom2::Node const &intended_parent) const;

--- a/html2/tree_constructor.h
+++ b/html2/tree_constructor.h
@@ -8,6 +8,7 @@
 #include "dom2/document.h"
 #include "dom2/element.h"
 #include "dom2/node.h"
+#include "html2/token.h"
 #include "html2/tokenizer.h"
 
 #include <functional>
@@ -15,6 +16,7 @@
 #include <optional>
 #include <stack>
 #include <string_view>
+#include <vector>
 
 namespace html2 {
 namespace ns {
@@ -50,6 +52,11 @@ enum class InsertionMode {
 class TreeConstructor {
 public:
     void run(std::string_view input);
+    void run(std::vector<html2::Token>);
+
+    std::unique_ptr<dom2::Document> take_document() {
+        return std::exchange(document_, std::make_unique<dom2::Document>());
+    }
 
 private:
     InsertionMode mode_{InsertionMode::Initial};

--- a/html2/tree_constructor.h
+++ b/html2/tree_constructor.h
@@ -47,7 +47,7 @@ enum class InsertionMode {
     AfterAfterFrameset,
 };
 
-class TreeBuilder {
+class TreeConstructor {
 public:
     void run(std::string_view input);
 

--- a/html2/tree_constructor_test.cpp
+++ b/html2/tree_constructor_test.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "html2/tree_constructor.h"
+
+#include "dom2/document_type.h"
+#include "etest/etest.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace std::literals;
+
+using etest::expect_eq;
+using etest::require;
+
+using namespace html2;
+
+namespace {
+
+std::unique_ptr<dom2::Document> construct_from(std::vector<html2::Token> tokens) {
+    auto constructor = TreeConstructor{};
+    constructor.run(std::move(tokens));
+    return constructor.take_document();
+}
+
+} // namespace
+
+int main() {
+    etest::test("document with only doctype", [] {
+        auto document = construct_from({DoctypeToken{"html"s}});
+
+        expect_eq(document->type(), dom2::NodeType::Document);
+        expect_eq(document->child_nodes().size(), size_t{1});
+
+        expect_eq(document->first_child()->type(), dom2::NodeType::DocumentType);
+        auto const *doctype = static_cast<dom2::DocumentType const *>(document->first_child());
+        expect_eq(doctype->name(), "html"s);
+    });
+
+    return etest::run_all_tests();
+}


### PR DESCRIPTION
A lot of red commits, but it's because I moved things there's no test coverage on, like the tree constructor and `to_string(Token const &)`.