### PR TITLE
Add an SFML gfx backend

### DIFF
--- a/browser/BUILD
+++ b/browser/BUILD
@@ -57,6 +57,7 @@ cc_binary(
         ":engine",
         "//dom",
         "//gfx",
+        "//gfx:opengl",
         "//layout",
         "//render",
         "//uri",

--- a/gfx/BUILD
+++ b/gfx/BUILD
@@ -21,6 +21,17 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "sfml",
+    srcs = ["sfml_painter.cpp"],
+    hdrs = ["sfml_painter.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gfx",
+        "@sfml//:graphics",
+    ],
+)
+
 [cc_test(
     name = src[:-4],
     size = "small",

--- a/gfx/BUILD
+++ b/gfx/BUILD
@@ -48,6 +48,8 @@ cc_binary(
     deps = [
         ":gfx",
         ":opengl",
+        ":sfml",
+        "@sfml//:graphics",
         "@sfml//:window",
     ],
 )

--- a/gfx/BUILD
+++ b/gfx/BUILD
@@ -2,11 +2,21 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 cc_library(
     name = "gfx",
+    hdrs = glob(
+        include = ["*.h"],
+        exclude = ["*_painter.h"],
+    ),
+    visibility = ["//visibility:public"],
+    deps = ["//geom"],
+)
+
+cc_library(
+    name = "opengl",
     srcs = ["opengl_painter.cpp"],
-    hdrs = glob(["*.h"]),
+    hdrs = ["opengl_painter.h"],
     visibility = ["//visibility:public"],
     deps = [
-        "//geom",
+        ":gfx",
         "@glew",
     ],
 )
@@ -26,6 +36,7 @@ cc_binary(
     srcs = ["gfx_example.cpp"],
     deps = [
         ":gfx",
+        ":opengl",
         "@sfml//:window",
     ],
 )

--- a/gfx/gfx_example.cpp
+++ b/gfx/gfx_example.cpp
@@ -1,20 +1,32 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "gfx/color.h"
 #include "gfx/opengl_painter.h"
+#include "gfx/sfml_painter.h"
 
+#include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Window/Event.hpp>
-#include <SFML/Window/Window.hpp>
 
-int main() {
-    sf::Window window{sf::VideoMode{800, 600}, "gfx"};
+#include <memory>
+#include <string_view>
+
+using namespace std::literals;
+
+int main(int argc, char **argv) {
+    sf::RenderWindow window{sf::VideoMode{800, 600}, "gfx"};
     window.setVerticalSyncEnabled(true);
     window.setActive(true);
 
-    gfx::OpenGLPainter painter{};
-    painter.set_viewport_size(window.getSize().x, window.getSize().y);
+    auto painter = [&]() -> std::unique_ptr<gfx::IPainter> {
+        if (argc == 2 && argv[1] == "--sf"sv) {
+            return std::make_unique<gfx::SfmlPainter>(window);
+        }
+        return std::make_unique<gfx::OpenGLPainter>();
+    }();
+
+    painter->set_viewport_size(window.getSize().x, window.getSize().y);
 
     bool running = true;
     while (running) {
@@ -25,7 +37,7 @@ int main() {
                     running = false;
                     break;
                 case sf::Event::Resized:
-                    painter.set_viewport_size(event.size.width, event.size.height);
+                    painter->set_viewport_size(event.size.width, event.size.height);
                     break;
                 default:
                     break;
@@ -36,10 +48,10 @@ int main() {
         auto x = static_cast<int>(size.x);
         auto y = static_cast<int>(size.y);
 
-        painter.fill_rect({0, 0, x, y}, gfx::Color{0xFF, 0xFF, 0xFF});
+        painter->fill_rect({0, 0, x, y}, gfx::Color{0xFF, 0xFF, 0xFF});
 
-        painter.fill_rect({200, 200, 100, 100}, gfx::Color{0, 0, 0xAA});
-        painter.fill_rect({x / 4 + 50, y / 3 + 50, x / 2, y / 3}, gfx::Color{0xAA, 0, 0, 0x33});
+        painter->fill_rect({200, 200, 100, 100}, gfx::Color{0, 0, 0xAA});
+        painter->fill_rect({x / 4 + 50, y / 3 + 50, x / 2, y / 3}, gfx::Color{0xAA, 0, 0, 0x33});
 
         window.display();
     }

--- a/gfx/sfml_painter.cpp
+++ b/gfx/sfml_painter.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "gfx/sfml_painter.h"
+
+#include <SFML/Graphics/RectangleShape.hpp>
+#include <SFML/Graphics/RenderTarget.hpp>
+#include <SFML/Graphics/View.hpp>
+
+namespace gfx {
+
+void SfmlPainter::set_viewport_size(int width, int height) {
+    sf::View viewport{sf::FloatRect{0, 0, static_cast<float>(width), static_cast<float>(height)}};
+    target_.setView(viewport);
+}
+
+void SfmlPainter::fill_rect(geom::Rect const &rect, Color color) {
+    auto translated{rect.translated(tx_, ty_)};
+    auto scaled{translated.scaled(scale_)};
+
+    sf::RectangleShape drawable{{static_cast<float>(scaled.width), static_cast<float>(scaled.height)}};
+    drawable.setPosition(static_cast<float>(scaled.x), static_cast<float>(scaled.y));
+    drawable.setFillColor(sf::Color{color.r, color.g, color.b, color.a});
+    target_.draw(drawable);
+}
+
+} // namespace gfx

--- a/gfx/sfml_painter.h
+++ b/gfx/sfml_painter.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef GFX_SFML_PAINTER_H_
+#define GFX_SFML_PAINTER_H_
+
+#include "gfx/ipainter.h"
+
+namespace sf {
+class RenderTarget;
+} // namespace sf
+
+namespace gfx {
+
+class SfmlPainter : public IPainter {
+public:
+    SfmlPainter(sf::RenderTarget &target) : target_{target} {}
+
+    void set_viewport_size(int width, int height) override;
+    constexpr void set_scale(int scale) override { scale_ = scale; }
+
+    constexpr void add_translation(int dx, int dy) override {
+        tx_ += dx;
+        ty_ += dy;
+    }
+
+    void fill_rect(geom::Rect const &, Color) override;
+
+private:
+    sf::RenderTarget &target_;
+
+    int scale_{1};
+    int tx_{0};
+    int ty_{0};
+};
+
+} // namespace gfx
+
+#endif


### PR DESCRIPTION
This can currently only be tested by passing `--sf` to the gfx_example application.

The plan is to hack together a temporary text rendering in this to unblock some other parts we want to work on while I set up more proper text rendering.