### PR TITLE
build: Disable rtti

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,6 +19,7 @@ build --incompatible_disallow_empty_glob
 # =========================================================
 
 build:linux --cxxopt='-std=c++20'
+build:linux --cxxopt='-fno-rtti'
 build:linux --copt='-Wall'
 build:linux --copt='-Wextra'
 build:linux --copt='-pedantic-errors'
@@ -93,6 +94,7 @@ build:gcc12 --per_file_copt='external/glew[:/]@-Wno-address'
 
 build:windows --enable_runfiles
 build:windows --cxxopt='/std:c++20'
+build:windows --cxxopt='/GR-' # Disable rtti.
 build:windows --copt='/W4' # More warnings.
 build:windows --copt='/WX' # Treat warnings as errors.
 build:windows --copt='/permissive-' # Conform to the standard.

--- a/third_party/asio.BUILD
+++ b/third_party/asio.BUILD
@@ -7,7 +7,10 @@ cc_library(
         "include/**/*.hpp",
         "include/**/*.ipp",
     ]),
-    defines = ["ASIO_SEPARATE_COMPILATION"],
+    defines = [
+        "ASIO_NO_TYPEID",
+        "ASIO_SEPARATE_COMPILATION",
+    ],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = ["@boringssl//:ssl"],


### PR DESCRIPTION
We're not using it yet, and since we've gotten quite far without it now
I figure we should make a conscious decision if/when to introduce it
rather than let it sneak in by accident.