### PR TITLE
dom: Port from range-v3 to std::ranges

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -92,7 +92,7 @@ build:gcc12 --per_file_copt='external/freetype2[:/]@-Wno-dangling-pointer'
 build:gcc12 --per_file_copt='external/glew[:/]@-Wno-address'
 
 build:windows --enable_runfiles
-build:windows --cxxopt='/std:c++20'
+build:windows --cxxopt='/std:c++latest' # We're using parts of C++20 that aren't ABI-stable yet. See: https://github.com/microsoft/STL/issues/1814#issuecomment-845572895
 build:windows --copt='/W4' # More warnings.
 build:windows --copt='/WX' # Treat warnings as errors.
 build:windows --copt='/permissive-' # Conform to the standard.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,13 +102,6 @@ http_archive(
 )
 
 http_archive(
-    name = "range-v3",  # BSL-1.0
-    sha256 = "3575e4645cd1a7d42fa42a6b016e75a7c72d31d13f72ee4e5bb9773d36303258",
-    strip_prefix = "range-v3-83783f578e0e6666d68a3bf17b0038a80e62530e",
-    url = "https://github.com/ericniebler/range-v3/archive/83783f578e0e6666d68a3bf17b0038a80e62530e.tar.gz",
-)
-
-http_archive(
     name = "sfml",  # Zlib
     build_file = "//third_party:sfml.BUILD",
     sha256 = "6124b5fe3d96e7f681f587e2d5b456cd0ec460393dfe46691f1933d6bde0640b",

--- a/dom/BUILD
+++ b/dom/BUILD
@@ -5,7 +5,6 @@ cc_library(
     srcs = ["dom.cpp"],
     hdrs = ["dom.h"],
     visibility = ["//visibility:public"],
-    deps = ["@range-v3"],
 )
 
 cc_test(

--- a/dom/dom.cpp
+++ b/dom/dom.cpp
@@ -1,16 +1,13 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "dom/dom.h"
 
-#include <range/v3/action/push_back.hpp>
-#include <range/v3/view/remove_if.hpp>
-#include <range/v3/view/transform.hpp>
-
 #include <algorithm>
 #include <iterator>
 #include <ostream>
+#include <ranges>
 #include <sstream>
 #include <variant>
 #include <vector>
@@ -78,9 +75,9 @@ std::vector<Element const *> nodes_by_path(std::reference_wrapper<Element const>
 
             if (path.starts_with(node->name + ".")) {
                 auto view = node->children
-                        | ranges::views::transform([](Node const &n) { return std::get_if<Element>(&n); })
-                        | ranges::views::remove_if([](Element const *n) { return n == nullptr; });
-                next_search |= ranges::actions::push_back(view);
+                        | std::ranges::views::transform([](Node const &n) { return std::get_if<Element>(&n); })
+                        | std::ranges::views::filter([](Element const *n) { return n != nullptr; });
+                std::ranges::copy(view, std::back_inserter(next_search));
             }
         }
 

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -16,7 +16,6 @@ cc_library(
         "//uri",
         "//util:string",
         "@fmt",
-        "@range-v3",
     ],
 )
 

--- a/protocol/http.cpp
+++ b/protocol/http.cpp
@@ -8,8 +8,8 @@
 #include "util/string.h"
 
 #include <fmt/format.h>
-#include <range/v3/algorithm/lexicographical_compare.hpp>
 
+#include <algorithm>
 #include <charconv>
 #include <sstream>
 
@@ -41,7 +41,7 @@ std::size_t Headers::size() const {
 }
 
 bool Headers::CaseInsensitiveLess::operator()(std::string_view s1, std::string_view s2) const {
-    return ranges::lexicographical_compare(
+    return std::ranges::lexicographical_compare(
             s1, s2, [](unsigned char c1, unsigned char c2) { return std::tolower(c1) < std::tolower(c2); });
 }
 

--- a/render/BUILD
+++ b/render/BUILD
@@ -10,7 +10,6 @@ cc_library(
         "//gfx",
         "//layout",
         "//style",
-        "@range-v3",
         "@spdlog",
     ],
 )

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -9,9 +9,9 @@
 #include "gfx/color.h"
 #include "style/style.h"
 
-#include <range/v3/algorithm/lexicographical_compare.hpp>
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
 #include <cctype>
 #include <charconv>
 #include <cstdint>
@@ -30,7 +30,7 @@ constexpr std::string_view kDefaultColor{"#000000"};
 struct CaseInsensitiveLess {
     using is_transparent = void;
     bool operator()(std::string_view s1, std::string_view s2) const {
-        return ranges::lexicographical_compare(
+        return std::ranges::lexicographical_compare(
                 s1, s2, [](unsigned char c1, unsigned char c2) { return std::tolower(c1) < std::tolower(c2); });
     }
 };

--- a/util/BUILD
+++ b/util/BUILD
@@ -1,17 +1,9 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
-dependencies = {
-    "string": ["@range-v3"],
-}
-
 [cc_library(
     name = hdr[:-2],
     hdrs = [hdr],
     visibility = ["//visibility:public"],
-    deps = dependencies.get(
-        hdr[:-2],
-        [],
-    ),
 ) for hdr in glob(["*.h"])]
 
 [cc_test(

--- a/util/string.h
+++ b/util/string.h
@@ -6,8 +6,6 @@
 #ifndef UTIL_STRING_H_
 #define UTIL_STRING_H_
 
-#include <range/v3/algorithm/equal.hpp>
-
 #include <algorithm>
 #include <array>
 #include <cctype>
@@ -18,7 +16,7 @@
 namespace util {
 
 constexpr bool no_case_compare(std::string_view a, std::string_view b) {
-    return ranges::equal(a, b, [](auto c1, auto c2) { return std::tolower(c1) == std::tolower(c2); });
+    return std::ranges::equal(a, b, [](auto c1, auto c2) { return std::tolower(c1) == std::tolower(c2); });
 }
 
 inline std::vector<std::string_view> split(std::string_view str, std::string_view sep) {


### PR DESCRIPTION
Looks like Clang doesn't yet support libstdc++ views: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102807

libc++ ranges support is a bit wip: https://libcxx.llvm.org/Status/Ranges.html, but
`std::ranges::copy` should be supported: https://reviews.llvm.org/D122982
`std::ranges::views::{transform, filter}` should be supported: https://reviews.llvm.org/D109086 https://reviews.llvm.org/D103056
, but I guess that won't be released until Clang 15.