### PR TITLE
geom: Add support for getting the intersection of two rectangles

### DIFF
--- a/geom/geom.h
+++ b/geom/geom.h
@@ -22,10 +22,15 @@ struct Rect {
     int x{}, y{}, width{}, height{};
     [[nodiscard]] bool operator==(Rect const &) const = default;
 
+    [[nodiscard]] constexpr int left() const { return x; }
+    [[nodiscard]] constexpr int right() const { return x + width; }
+    [[nodiscard]] constexpr int top() const { return y; }
+    [[nodiscard]] constexpr int bottom() const { return y + height; }
+
     [[nodiscard]] constexpr Rect expanded(EdgeSize const &edges) const {
         return Rect{
-                x - edges.left,
-                y - edges.top,
+                left() - edges.left,
+                top() - edges.top,
                 edges.left + width + edges.right,
                 edges.top + height + edges.bottom,
         };
@@ -43,25 +48,25 @@ struct Rect {
     [[nodiscard]] constexpr Rect translated(int dx, int dy) const { return {x + dx, y + dy, width, height}; }
 
     [[nodiscard]] constexpr Rect intersected(Rect const &other) const {
-        auto left = std::max(x, other.x);
-        auto right = std::min(x + width, other.x + other.width);
-        auto top = std::max(y, other.y);
-        auto bottom = std::min(y + height, other.y + other.height);
-        if (left > right || top > bottom) {
+        auto new_left = std::max(left(), other.left());
+        auto new_right = std::min(right(), other.right());
+        auto new_top = std::max(top(), other.top());
+        auto new_bottom = std::min(bottom(), other.bottom());
+        if (new_left > new_right || new_top > new_bottom) {
             return {};
         }
 
         return Rect{
-                left,
-                top,
-                right - left,
-                bottom - top,
+                new_left,
+                new_top,
+                new_right - new_left,
+                new_bottom - new_top,
         };
     }
 
     [[nodiscard]] constexpr bool contains(Position const &p) const {
-        bool inside_horizontally = p.x >= x && p.x <= x + width;
-        bool inside_vertically = p.y >= y && p.y <= y + height;
+        bool inside_horizontally = p.x >= left() && p.x <= right();
+        bool inside_vertically = p.y >= top() && p.y <= bottom();
         return inside_vertically && inside_horizontally;
     }
 };

--- a/geom/geom.h
+++ b/geom/geom.h
@@ -1,9 +1,11 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #ifndef GEOM_GEOM_H_
 #define GEOM_GEOM_H_
+
+#include <algorithm>
 
 namespace geom {
 
@@ -39,6 +41,23 @@ struct Rect {
     }
 
     [[nodiscard]] constexpr Rect translated(int dx, int dy) const { return {x + dx, y + dy, width, height}; }
+
+    [[nodiscard]] constexpr Rect intersected(Rect const &other) const {
+        auto left = std::max(x, other.x);
+        auto right = std::min(x + width, other.x + other.width);
+        auto top = std::max(y, other.y);
+        auto bottom = std::min(y + height, other.y + other.height);
+        if (left > right || top > bottom) {
+            return {};
+        }
+
+        return Rect{
+                left,
+                top,
+                right - left,
+                bottom - top,
+        };
+    }
 
     [[nodiscard]] constexpr bool contains(Position const &p) const {
         bool inside_horizontally = p.x >= x && p.x <= x + width;

--- a/geom/geom_test.cpp
+++ b/geom/geom_test.cpp
@@ -7,6 +7,7 @@
 #include "etest/etest.h"
 
 using etest::expect;
+using etest::expect_eq;
 using geom::EdgeSize;
 using geom::Rect;
 
@@ -54,6 +55,24 @@ int main() {
         expect(Rect{10, 0, 10, 10} == r.translated(10, 0));
         expect(Rect{0, 10, 10, 10} == r.translated(0, 10));
         expect(Rect{-10, -10, 10, 10} == r.translated(-10, -10));
+    });
+
+    etest::test("Rect::intersected", [] {
+        Rect r{0, 0, 10, 10};
+
+        // Intersect with self should be a no-op.
+        expect_eq(r, r.intersected(r));
+
+        expect_eq(Rect{3, 4, 5, 5}, r.intersected({3, 4, 5, 5}));
+        expect_eq(Rect{0, 0, 1, 2}, r.intersected({0, 0, 1, 2}));
+        expect_eq(Rect{8, 5, 2, 5}, r.intersected({8, 5, 10, 10}));
+        expect_eq(Rect{0, 0, 2, 2}, r.intersected({-2, -2, 4, 4}));
+
+        expect_eq(Rect{-10, -10, 5, 5}, Rect{-20, -20, 15, 15}.intersected({-10, -10, 100, 100}));
+
+        // Intersect with a non-overlapping rect should yield an empty rect.
+        expect_eq(Rect{}, r.intersected({-1, -1, 1, 1}));
+        expect_eq(Rect{}, r.intersected({11, 11, 1, 1}));
     });
 
     etest::test("Rect::contains", [] {


### PR DESCRIPTION
I've been using this when messing around with Vulkan and OpenGL to clip things to the visible area.