### PR TITLE
protocol: Always include the status line when available

### DIFF
--- a/protocol/http.h
+++ b/protocol/http.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -72,18 +72,18 @@ public:
             }
             data = socket.read_until("\r\n\r\n"sv);
             if (data.empty()) {
-                return {Error::InvalidResponse};
+                return {Error::InvalidResponse, std::move(*status_line)};
             }
             auto headers = Http::parse_headers(data.substr(0, data.size() - 4));
             if (headers.size() == 0) {
-                return {Error::InvalidResponse};
+                return {Error::InvalidResponse, std::move(*status_line)};
             }
             auto encoding = headers.get("transfer-encoding"sv);
             if (encoding == "chunked"sv) {
                 if (auto body = Http::get_chunked_body(socket)) {
                     data = *body;
                 } else {
-                    return {Error::InvalidResponse};
+                    return {Error::InvalidResponse, std::move(*status_line)};
                 }
             } else {
                 data = socket.read_all();

--- a/protocol/http_test.cpp
+++ b/protocol/http_test.cpp
@@ -264,15 +264,16 @@ int main() {
         expect_eq(response.err, protocol::Error::InvalidResponse);
     });
 
-    // TODO(mkiael): Fix so that this test passes
-    // etest::test("404 no headers no body", [] {
-    //    auto response = protocol::parse("HTTP/1.1 404 Not Found\r\n\r\n"sv);
-    //
-    //    require(response.headers.size() == 0);
-    //    expect_eq(response.status_line.version, "HTTP/1.1"sv);
-    //    expect_eq(response.status_line.status_code, 404);
-    //    expect_eq(response.status_line.reason, "Not Found");
-    //});
+    etest::test("404 no headers no body", [] {
+        FakeSocket socket;
+        socket.read_data = "HTTP/1.1 404 Not Found\r\n\r\n";
+        auto response = protocol::Http::get(socket, create_uri());
+
+        require(response.headers.size() == 0);
+        expect_eq(response.status_line.version, "HTTP/1.1"sv);
+        expect_eq(response.status_line.status_code, 404);
+        expect_eq(response.status_line.reason, "Not Found");
+    });
 
     return etest::run_all_tests();
 }


### PR DESCRIPTION
This is pretty helpful when debugging. These probably aren't all `InvalidResponse`, but messing around with that seems like a separate issue, and not dropping the status line on the floor is better than nothing. :P