### PR TITLE
style: Get rid of redundant get_property_or function

### DIFF
--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -122,9 +122,9 @@ void calculate_width_and_margin(LayoutBox &box, geom::Rect const &parent, int co
         box.dimensions.margin.bottom = to_px(*margin_bottom, font_size);
     }
 
-    auto width = style::get_property_or(*box.node, "width", "auto");
-    auto margin_left = style::get_property_or(*box.node, "margin-left", "0");
-    auto margin_right = style::get_property_or(*box.node, "margin-right", "0");
+    auto width = style::get_property(*box.node, "width").value_or("auto");
+    auto margin_left = style::get_property(*box.node, "margin-left").value_or("0");
+    auto margin_right = style::get_property(*box.node, "margin-right").value_or("0");
     if (width == "auto") {
         if (margin_left != "auto") {
             box.dimensions.margin.left = to_px(margin_left, font_size);
@@ -205,23 +205,23 @@ void calculate_border(LayoutBox &box, int const font_size) {
     // TODO(mkiael): Change to "meduim" when this is supported
     std::string_view default_width = "3px";
 
-    if (style::get_property_or(*box.node, "border-left-style", default_style) != default_style) {
-        auto border_width = style::get_property_or(*box.node, "border-left-width", default_width);
+    if (style::get_property(*box.node, "border-left-style").value_or(default_style) != default_style) {
+        auto border_width = style::get_property(*box.node, "border-left-width").value_or(default_width);
         box.dimensions.border.left = to_px(border_width, font_size);
     }
 
-    if (style::get_property_or(*box.node, "border-right-style", default_style) != default_style) {
-        auto border_width = style::get_property_or(*box.node, "border-right-width", default_width);
+    if (style::get_property(*box.node, "border-right-style").value_or(default_style) != default_style) {
+        auto border_width = style::get_property(*box.node, "border-right-width").value_or(default_width);
         box.dimensions.border.right = to_px(border_width, font_size);
     }
 
-    if (style::get_property_or(*box.node, "border-top-style", default_style) != default_style) {
-        auto border_width = style::get_property_or(*box.node, "border-top-width", default_width);
+    if (style::get_property(*box.node, "border-top-style").value_or(default_style) != default_style) {
+        auto border_width = style::get_property(*box.node, "border-top-width").value_or(default_width);
         box.dimensions.border.top = to_px(border_width, font_size);
     }
 
-    if (style::get_property_or(*box.node, "border-bottom-style", default_style) != default_style) {
-        auto border_width = style::get_property_or(*box.node, "border-bottom-width", default_width);
+    if (style::get_property(*box.node, "border-bottom-style").value_or(default_style) != default_style) {
+        auto border_width = style::get_property(*box.node, "border-bottom-width").value_or(default_width);
         box.dimensions.border.bottom = to_px(border_width, font_size);
     }
 }
@@ -232,7 +232,7 @@ void layout(LayoutBox &box, geom::Rect const &bounds) {
         case LayoutType::Block: {
             // TODO(robinlinden): font-size should be inherited.
             auto font_size =
-                    to_px(style::get_property_or(*box.node, "font-size", kDefaultFontSize), kDefaultFontSizePx);
+                    to_px(style::get_property(*box.node, "font-size").value_or(kDefaultFontSize), kDefaultFontSizePx);
             calculate_padding(box, font_size);
             calculate_border(box, font_size);
             calculate_width_and_margin(box, bounds, font_size);

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -99,7 +99,7 @@ void do_render(gfx::IPainter &painter, layout::LayoutBox const &layout) {
         // * This shouldn't be done here.
         auto font = gfx::Font{"arial"sv};
         auto font_size = gfx::FontSize{.px = 10};
-        auto color = parse_color(style::get_property_or(*layout.node, "color"sv, "#000000"sv));
+        auto color = parse_color(style::get_property(*layout.node, "color"sv).value_or("#000000"sv));
         painter.draw_text(layout.dimensions.content.position(), text->text, font, font_size, color);
     } else {
         if (auto maybe_color = style::get_property(*layout.node, "background-color")) {

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -31,11 +31,4 @@ std::optional<std::string_view> get_property(style::StyledNode const &node, std:
     return it->second;
 }
 
-std::string_view get_property_or(style::StyledNode const &node, std::string_view property, std::string_view fallback) {
-    if (auto prop = get_property(node, property)) {
-        return *prop;
-    }
-    return fallback;
-}
-
 } // namespace style

--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -27,7 +27,6 @@ struct StyledNode {
 }
 
 std::optional<std::string_view> get_property(StyledNode const &node, std::string_view property);
-std::string_view get_property_or(StyledNode const &node, std::string_view property, std::string_view fallback);
 
 } // namespace style
 

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -22,8 +22,6 @@ int main() {
 
         expect(style::get_property(styled_node, "bad_property"sv) == std::nullopt);
         expect(style::get_property(styled_node, "good_property"sv).value() == "fantastic_value"sv);
-        expect(style::get_property_or(styled_node, "bad_property"sv, "fallback"sv) == "fallback"sv);
-        expect(style::get_property_or(styled_node, "good_property"sv, "fallback"sv) == "fantastic_value"sv);
     });
 
     etest::test("property inheritance"sv, [] {


### PR DESCRIPTION
Use std::optional::value_or(fallback) instead.