### PR TITLE
render: Add support for named colors

### DIFF
--- a/render/BUILD
+++ b/render/BUILD
@@ -10,6 +10,7 @@ cc_library(
         "//gfx",
         "//layout",
         "//style",
+        "@range-v3",
         "@spdlog",
     ],
 )


### PR DESCRIPTION
These may move to //gfx later, but for now they're only needed in //render.