### PR TITLE
Add support for disabling tests, disable everything accessing live websites in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,8 +73,10 @@ jobs:
         run: bazel build //... ${{ matrix.bazel }}
       - name: Test
         run: bazel test //... ${{ matrix.bazel }}
-      - name: Run
-        run: bazel run browser:tui ${{ matrix.bazel }}
+      # TODO(robinlinden): This no longer runs in CI due to http://example.com
+      # being inaccessible.
+      # - name: Run
+      #   run: bazel run browser:tui ${{ matrix.bazel }}
 
   linux-gcc-10-coverage:
     runs-on: ubuntu-20.04
@@ -111,8 +113,10 @@ jobs:
         run: bazel build ///... --config debug
       - name: Test
         run: bazel test ///... --config debug
-      - name: Run
-        run: bazel run browser:tui --config debug
+      # TODO(robinlinden): This no longer runs in CI due to http://example.com
+      # being inaccessible.
+      # - name: Run
+      #   run: bazel run browser:tui --config debug
       - run: bazel run refresh_compile_commands
       - run: wc -l compile_commands.json && head -n 100 compile_commands.json
 
@@ -127,7 +131,9 @@ jobs:
       - run: choco install llvm -y --force --version 14.0.3
       - run: echo "build --config clang-cl" >.bazelrc.local
       - run: bazel test ...
-      - run: bazel run browser:tui
+      # TODO(robinlinden): This no longer runs in CI due to http://example.com
+      # being inaccessible.
+      # - run: bazel run browser:tui
       - run: bazel run refresh_compile_commands
       - run: wc -l compile_commands.json && head -n 100 compile_commands.json
 

--- a/browser/engine_test.cpp
+++ b/browser/engine_test.cpp
@@ -24,7 +24,7 @@ int main() {
         expect(success);
     });
 
-    etest::test("page load", [] {
+    etest::disabled_test("page load", [] {
         bool success{false};
         browser::Engine e;
         e.set_on_navigation_failure([&](protocol::Error) { require(false); });
@@ -35,7 +35,7 @@ int main() {
         expect(success);
     });
 
-    etest::test("layout update", [] {
+    etest::disabled_test("layout update", [] {
         browser::Engine e;
         e.set_on_navigation_failure([&](protocol::Error) { require(false); });
         e.set_on_page_loaded([] { require(false); });

--- a/etest/etest.cpp
+++ b/etest/etest.cpp
@@ -16,6 +16,7 @@ namespace etest {
 namespace {
 
 int assertion_failures = 0;
+int disabled_tests = 0;
 
 struct Test {
     std::string name;
@@ -34,7 +35,13 @@ std::stringstream test_log{};
 } // namespace
 
 int run_all_tests() noexcept {
-    std::cout << registry().size() << " test(s) registered." << std::endl;
+    std::cout << registry().size() + disabled_tests << " test(s) registered";
+    if (disabled_tests == 0) {
+        std::cout << "." << std::endl;
+    } else {
+        std::cout << ", " << disabled_tests << " disabled." << std::endl;
+    }
+
     auto const longest_name = std::max_element(registry().begin(), registry().end(), [](auto const &a, auto const &b) {
         return a.name.size() < b.name.size();
     });
@@ -71,6 +78,11 @@ int run_all_tests() noexcept {
 void test(std::string name, std::function<void()> body) noexcept {
     // TODO(robinlinden): push_back -> emplace_back once Clang supports it (C++20/p0960). Not supported as of Clang 13.
     registry().push_back({std::move(name), std::move(body)});
+}
+
+// TODO(robinlinden): Save and allow running these by passing some flag.
+void disabled_test(std::string, std::function<void()>) noexcept {
+    ++disabled_tests;
 }
 
 void expect(bool b, etest::source_location const &loc) noexcept {

--- a/etest/etest.h
+++ b/etest/etest.h
@@ -21,6 +21,7 @@ concept Printable = requires(std::ostream &os, T t) {
 
 [[nodiscard]] int run_all_tests() noexcept;
 void test(std::string name, std::function<void()> body) noexcept;
+void disabled_test(std::string name, std::function<void()> body) noexcept;
 
 // Weak test requirement. Allows the test to continue even if the check fails.
 void expect(bool, etest::source_location const &loc = etest::source_location::current()) noexcept;


### PR DESCRIPTION
@mkiael Think something like this is fine for now?

I'm hacking on a nicer abstraction that will allow testing this without a live web server to speak with, but this unblocks CI so we can continue merging things. It's been on my todo for a bit, but this makes it more important. :P