### PR TITLE
html2: Add missing replacement-character emits

### DIFF
--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -168,9 +168,8 @@ void Tokenizer::run() {
                         state_ = State::ScriptDataLessThanSign;
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
-                        // TODO(mkiael): Emit replacement character for null
-                        // emit(CharacterToken("\xFF\xFD"));
+                        emit(ParseError::UnexpectedNullCharacter);
+                        emit_replacement_character();
                         continue;
                     default:
                         emit(CharacterToken{*c});
@@ -424,9 +423,8 @@ void Tokenizer::run() {
                         state_ = State::ScriptDataEscapedLessThanSign;
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
-                        // TODO(mkiael): Emit replacement character for null
-                        // emit(CharacterToken("\xFF\xFD"));
+                        emit(ParseError::UnexpectedNullCharacter);
+                        emit_replacement_character();
                         continue;
                     default:
                         emit(CharacterToken{*c});
@@ -451,10 +449,9 @@ void Tokenizer::run() {
                         state_ = State::ScriptDataEscapedLessThanSign;
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
+                        emit(ParseError::UnexpectedNullCharacter);
                         state_ = State::ScriptDataEscaped;
-                        // TODO(mkiael): Emit replacement character for null
-                        // emit(CharacterToken("\xFF\xFD"));
+                        emit_replacement_character();
                         continue;
                     default:
                         state_ = State::ScriptDataEscaped;
@@ -483,10 +480,9 @@ void Tokenizer::run() {
                         emit(CharacterToken{*c});
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
+                        emit(ParseError::UnexpectedNullCharacter);
                         state_ = State::ScriptDataEscaped;
-                        // TODO(mkiael): Emit replacement character for null
-                        // emit(CharacterToken("\xFF\xFD"));
+                        emit_replacement_character();
                         continue;
                     default:
                         state_ = State::ScriptDataEscaped;
@@ -645,9 +641,8 @@ void Tokenizer::run() {
                         emit(CharacterToken{*c});
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
-                        // TODO(mkiael): Emit replacement character for null
-                        // emit(CharacterToken("\xFF\xFD"));
+                        emit(ParseError::UnexpectedNullCharacter);
+                        emit_replacement_character();
                         continue;
                     default:
                         emit(CharacterToken{*c});
@@ -673,10 +668,9 @@ void Tokenizer::run() {
                         emit(CharacterToken{*c});
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
+                        emit(ParseError::UnexpectedNullCharacter);
                         state_ = State::ScriptDataDoubleEscaped;
-                        // TODO(mkiael): Emit replacement character for null
-                        // emit(CharacterToken("\xFF\xFD"));
+                        emit_replacement_character();
                         continue;
                     default:
                         state_ = State::ScriptDataDoubleEscaped;
@@ -706,10 +700,9 @@ void Tokenizer::run() {
                         emit(CharacterToken{*c});
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
+                        emit(ParseError::UnexpectedNullCharacter);
                         state_ = State::ScriptDataDoubleEscaped;
-                        // TODO(mkiael): Emit replacement character for null
-                        // emit(CharacterToken("\xFF\xFD"));
+                        emit_replacement_character();
                         continue;
                     default:
                         state_ = State::ScriptDataDoubleEscaped;
@@ -1897,6 +1890,12 @@ bool Tokenizer::is_appropriate_end_tag_token(Token const &token) const {
         return std::get<EndTagToken>(token).tag_name == last_start_tag_name_;
     }
     return false;
+}
+
+void Tokenizer::emit_replacement_character() {
+    for (char c : util::unicode_to_utf8(0xFFFD)) {
+        emit(CharacterToken{c});
+    }
 }
 
 } // namespace html2

--- a/html2/tokenizer.h
+++ b/html2/tokenizer.h
@@ -155,6 +155,7 @@ private:
     void flush_code_points_consumed_as_a_character_reference();
     void emit_temporary_buffer_as_character_tokens();
     bool is_appropriate_end_tag_token(Token const &) const;
+    void emit_replacement_character();
 };
 
 } // namespace html2

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -108,6 +108,16 @@ int main() {
         expect_token(tokens, EndOfFileToken{});
     });
 
+    etest::test("script, unexpected null", [] {
+        auto tokens = run_tokenizer("<script>\0</script>"sv);
+
+        expect_error(tokens, ParseError::UnexpectedNullCharacter);
+        expect_token(tokens, StartTagToken{.tag_name = "script"});
+        expect_text(tokens, kReplacementCharacter);
+        expect_token(tokens, EndTagToken{.tag_name = "script"});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
     etest::test("script, with source file attribute", [] {
         auto tokens = run_tokenizer("<script src=\"/foo.js\"></script>");
 
@@ -162,11 +172,41 @@ int main() {
         expect_token(tokens, EndOfFileToken{});
     });
 
+    etest::test("script, escaped null", [] {
+        auto tokens = run_tokenizer("<script><!-- \0 --></script>"sv);
+
+        expect_error(tokens, ParseError::UnexpectedNullCharacter);
+        expect_token(tokens, StartTagToken{.tag_name = "script"});
+        expect_text(tokens, "<!-- "s + kReplacementCharacter + " -->");
+        expect_token(tokens, EndTagToken{.tag_name = "script"});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
     etest::test("script, escaped one dash", [] {
         auto tokens = run_tokenizer("<script><!-- -<</script>");
 
         expect_token(tokens, StartTagToken{.tag_name = "script"});
         expect_text(tokens, "<!-- -<"sv);
+        expect_token(tokens, EndTagToken{.tag_name = "script"});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
+    etest::test("script, escaped dash null", [] {
+        auto tokens = run_tokenizer("<script><!-- -\0</script>"sv);
+
+        expect_error(tokens, ParseError::UnexpectedNullCharacter);
+        expect_token(tokens, StartTagToken{.tag_name = "script"});
+        expect_text(tokens, "<!-- -"s + kReplacementCharacter);
+        expect_token(tokens, EndTagToken{.tag_name = "script"});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
+    etest::test("script, escaped dash dash null", [] {
+        auto tokens = run_tokenizer("<script><!-- --\0</script>"sv);
+
+        expect_error(tokens, ParseError::UnexpectedNullCharacter);
+        expect_token(tokens, StartTagToken{.tag_name = "script"});
+        expect_text(tokens, "<!-- --"s + kReplacementCharacter);
         expect_token(tokens, EndTagToken{.tag_name = "script"});
         expect_token(tokens, EndOfFileToken{});
     });
@@ -209,11 +249,41 @@ int main() {
         expect_token(tokens, EndOfFileToken{});
     });
 
+    etest::test("script, double escaped null", [] {
+        auto tokens = run_tokenizer("<script><!--<script>\0</script>--></script>"sv);
+
+        expect_error(tokens, ParseError::UnexpectedNullCharacter);
+        expect_token(tokens, StartTagToken{.tag_name = "script"});
+        expect_text(tokens, "<!--<script>"s + kReplacementCharacter + "</script>-->");
+        expect_token(tokens, EndTagToken{.tag_name = "script"});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
     etest::test("script, double escaped dash", [] {
         auto tokens = run_tokenizer("<script><!--<script>---</script>--></script>");
 
         expect_token(tokens, StartTagToken{.tag_name = "script"});
         expect_text(tokens, "<!--<script>---</script>-->"sv);
+        expect_token(tokens, EndTagToken{.tag_name = "script"});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
+    etest::test("script, double escaped dash null", [] {
+        auto tokens = run_tokenizer("<script><!--<script>-\0</script>--></script>"sv);
+
+        expect_error(tokens, ParseError::UnexpectedNullCharacter);
+        expect_token(tokens, StartTagToken{.tag_name = "script"});
+        expect_text(tokens, "<!--<script>-"s + kReplacementCharacter + "</script>-->");
+        expect_token(tokens, EndTagToken{.tag_name = "script"});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
+    etest::test("script, double escaped dash dash null", [] {
+        auto tokens = run_tokenizer("<script><!--<script>--\0</script>--></script>"sv);
+
+        expect_error(tokens, ParseError::UnexpectedNullCharacter);
+        expect_token(tokens, StartTagToken{.tag_name = "script"});
+        expect_text(tokens, "<!--<script>--"s + kReplacementCharacter + "</script>-->");
         expect_token(tokens, EndTagToken{.tag_name = "script"});
         expect_token(tokens, EndOfFileToken{});
     });


### PR DESCRIPTION
We still have a few cases where we're emitting the wrong character, but I think this covers all cases where it was missing altogether.