### PR TITLE
build: Make generating compile_commands.json more convenient

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,6 +115,8 @@ jobs:
       run: bazel test ///... --config debug
     - name: Run
       run: bazel run browser:tui --config debug
+    - run: bazel run refresh_compile_commands
+    - run: wc -l compile_commands.json && head -n 100 compile_commands.json
 
   clang-format:
     runs-on: ubuntu-20.04
@@ -135,6 +137,13 @@ jobs:
         sudo chmod +x buildifier
     - name: Check
       run: ./buildifier --lint=warn --warnings=all -mode diff WORKSPACE $(find . -type f -iname "*.BUILD" -or -iname BUILD)
+
+  linux-compile-commands:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - run: CC=gcc-10 CXX=g++-10 bazel run refresh_compile_commands
+    - run: wc -l compile_commands.json && head -n 100 compile_commands.json
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
 # Build artifacts.
 /bazel-*
+/compile_commands.json
+/external
 
 # Work-in-progress directory.
 /wip
 
 # Local settings.
 /.bazelrc.local
+
+# For clangd, required to be here by hedronvision/bazel-compile-commands-extractor.
+# IDE files in general should go in .git/info/exclude.
+/.cache/

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,6 @@
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+    tags = ["manual"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,20 @@ http_archive(
     url = "https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
 )
 
+# Misc tools
+# =========================================================
+
+http_archive(
+    name = "hedron_compile_commands",
+    sha256 = "89cf5a306d25ab14559c95e82d0237638a01eb45e8f4f181304540f97e4d66fe",
+    strip_prefix = "bazel-compile-commands-extractor-d3cbc6220320e8d2fce856d8487b45e639e57758",
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/d3cbc6220320e8d2fce856d8487b45e639e57758.tar.gz",
+)
+
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()
+
 # Third-party
 # =========================================================
 


### PR DESCRIPTION
With this change, you can generate `compile_commands.json` by running `bazel run refresh_compile_commands` without having to do any setup outside of cloning the repository.

Works fine with gcc and MSVC, but I ran into issues with clang-13.