### PR TITLE
Reduce meme-value of the base-parser tests

### DIFF
--- a/util/base_parser_test.cpp
+++ b/util/base_parser_test.cpp
@@ -9,39 +9,28 @@
 using etest::expect;
 using util::BaseParser;
 
-namespace {
-
-template<bool B>
-bool static_test() {
-    static_assert(B);
-    return B;
-}
-
-} // namespace
-
 int main() {
     etest::test("peek", [] {
         constexpr auto abcd = BaseParser("abcd");
-        expect(static_test<abcd.peek() == 'a'>());
-        expect(static_test<abcd.peek(2) == "ab">());
-        expect(static_test<abcd.peek(3) == "abc">());
-        expect(static_test<abcd.peek(4) == "abcd">());
-        expect(static_test<BaseParser(" ").peek() == ' '>());
+        expect(abcd.peek() == 'a');
+        expect(abcd.peek(2) == "ab");
+        expect(abcd.peek(3) == "abc");
+        expect(abcd.peek(4) == "abcd");
+        expect(BaseParser(" ").peek() == ' ');
     });
 
     etest::test("starts_with", [] {
         constexpr auto abcd = BaseParser("abcd");
-        expect(static_test<!abcd.starts_with("hello")>());
-        expect(static_test<abcd.starts_with("ab")>());
-        expect(static_test<abcd.starts_with("abcd")>());
+        expect(!abcd.starts_with("hello"));
+        expect(abcd.starts_with("ab"));
+        expect(abcd.starts_with("abcd"));
     });
 
-#ifndef __clang__ // Clang doesn't yet support lambdas in templates.
     etest::test("is_eof, advance", [] {
         constexpr auto abcd = BaseParser("abcd");
-        expect(static_test<!abcd.is_eof()>());
-        expect(static_test<BaseParser("").is_eof()>());
-        expect(static_test<[] {
+        expect(!abcd.is_eof());
+        expect(BaseParser("").is_eof());
+        expect([] {
             auto p = BaseParser("abcd");
             p.advance(3);
             if (p.is_eof()) {
@@ -49,11 +38,11 @@ int main() {
             }
             p.advance(1);
             return p.is_eof();
-        }()>());
+        }());
     });
 
     etest::test("consume_char", [] {
-        expect(static_test<[] {
+        expect([] {
             auto p = BaseParser("abcd");
             if (p.consume_char() != 'a') {
                 return false;
@@ -68,11 +57,11 @@ int main() {
                 return false;
             }
             return true;
-        }()>());
+        }());
     });
 
     etest::test("consume_while", [] {
-        expect(static_test<[] {
+        expect([] {
             auto p = BaseParser("abcd");
             if (p.consume_while([](char c) { return c != 'c'; }) != "ab") {
                 return false;
@@ -81,11 +70,11 @@ int main() {
                 return false;
             }
             return true;
-        }()>());
+        }());
     });
 
     etest::test("skip_whitespace, consume_char", [] {
-        expect(static_test<[] {
+        expect([] {
             auto p = BaseParser("      \t       \n         h          \n\n\ni");
             p.skip_whitespace();
             if (p.consume_char() != 'h') {
@@ -96,7 +85,6 @@ int main() {
                 return false;
             }
             return true;
-        }()>());
+        }());
     });
-#endif
 }

--- a/util/base_parser_test.cpp
+++ b/util/base_parser_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -7,6 +7,7 @@
 #include "etest/etest.h"
 
 using etest::expect;
+using etest::expect_eq;
 using util::BaseParser;
 
 int main() {
@@ -30,61 +31,35 @@ int main() {
         constexpr auto abcd = BaseParser("abcd");
         expect(!abcd.is_eof());
         expect(BaseParser("").is_eof());
-        expect([] {
-            auto p = BaseParser("abcd");
-            p.advance(3);
-            if (p.is_eof()) {
-                return false;
-            }
-            p.advance(1);
-            return p.is_eof();
-        }());
+
+        auto p = BaseParser("abcd");
+        p.advance(3);
+        expect(!p.is_eof());
+
+        p.advance(1);
+        expect(p.is_eof());
     });
 
     etest::test("consume_char", [] {
-        expect([] {
-            auto p = BaseParser("abcd");
-            if (p.consume_char() != 'a') {
-                return false;
-            }
-            if (p.consume_char() != 'b') {
-                return false;
-            }
-            if (p.consume_char() != 'c') {
-                return false;
-            }
-            if (p.consume_char() != 'd') {
-                return false;
-            }
-            return true;
-        }());
+        auto p = BaseParser("abcd");
+        expect_eq(p.consume_char(), 'a');
+        expect_eq(p.consume_char(), 'b');
+        expect_eq(p.consume_char(), 'c');
+        expect_eq(p.consume_char(), 'd');
     });
 
     etest::test("consume_while", [] {
-        expect([] {
-            auto p = BaseParser("abcd");
-            if (p.consume_while([](char c) { return c != 'c'; }) != "ab") {
-                return false;
-            }
-            if (p.consume_while([](char c) { return c != 'd'; }) != "c") {
-                return false;
-            }
-            return true;
-        }());
+        auto p = BaseParser("abcd");
+        expect_eq(p.consume_while([](char c) { return c != 'c'; }), "ab");
+        expect_eq(p.consume_while([](char c) { return c != 'd'; }), "c");
     });
 
     etest::test("skip_whitespace, consume_char", [] {
-        expect([] {
-            auto p = BaseParser("      \t       \n         h          \n\n\ni");
-            p.skip_whitespace();
-            if (p.consume_char() != 'h') {
-                return false;
-            }
-            p.skip_whitespace();
-            if (p.consume_char() != 'i') {
-                return false;
-            }
-            return true;
-        }());
+        auto p = BaseParser("      \t       \n         h          \n\n\ni");
+        p.skip_whitespace();
+        expect_eq(p.consume_char(), 'h');
+
+        p.skip_whitespace();
+        expect_eq(p.consume_char(), 'i');
     });
 }


### PR DESCRIPTION
Running 100% of the base parser tests at compile time was a fun
experiment, but the tests looking more standard and being able to run
them under Clang as well outweighs the meme-value of it.