### PR TITLE
html: Switch to the ScriptData state when a script tag is encountered

### DIFF
--- a/html/parser.cpp
+++ b/html/parser.cpp
@@ -37,7 +37,7 @@ constexpr auto kImmediatelyPopped = std::to_array(
 
 } // namespace
 
-void Parser::on_token(html2::Tokenizer &, html2::Token &&token) {
+void Parser::on_token(html2::Tokenizer &tokenizer, html2::Token &&token) {
     if (auto doctype = std::get_if<html2::DoctypeToken>(&token)) {
         if (doctype->name.has_value()) {
             doc_.doctype = *(doctype->name);
@@ -49,6 +49,10 @@ void Parser::on_token(html2::Tokenizer &, html2::Token &&token) {
             open_elements_.push(&doc_.html());
             seen_html_tag_ = true;
             return;
+        }
+
+        if (start_tag->tag_name == "script"sv) {
+            tokenizer.set_state(html2::State::ScriptData);
         }
 
         if (open_elements_.empty() && !seen_html_tag_) {

--- a/html/parser_test.cpp
+++ b/html/parser_test.cpp
@@ -6,9 +6,13 @@
 
 #include "etest/etest.h"
 
+#include <cstddef>
+
 using namespace std::literals;
 using etest::expect;
+using etest::expect_eq;
 using etest::require;
+using etest::require_eq;
 
 int main() {
     etest::test("doctype", [] {
@@ -168,6 +172,18 @@ int main() {
         auto p = std::get<dom::Element>(html.children[1]);
         expect(p.name == "p"sv);
         expect(p.children.empty());
+    });
+
+    etest::test("script is handled correctly", [] {
+        auto html = html::parse("<script><hello></script>"sv).html();
+        require_eq(html.children.size(), std::size_t{1});
+
+        auto script = std::get<dom::Element>(html.children[0]);
+        expect_eq(script.name, "script"sv);
+        expect_eq(script.children.size(), std::size_t{1});
+
+        auto script_content = std::get<dom::Text>(script.children[0]);
+        expect_eq(script_content.text, "<hello>"sv);
     });
 
     return etest::run_all_tests();


### PR DESCRIPTION
This makes the DOM on https://www.google.com/ look correct. (At a glance. I haven't verified that it's completely correct.)