### PR TITLE
ci: Use cli-stable apt-get instead of apt

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,8 +62,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install
         run: |
-          sudo apt update
-          sudo apt install libgl-dev ${{ matrix.compiler }}-${{ matrix.version }} ${{ matrix.apt }}
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends libgl-dev ${{ matrix.compiler }}-${{ matrix.version }} ${{ matrix.apt }}
       - uses: actions/cache@v3
         with:
           path: ~/.cache/bazel
@@ -87,8 +87,8 @@ jobs:
           restore-keys: ${{ matrix.name }}-
       - name: Install
         run: |
-          sudo apt update
-          sudo apt install libgl-dev lcov
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends libgl-dev lcov
       - name: Setup
         run: |
           echo "CC=gcc-10" >> $GITHUB_ENV


### PR DESCRIPTION
I sneaked the `--no-install-recommends`-change in as well, but I hope that's fine. :P