### PR TITLE
browser/gui: Render everything against a white background

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -403,7 +403,11 @@ void App::run_layout_widget() const {
 }
 
 void App::clear_render_surface() {
-    window_.clear();
+    if (render_debug_) {
+        window_.clear();
+    } else {
+        window_.clear(sf::Color(255, 255, 255));
+    }
 }
 
 void App::render_layout() {


### PR DESCRIPTION
Defaulting to a black background with black text doesn't work great on most websites.