### PR TITLE
layout: Calculate em sizes based on the current node's font-size

### DIFF
--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -552,6 +552,90 @@ int main() {
         expect(layout::create_layout(style_root, 100) == expected_layout);
     });
 
+    etest::test("em sizes depend on the font-size", [] {
+        auto dom_root = dom::create_element_node("html", {}, {});
+        auto style_root = style::StyledNode{
+            .node = dom_root,
+            .properties = {
+                    std::pair{"font-size", "10px"},
+                    std::pair{"height", "10em"},
+                    std::pair{"width", "10em"},
+            },
+            .children = {},
+        };
+
+        auto expected_layout = layout::LayoutBox{
+            .node = &style_root,
+            .type = LayoutType::Block,
+            .dimensions = {{0, 0, 100, 100}},
+            .children = {}
+        };
+
+        expect(layout::create_layout(style_root, 1000) == expected_layout);
+
+        // Doubling the font-size should double the width/height.
+        style_root = style::StyledNode{
+            .node = dom_root,
+            .properties = {
+                    std::pair{"font-size", "20px"},
+                    std::pair{"height", "10em"},
+                    std::pair{"width", "10em"},
+            },
+            .children = {},
+        };
+
+        expected_layout = layout::LayoutBox{
+            .node = &style_root,
+            .type = LayoutType::Block,
+            .dimensions = {{0, 0, 200, 200}},
+            .children = {}
+        };
+
+        expect(layout::create_layout(style_root, 1000) == expected_layout);
+    });
+
+    etest::test("px sizes don't depend on the font-size", [] {
+        auto dom_root = dom::create_element_node("html", {}, {});
+        auto style_root = style::StyledNode{
+            .node = dom_root,
+            .properties = {
+                    std::pair{"font-size", "10px"},
+                    std::pair{"height", "10px"},
+                    std::pair{"width", "10px"},
+            },
+            .children = {},
+        };
+
+        auto expected_layout = layout::LayoutBox{
+            .node = &style_root,
+            .type = LayoutType::Block,
+            .dimensions = {{0, 0, 10, 10}},
+            .children = {}
+        };
+
+        expect(layout::create_layout(style_root, 1000) == expected_layout);
+
+        // Doubling the font-size shouldn't change the width/height.
+        style_root = style::StyledNode{
+            .node = dom_root,
+            .properties = {
+                    std::pair{"font-size", "20px"},
+                    std::pair{"height", "10px"},
+                    std::pair{"width", "10px"},
+            },
+            .children = {},
+        };
+
+        expected_layout = layout::LayoutBox{
+            .node = &style_root,
+            .type = LayoutType::Block,
+            .dimensions = {{0, 0, 10, 10}},
+            .children = {}
+        };
+
+        expect(layout::create_layout(style_root, 1000) == expected_layout);
+    });
+
     etest::test("BoxModel box models", [] {
         layout::BoxModel box{
             .content{.x = 400, .y = 400, .width = 100, .height = 100}, // x: 400-500, y: 400-500


### PR DESCRIPTION
I need some bits for grabbing properties from the parent node for text rendering, and this is part of being able to test that in a nice way.