### PR TITLE
etest: Don't require test names to be kept alive outside of etest

### DIFF
--- a/etest/etest.cpp
+++ b/etest/etest.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -18,7 +18,7 @@ namespace {
 int assertion_failures = 0;
 
 struct Test {
-    std::string_view name;
+    std::string name;
     std::function<void()> body;
 };
 
@@ -68,9 +68,9 @@ int run_all_tests() noexcept {
     return assertion_failures > 0 ? 1 : 0;
 }
 
-void test(std::string_view name, std::function<void()> body) noexcept {
+void test(std::string name, std::function<void()> body) noexcept {
     // TODO(robinlinden): push_back -> emplace_back once Clang supports it (C++20/p0960). Not supported as of Clang 13.
-    registry().push_back({name, std::move(body)});
+    registry().push_back({std::move(name), std::move(body)});
 }
 
 void expect(bool b, etest::source_location const &loc) noexcept {

--- a/etest/etest.h
+++ b/etest/etest.h
@@ -10,7 +10,7 @@
 #include <concepts>
 #include <functional>
 #include <ostream>
-#include <string_view>
+#include <string>
 
 namespace etest {
 
@@ -20,7 +20,7 @@ concept Printable = requires(std::ostream &os, T t) {
 };
 
 [[nodiscard]] int run_all_tests() noexcept;
-void test(std::string_view name, std::function<void()> body) noexcept;
+void test(std::string name, std::function<void()> body) noexcept;
 
 // Weak test requirement. Allows the test to continue even if the check fails.
 void expect(bool, etest::source_location const &loc = etest::source_location::current()) noexcept;

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -12,7 +12,7 @@ using etest::expect_eq;
 using etest::require;
 
 int main() {
-    etest::test("get_property"sv, [] {
+    etest::test("get_property", [] {
         dom::Node dom_node = dom::create_element_node("dummy"sv, {}, {});
         style::StyledNode styled_node{
                 .node = dom_node,
@@ -24,7 +24,7 @@ int main() {
         expect(style::get_property(styled_node, "good_property"sv).value() == "fantastic_value"sv);
     });
 
-    etest::test("property inheritance"sv, [] {
+    etest::test("property inheritance", [] {
         dom::Node dom_node = dom::create_element_node("dummy"sv, {}, {});
         style::StyledNode root{
                 .node = dom_node,


### PR DESCRIPTION
This allows for constructions like

```
for (char quote : std::array{'\'', '"'}) {
  test(std::format("thing with {}-quote", quote == '"' ? "double" : "single"), [] { expect(true); });
}
```