### PR TITLE
Improve link behaviour

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -53,13 +53,13 @@ std::string element_text(std::vector<dom::Node const *> const &dom_nodes) {
         return ""s;
     }
 
-    if (std::holds_alternative<dom::Text>(*dom_nodes[0])) {
-        return std::get<dom::Text>(*dom_nodes[0]).text;
-    }
-
     // Special handling of <a> because I want to see what link I'm hovering.
     if (auto uri = try_get_uri(dom_nodes); uri.has_value()) {
         return "a: "s + std::string{*uri};
+    }
+
+    if (std::holds_alternative<dom::Text>(*dom_nodes[0])) {
+        return std::get<dom::Text>(*dom_nodes[0]).text;
     }
 
     return std::get<dom::Element>(*dom_nodes[0]).name;

--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -70,9 +70,11 @@ std::optional<std::string_view> try_get_uri(std::vector<dom::Node const *> const
         return std::nullopt;
     }
 
-    auto const *element = std::get_if<dom::Element>(nodes[0]);
-    if (element && element->name == "a"sv && element->attributes.contains("href")) {
-        return element->attributes.at("href");
+    for (auto const *node : nodes) {
+        auto const *element = std::get_if<dom::Element>(node);
+        if (element && element->name == "a"sv && element->attributes.contains("href")) {
+            return element->attributes.at("href");
+        }
     }
 
     return std::nullopt;

--- a/browser/gui/app.h
+++ b/browser/gui/app.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace browser::gui {
 
@@ -68,7 +69,7 @@ private:
     void navigate();
     void layout();
 
-    dom::Node const *get_hovered_node(geom::Position document_position) const;
+    std::vector<dom::Node const *> get_hovered_nodes(geom::Position document_position) const;
     geom::Position to_document_position(geom::Position window_position) const;
 
     void reset_scroll();


### PR DESCRIPTION
With this change, any hovered link will have higher priority than any of its children, so `<a href="http://example.com>text</a>` will now show `a: http://example.com` and be clickable instead of displaying `text` and, well, not be clickable.