### PR TITLE
Make sure all tokens are consumed in html2 tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto eol=lf
+* text=auto

--- a/html2/BUILD
+++ b/html2/BUILD
@@ -16,10 +16,6 @@ cc_library(
     ],
 )
 
-data_files = {
-    "tokenizer": ["test/simple_page.html"],
-}
-
 dependencies = {
     "tree_constructor": ["//dom2"],
 }
@@ -28,10 +24,6 @@ dependencies = {
     name = src[:-4],
     size = "small",
     srcs = [src],
-    data = data_files.get(
-        src[:-9],
-        [],
-    ),
     deps = dependencies.get(
         src[:-9],
         [],

--- a/html2/test/simple_page.html
+++ b/html2/test/simple_page.html
@@ -1,3 +1,0 @@
-<!DOCTYPE html>
-<html>
-</html>

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -442,35 +442,13 @@ int main() {
 
     etest::test("character entity reference, reference to non-ascii glyph", [] {
         auto tokens = run_tokenizer("&div;");
-
-        expect(tokens.tokens.size() >= 2);
-        std::string glyph{};
-        glyph += std::get<CharacterToken>(tokens.tokens[0]).data;
-        glyph += std::get<CharacterToken>(tokens.tokens[1]).data;
-        expect_eq(glyph, "÷"sv);
-
-        expect_token(tokens, CharacterToken{'\xc3'});
-        expect_token(tokens, CharacterToken{'\xb7'});
+        expect_text(tokens, "\xc3\xb7"sv);
         expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("character entity reference, two unicode code points required", [] {
         auto tokens = run_tokenizer("&acE;");
-
-        expect(tokens.tokens.size() >= 5);
-        std::string glyph{};
-        glyph += std::get<CharacterToken>(tokens.tokens[0]).data;
-        glyph += std::get<CharacterToken>(tokens.tokens[1]).data;
-        glyph += std::get<CharacterToken>(tokens.tokens[2]).data;
-        glyph += std::get<CharacterToken>(tokens.tokens[3]).data;
-        glyph += std::get<CharacterToken>(tokens.tokens[4]).data;
-        expect_eq(glyph, "∾̳"sv);
-
-        expect_token(tokens, CharacterToken{'\xe2'});
-        expect_token(tokens, CharacterToken{'\x88'});
-        expect_token(tokens, CharacterToken{'\xbe'});
-        expect_token(tokens, CharacterToken{'\xcc'});
-        expect_token(tokens, CharacterToken{'\xb3'});
+        expect_text(tokens, "\xe2\x88\xbe\xcc\xb3"sv);
         expect_token(tokens, EndOfFileToken{});
     });
 

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -384,10 +384,7 @@ int main() {
     etest::test("comment, nested comment closed", [] {
         auto tokens = run_tokenizer("<!-- <!-- nested --> -->");
         expect_token(tokens, CommentToken{.data = " <!-- nested "});
-        expect_token(tokens, CharacterToken{' '});
-        expect_token(tokens, CharacterToken{'-'});
-        expect_token(tokens, CharacterToken{'-'});
-        expect_token(tokens, CharacterToken{'>'});
+        expect_text(tokens, " -->");
         expect_token(tokens, EndOfFileToken{});
     });
 
@@ -435,8 +432,7 @@ int main() {
 
     etest::test("character entity reference, not ascii alphanumeric", [] {
         auto tokens = run_tokenizer("&@");
-        expect_token(tokens, CharacterToken{'&'});
-        expect_token(tokens, CharacterToken{'@'});
+        expect_text(tokens, "&@");
         expect_token(tokens, EndOfFileToken{});
     });
 
@@ -454,12 +450,7 @@ int main() {
 
     etest::test("ambiguous ampersand", [] {
         auto tokens = run_tokenizer("&blah;");
-        expect_token(tokens, CharacterToken{'&'});
-        expect_token(tokens, CharacterToken{'b'});
-        expect_token(tokens, CharacterToken{'l'});
-        expect_token(tokens, CharacterToken{'a'});
-        expect_token(tokens, CharacterToken{'h'});
-        expect_token(tokens, CharacterToken{';'});
+        expect_text(tokens, "&blah;");
         expect_token(tokens, EndOfFileToken{});
     });
 
@@ -541,9 +532,7 @@ int main() {
 
     etest::test("numeric character reference", [] {
         auto tokens = run_tokenizer("&#9731;"); // U+2603: SNOWMAN
-        expect_token(tokens, CharacterToken{'\xe2'});
-        expect_token(tokens, CharacterToken{'\x98'});
-        expect_token(tokens, CharacterToken{'\x83'});
+        expect_text(tokens, "\xe2\x98\x83");
         expect_token(tokens, EndOfFileToken{});
     });
 

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -61,14 +61,13 @@ int main() {
         std::string page_str{std::istreambuf_iterator<char>{page}, std::istreambuf_iterator<char>{}};
         auto tokens = run_tokenizer(page_str);
 
-        expect_eq(tokens,
-                std::vector<Token>{DoctypeToken{.name = "html"s},
-                        CharacterToken{'\n'},
-                        StartTagToken{.tag_name = "html"s},
-                        CharacterToken{'\n'},
-                        EndTagToken{.tag_name = "html"s},
-                        CharacterToken{'\n'},
-                        EndOfFileToken{}});
+        expect_token(tokens, DoctypeToken{.name = "html"s});
+        expect_token(tokens, CharacterToken{'\n'});
+        expect_token(tokens, StartTagToken{.tag_name = "html"s});
+        expect_token(tokens, CharacterToken{'\n'});
+        expect_token(tokens, EndTagToken{.tag_name = "html"s});
+        expect_token(tokens, CharacterToken{'\n'});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("script, empty", [] {
@@ -332,128 +331,127 @@ int main() {
 
     etest::test("comment, simple", [] {
         auto tokens = run_tokenizer("<!-- Hello -->");
-
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = " Hello "}, EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = " Hello "});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, empty", [] {
         auto tokens = run_tokenizer("<!---->");
-
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = ""}, EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = ""});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, with dashes and bang", [] {
         auto tokens = run_tokenizer("<!--!-->");
-
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "!"}, EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = "!"});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, with new lines", [] {
         auto tokens = run_tokenizer("<!--\nOne\nTwo\n-->");
-
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "\nOne\nTwo\n"}, EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = "\nOne\nTwo\n"});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, multiple with new lines", [] {
         auto tokens = run_tokenizer("<!--a-->\n<!--b-->\n<!--c-->");
-
-        expect_eq(tokens,
-                std::vector<Token>{CommentToken{.data = "a"},
-                        CharacterToken{'\n'},
-                        CommentToken{.data = "b"},
-                        CharacterToken{'\n'},
-                        CommentToken{.data = "c"},
-                        EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = "a"});
+        expect_token(tokens, CharacterToken{'\n'});
+        expect_token(tokens, CommentToken{.data = "b"});
+        expect_token(tokens, CharacterToken{'\n'});
+        expect_token(tokens, CommentToken{.data = "c"});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, allowed to end with <!", [] {
         auto tokens = run_tokenizer("<!--My favorite operators are > and <!-->");
-
-        expect_eq(tokens,
-                std::vector<Token>{CommentToken{.data = "My favorite operators are > and <!"}, EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = "My favorite operators are > and <!"});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, nested comment", [] {
         auto tokens = run_tokenizer("<!--<!---->");
-
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "<!--"}, EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = "<!--"});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, nested comment closed", [] {
         auto tokens = run_tokenizer("<!-- <!-- nested --> -->");
