### PR TITLE
Render solid borders

### DIFF
--- a/render/render.cpp
+++ b/render/render.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -92,19 +93,27 @@ gfx::Color parse_color(std::string_view str) {
     return gfx::Color{0xFF, 0, 0};
 }
 
+void render_text(gfx::IPainter &painter, layout::LayoutBox const &layout, dom::Text const &text) {
+    // TODO(robinlinden):
+    // * We need to grab properties from the parent for this to work.
+    // * This shouldn't be done here.
+    auto font = gfx::Font{"arial"sv};
+    auto font_size = gfx::FontSize{.px = 10};
+    auto color = parse_color(style::get_property(*layout.node, "color"sv).value_or("#000000"sv));
+    painter.draw_text(layout.dimensions.content.position(), text.text, font, font_size, color);
+}
+
+void render_background(gfx::IPainter &painter, layout::LayoutBox const &layout) {
+    if (auto maybe_color = style::get_property(*layout.node, "background-color")) {
+        painter.fill_rect(layout.dimensions.padding_box(), parse_color(*maybe_color));
+    }
+}
+
 void do_render(gfx::IPainter &painter, layout::LayoutBox const &layout) {
     if (auto const *text = try_get_text(layout)) {
-        // TODO(robinlinden):
-        // * We need to grab properties from the parent for this to work.
-        // * This shouldn't be done here.
-        auto font = gfx::Font{"arial"sv};
-        auto font_size = gfx::FontSize{.px = 10};
-        auto color = parse_color(style::get_property(*layout.node, "color"sv).value_or("#000000"sv));
-        painter.draw_text(layout.dimensions.content.position(), text->text, font, font_size, color);
+        render_text(painter, layout, *text);
     } else {
-        if (auto maybe_color = style::get_property(*layout.node, "background-color")) {
-            painter.fill_rect(layout.dimensions.padding_box(), parse_color(*maybe_color));
-        }
+        render_background(painter, layout);
     }
 }
 

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -25,6 +25,8 @@ using namespace std::literals;
 namespace render {
 namespace {
 
+constexpr std::string_view kDefaultColor{"#000000"};
+
 struct CaseInsensitiveLess {
     using is_transparent = void;
     bool operator()(std::string_view s1, std::string_view s2) const {
@@ -99,7 +101,7 @@ void render_text(gfx::IPainter &painter, layout::LayoutBox const &layout, dom::T
     // * This shouldn't be done here.
     auto font = gfx::Font{"arial"sv};
     auto font_size = gfx::FontSize{.px = 10};
-    auto color = parse_color(style::get_property(*layout.node, "color"sv).value_or("#000000"sv));
+    auto color = parse_color(style::get_property(*layout.node, "color"sv).value_or(kDefaultColor));
     painter.draw_text(layout.dimensions.content.position(), text.text, font, font_size, color);
 }
 

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -63,6 +63,10 @@ bool looks_like_hex(std::string_view str) {
     return str.starts_with('#') && (str.length() == 7 || str.length() == 4);
 }
 
+bool has_any_border(layout::LayoutBox const &layout) {
+    return layout.dimensions.border_box() != layout.dimensions.padding_box();
+}
+
 dom::Text const *try_get_text(layout::LayoutBox const &layout) {
     return std::get_if<dom::Text>(&layout.node->node);
 }
@@ -105,6 +109,40 @@ void render_text(gfx::IPainter &painter, layout::LayoutBox const &layout, dom::T
     painter.draw_text(layout.dimensions.content.position(), text.text, font, font_size, color);
 }
 
+void render_borders(gfx::IPainter &painter, layout::LayoutBox const &layout) {
+    // TODO(mkiael): Handle a lot more border styles
+    auto color = style::get_property(*layout.node, "color"sv).value_or(kDefaultColor);
+    auto border_box = layout.dimensions.border_box();
+    auto const &border_size = layout.dimensions.border;
+    if (border_size.left > 0) {
+        geom::Rect border{border_box.left(),
+                border_box.top() + border_size.top,
+                border_size.left,
+                border_box.height - border_size.top - border_size.bottom};
+        auto border_color = style::get_property(*layout.node, "border-left-color"sv).value_or(color);
+        painter.fill_rect(border, parse_color(border_color));
+    }
+    if (border_size.right > 0) {
+        geom::Rect border{border_box.right() - border_size.right,
+                border_box.top() + border_size.top,
+                border_size.right,
+                border_box.height - border_size.top - border_size.bottom};
+        auto border_color = style::get_property(*layout.node, "border-right-color"sv).value_or(color);
+        painter.fill_rect(border, parse_color(border_color));
+    }
+    if (border_size.top > 0) {
+        geom::Rect border{border_box.left(), border_box.top(), border_box.width, border_size.top};
+        auto border_color = style::get_property(*layout.node, "border-top-color"sv).value_or(color);
+        painter.fill_rect(border, parse_color(border_color));
+    }
+    if (border_size.bottom > 0) {
+        geom::Rect border{
+                border_box.left(), border_box.bottom() - border_size.bottom, border_box.width, border_size.bottom};
+        auto border_color = style::get_property(*layout.node, "border-bottom-color"sv).value_or(color);
+        painter.fill_rect(border, parse_color(border_color));
+    }
+}
+
 void render_background(gfx::IPainter &painter, layout::LayoutBox const &layout) {
     if (auto maybe_color = style::get_property(*layout.node, "background-color")) {
         painter.fill_rect(layout.dimensions.padding_box(), parse_color(*maybe_color));
@@ -115,6 +153,9 @@ void do_render(gfx::IPainter &painter, layout::LayoutBox const &layout) {
     if (auto const *text = try_get_text(layout)) {
         render_text(painter, layout, *text);
     } else {
+        if (has_any_border(layout)) {
+            render_borders(painter, layout);
+        }
         render_background(painter, layout);
     }
 }


### PR DESCRIPTION
This PR adds initial support for rendering solid borders. This might need to be refactored a bit once we start adding support for more border styles and border radius.

Part #99 
