### PR TITLE
Add bits the text rendering depends on

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,9 +40,9 @@ http_archive(
 http_archive(
     name = "freetype2",  # FTL
     build_file = "//third_party:freetype2.BUILD",
-    sha256 = "a45c6b403413abd5706f3582f04c8339d26397c4304b78fa552f2215df64101f",
-    strip_prefix = "freetype-2.11.0",
-    url = "https://download.savannah.gnu.org/releases/freetype/freetype-2.11.0.tar.gz",
+    sha256 = "f8db94d307e9c54961b39a1cc799a67d46681480696ed72ecf78d4473770f09b",
+    strip_prefix = "freetype-2.11.1",
+    url = "https://download.savannah.gnu.org/releases/freetype/freetype-2.11.1.tar.gz",
 )
 
 http_archive(

--- a/browser/BUILD
+++ b/browser/BUILD
@@ -58,6 +58,7 @@ cc_binary(
         "//dom",
         "//gfx",
         "//gfx:opengl",
+        "//gfx:sfml",
         "//layout",
         "//render",
         "//uri",

--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -337,9 +337,7 @@ void App::render_layout() {
 }
 
 void App::render_overlay() {
-    window_.pushGLStates();
     ImGui::SFML::Render(window_);
-    window_.popGLStates();
 }
 
 void App::show_render_surface() {

--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -5,6 +5,7 @@
 #include "browser/gui/app.h"
 
 #include "dom/dom.h"
+#include "gfx/sfml_painter.h"
 #include "render/render.h"
 #include "uri/uri.h"
 
@@ -43,7 +44,7 @@ App::App(std::string browser_title, std::string start_page_hint, bool load_start
       url_buf_{std::move(start_page_hint)} {
     window_.setFramerateLimit(60);
     ImGui::SFML::Init(window_);
-    painter_.set_viewport_size(window_.getSize().x, window_.getSize().y);
+    painter_->set_viewport_size(window_.getSize().x, window_.getSize().y);
 
     engine_.set_layout_width(window_.getSize().x / scale_);
     engine_.set_on_navigation_failure(std::bind(&App::on_navigation_failure, this, std::placeholders::_1));
@@ -62,13 +63,13 @@ App::~App() {
 void App::set_scale(unsigned scale) {
     scale_ = scale;
     ImGui::GetIO().FontGlobalScale = static_cast<float>(scale_);
-    painter_.set_scale(scale_);
+    painter_->set_scale(scale_);
     auto windowSize = window_.getSize();
 
     // Only resize the window if the user hasn't resized it.
     if (windowSize.x == kDefaultResolutionX && windowSize.y == kDefaultResolutionY) {
         window_.setSize({kDefaultResolutionX * scale_, kDefaultResolutionY * scale_});
-        painter_.set_viewport_size(window_.getSize().x, window_.getSize().y);
+        painter_->set_viewport_size(window_.getSize().x, window_.getSize().y);
     }
 
     engine_.set_layout_width(windowSize.x / scale_);
@@ -86,7 +87,7 @@ int App::run() {
                     break;
                 }
                 case sf::Event::Resized: {
-                    painter_.set_viewport_size(event.size.width, event.size.height);
+                    painter_->set_viewport_size(event.size.width, event.size.height);
                     engine_.set_layout_width(event.size.width / scale_);
                     break;
                 }
@@ -102,6 +103,10 @@ int App::run() {
                         }
                         case sf::Keyboard::Key::F1: {
                             render_debug_ = !render_debug_;
+                            break;
+                        }
+                        case sf::Keyboard::Key::F2: {
+                            switch_painter();
                             break;
                         }
                         default:
@@ -264,12 +269,12 @@ geom::Position App::to_document_position(geom::Position window_position) const {
 }
 
 void App::reset_scroll() {
-    painter_.add_translation(0, -scroll_offset_y_);
+    painter_->add_translation(0, -scroll_offset_y_);
     scroll_offset_y_ = 0;
 }
 
 void App::scroll(int pixels) {
-    painter_.add_translation(0, pixels);
+    painter_->add_translation(0, pixels);
     scroll_offset_y_ += pixels;
 }
 
@@ -330,9 +335,9 @@ void App::clear_render_surface() {
 
 void App::render_layout() {
     if (render_debug_) {
-        render::debug::render_layout_depth(painter_, engine_.layout());
+        render::debug::render_layout_depth(*painter_, engine_.layout());
     } else {
-        render::render_layout(painter_, engine_.layout());
+        render::render_layout(*painter_, engine_.layout());
     }
 }
 
@@ -342,6 +347,17 @@ void App::render_overlay() {
 
 void App::show_render_surface() {
     window_.display();
+}
+
+void App::switch_painter() {
+    reset_scroll();
+    if (selected_painter_ == Painter::OpenGL) {
+        selected_painter_ = Painter::Sfml;
+        painter_ = std::make_unique<gfx::SfmlPainter>(window_);
+    } else {
+        selected_painter_ = Painter::OpenGL;
+        painter_ = std::make_unique<gfx::OpenGLPainter>();
+    }
 }
 
 } // namespace browser::gui

--- a/browser/gui/app.h
+++ b/browser/gui/app.h
@@ -7,12 +7,14 @@
 
 #include "browser/engine.h"
 #include "dom/dom.h"
+#include "gfx/ipainter.h"
 #include "gfx/opengl_painter.h"
 #include "layout/layout.h"
 
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/System/Clock.hpp>
 
+#include <memory>
 #include <string>
 
 namespace browser::gui {
@@ -39,7 +41,13 @@ private:
     std::string layout_str_{};
     std::string nav_widget_extra_info_{};
 
-    gfx::OpenGLPainter painter_{};
+    enum class Painter {
+        OpenGL,
+        Sfml,
+    };
+
+    Painter selected_painter_{Painter::OpenGL};
+    std::unique_ptr<gfx::IPainter> painter_{std::make_unique<gfx::OpenGLPainter>()};
 
     // The scroll offset is the opposite of the current translation of the web page.
     // When we scroll "down", the web page is translated "up".
@@ -75,6 +83,8 @@ private:
     void render_layout();
     void render_overlay();
     void show_render_surface();
+
+    void switch_painter();
 };
 
 } // namespace browser::gui

--- a/geom/geom.h
+++ b/geom/geom.h
@@ -11,6 +11,7 @@ namespace geom {
 
 struct Position {
     int x{}, y{};
+    [[nodiscard]] bool operator==(Position const &) const = default;
 };
 
 struct EdgeSize {
@@ -26,6 +27,8 @@ struct Rect {
     [[nodiscard]] constexpr int right() const { return x + width; }
     [[nodiscard]] constexpr int top() const { return y; }
     [[nodiscard]] constexpr int bottom() const { return y + height; }
+
+    [[nodiscard]] constexpr Position position() const { return {x, y}; }
 
     [[nodiscard]] constexpr Rect expanded(EdgeSize const &edges) const {
         return Rect{

--- a/geom/geom_test.cpp
+++ b/geom/geom_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -9,9 +9,16 @@
 using etest::expect;
 using etest::expect_eq;
 using geom::EdgeSize;
+using geom::Position;
 using geom::Rect;
 
 int main() {
+    etest::test("Rect::position", [] {
+        expect_eq(Rect{-10, 0, 20, 10}.position(), Position{-10, 0});
+        expect_eq(Rect{0, 0, 20, 10}.position(), Position{0, 0});
+        expect_eq(Rect{10, 10, 5, 5}.position(), Position{10, 10});
+    });
+
     etest::test("Rect::expanded", [] {
         Rect r{0, 0, 10, 10};
         expect(Rect{-10, 0, 20, 10} == r.expanded(EdgeSize{10, 0, 0, 0}));

--- a/gfx/color.h
+++ b/gfx/color.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -19,6 +19,8 @@ struct Color {
     }
 
     std::uint8_t r, g, b, a{0xFF};
+
+    [[nodiscard]] constexpr std::uint32_t as_rgba_u32() const { return r << 24 | g << 16 | b << 8 | a; }
 
     [[nodiscard]] constexpr bool operator==(Color const &) const = default;
 };

--- a/gfx/color_test.cpp
+++ b/gfx/color_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -7,6 +7,7 @@
 #include "etest/etest.h"
 
 using etest::expect;
+using etest::expect_eq;
 using gfx::Color;
 
 int main() {
@@ -14,6 +15,11 @@ int main() {
         expect(Color{0x12, 0x34, 0x56} == Color::from_rgb(0x12'34'56));
         expect(Color{} == Color::from_rgb(0));
         expect(Color{0xFF, 0xFF, 0xFF} == Color::from_rgb(0xFF'FF'FF));
+    });
+
+    etest::test("Color::as_rgba_u32", [] {
+        expect_eq(Color{0x12, 0x34, 0x56}.as_rgba_u32(), 0x12'34'56'FFu);
+        expect_eq(Color{0x12, 0x34, 0x56, 0x78}.as_rgba_u32(), 0x12'34'56'78u);
     });
 
     return etest::run_all_tests();


### PR DESCRIPTION
The most interesting change is that you can now hit F2 to switch between the SFML and GL rendering backend in the browser GUI.