-
-        expect_eq(tokens,
-                std::vector<Token>{CommentToken{.data = " <!-- nested "},
-                        CharacterToken{' '},
-                        CharacterToken{'-'},
-                        CharacterToken{'-'},
-                        CharacterToken{'>'},
-                        EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = " <!-- nested "});
+        expect_token(tokens, CharacterToken{' '});
+        expect_token(tokens, CharacterToken{'-'});
+        expect_token(tokens, CharacterToken{'-'});
+        expect_token(tokens, CharacterToken{'>'});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, abrupt closing in comment start", [] {
         auto tokens = run_tokenizer("<!-->");
-
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = ""}, EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = ""});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, abrupt closing in comment start dash", [] {
         auto tokens = run_tokenizer("<!--->");
-
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = ""}, EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = ""});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, incorrectly closed comment", [] {
         auto tokens = run_tokenizer("<!--abc--!>");
-
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "abc"}, EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = "abc"});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, end before comment", [] {
         auto tokens = run_tokenizer("<!--");
-
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = ""}, EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = ""});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("comment, eof before comment is closed", [] {
         auto tokens = run_tokenizer("<!--abc");
-
-        expect_eq(tokens, std::vector<Token>{CommentToken{.data = "abc"}, EndOfFileToken{}});
+        expect_token(tokens, CommentToken{.data = "abc"});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("character entity reference, simple", [] {
         auto tokens = run_tokenizer("&lt;");
-        expect_eq(tokens, std::vector<Token>{CharacterToken{'<'}, EndOfFileToken{}});
+        expect_token(tokens, CharacterToken{'<'});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("character entity reference, only &", [] {
         auto tokens = run_tokenizer("&");
-        expect_eq(tokens, std::vector<Token>{CharacterToken{'&'}, EndOfFileToken{}});
+        expect_token(tokens, CharacterToken{'&'});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("character entity reference, not ascii alphanumeric", [] {
         auto tokens = run_tokenizer("&@");
-        expect_eq(tokens, std::vector<Token>{CharacterToken{'&'}, CharacterToken{'@'}, EndOfFileToken{}});
+        expect_token(tokens, CharacterToken{'&'});
+        expect_token(tokens, CharacterToken{'@'});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("character entity reference, reference to non-ascii glyph", [] {
         auto tokens = run_tokenizer("&div;");
-        expect_eq(tokens, std::vector<Token>{CharacterToken{'\xc3'}, CharacterToken{'\xb7'}, EndOfFileToken{}});
+
+        expect(tokens.size() >= 2);
         std::string glyph{};
         glyph += std::get<CharacterToken>(tokens[0]).data;
         glyph += std::get<CharacterToken>(tokens[1]).data;
         expect_eq(glyph, "÷"sv);
+
+        expect_token(tokens, CharacterToken{'\xc3'});
+        expect_token(tokens, CharacterToken{'\xb7'});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("character entity reference, two unicode code points required", [] {
         auto tokens = run_tokenizer("&acE;");
-        expect_eq(tokens,
-                std::vector<Token>{CharacterToken{'\xe2'},
-                        CharacterToken{'\x88'},
-                        CharacterToken{'\xbe'},
-                        CharacterToken{'\xcc'},
-                        CharacterToken{'\xb3'},
-                        EndOfFileToken{}});
+
+        expect(tokens.size() >= 5);
         std::string glyph{};
         glyph += std::get<CharacterToken>(tokens[0]).data;
         glyph += std::get<CharacterToken>(tokens[1]).data;
@@ -461,6 +459,13 @@ int main() {
         glyph += std::get<CharacterToken>(tokens[3]).data;
         glyph += std::get<CharacterToken>(tokens[4]).data;
         expect_eq(glyph, "∾̳"sv);
+
+        expect_token(tokens, CharacterToken{'\xe2'});
+        expect_token(tokens, CharacterToken{'\x88'});
+        expect_token(tokens, CharacterToken{'\xbe'});
+        expect_token(tokens, CharacterToken{'\xcc'});
+        expect_token(tokens, CharacterToken{'\xb3'});
+        expect_token(tokens, EndOfFileToken{});
     });
 
     etest::test("ambiguous ampersand", [] {

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -61,21 +61,6 @@ void expect_text(TokenizerOutput &output, std::string_view text) {
 } // namespace
 
 int main() {
-    etest::test("simple_page", [] {
-        std::ifstream page{"html2/test/simple_page.html", std::ios::binary};
-        require(page.is_open());
-        std::string page_str{std::istreambuf_iterator<char>{page}, std::istreambuf_iterator<char>{}};
-        auto tokens = run_tokenizer(page_str);
-
-        expect_token(tokens, DoctypeToken{.name = "html"s});
-        expect_token(tokens, CharacterToken{'\n'});
-        expect_token(tokens, StartTagToken{.tag_name = "html"s});
-        expect_token(tokens, CharacterToken{'\n'});
-        expect_token(tokens, EndTagToken{.tag_name = "html"s});
-        expect_token(tokens, CharacterToken{'\n'});
-        expect_token(tokens, EndOfFileToken{});
-    });
-
     etest::test("script, empty", [] {
         auto tokens = run_tokenizer("<script></script>");
 


### PR DESCRIPTION
@mkiael Not sure if 005cb7827fc9d827cd15ad5f6a69ad1e57fc6be6 is a good idea. On one hand, I guess our tests would catch any behaviour change, but on the other hand https://en.cppreference.com/w/cpp/language/translation_phases#Phase_5 makes it sound like we shouldn't rely on literals being utf8 at runtime.

Maybe replace the text expected with the hex representation instead to be safe?