### PR TITLE
css: Fix crash when encountering @keyframes rules

### DIFF
--- a/css/parser.h
+++ b/css/parser.h
@@ -44,6 +44,28 @@ public:
                 skip_whitespace_and_comments();
             }
 
+            // https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes
+            // Not saved or anything yet, but stops us from crashing when encountering it.
+            if (starts_with("@keyframes ")) {
+                advance(std::strlen("@keyframes "));
+                skip_whitespace_and_comments();
+                [[maybe_unused]] auto keyframes_name = consume_while([](char c) { return c != '{'; });
+                consume_char(); // {
+                skip_whitespace_and_comments();
+
+                while (peek() != '}') {
+                    [[maybe_unused]] auto rule = parse_rule();
+                    skip_whitespace_and_comments();
+                }
+
+                consume_char(); // }
+                skip_whitespace_and_comments();
+
+                if (is_eof()) {
+                    break;
+                }
+            }
+
             rules.push_back(parse_rule());
             if (!media_query.empty()) {
                 rules.back().media_query = std::string{media_query};

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -615,5 +615,22 @@ int main() {
         expect(check_initial_font_values(body.declarations));
     });
 
+    etest::test("parser: @keyframes doesn't crash the parser", [] {
+        auto css = R"(
+            @keyframes toast-spinner {
+                from {
+                    transform: rotate(0deg)
+                }
+
+                to {
+                    transform: rotate(360deg)
+                }
+            })"sv;
+
+        // No rules produced (yet!) since this isn't handled aside from not crashing.
+        auto rules = css::parse(css);
+        expect(rules.empty());
+    });
+
     return etest::run_all_tests();
 }


### PR DESCRIPTION
This is a fix for that https://github.com was crashing the browser during the CSS parsing.