### PR TITLE
gfx: Add struct for grouping border properties

### DIFF
--- a/gfx/canvas_command_saver.h
+++ b/gfx/canvas_command_saver.h
@@ -43,8 +43,7 @@ struct FillRectCmd {
 
 struct DrawBorderCmd {
     geom::Rect rect{};
-    geom::EdgeSize edge_size{};
-    BorderColor color{};
+    Borders borders{};
 
     [[nodiscard]] constexpr bool operator==(DrawBorderCmd const &) const = default;
 };
@@ -69,8 +68,8 @@ public:
     void set_scale(int scale) override { cmds_.emplace_back(SetScaleCmd{scale}); }
     void add_translation(int dx, int dy) override { cmds_.emplace_back(AddTranslationCmd{dx, dy}); }
     void fill_rect(geom::Rect const &rect, Color color) override { cmds_.emplace_back(FillRectCmd{rect, color}); }
-    void draw_border(geom::Rect const &rect, geom::EdgeSize const &edge_size, BorderColor const &color) override {
-        cmds_.emplace_back(DrawBorderCmd{rect, edge_size, color});
+    void draw_border(geom::Rect const &rect, Borders const &borders) override {
+        cmds_.emplace_back(DrawBorderCmd{rect, borders});
     }
     void draw_text(geom::Position position, std::string_view text, Font font, FontSize size, Color color) override {
         cmds_.emplace_back(DrawTextCmd{position, std::string{text}, std::string{font.font}, size.px, color});
@@ -91,7 +90,7 @@ public:
     constexpr void operator()(SetScaleCmd const &cmd) { canvas_.set_scale(cmd.scale); }
     constexpr void operator()(AddTranslationCmd const &cmd) { canvas_.add_translation(cmd.dx, cmd.dy); }
     constexpr void operator()(FillRectCmd const &cmd) { canvas_.fill_rect(cmd.rect, cmd.color); }
-    constexpr void operator()(DrawBorderCmd const &cmd) { canvas_.draw_border(cmd.rect, cmd.edge_size, cmd.color); }
+    constexpr void operator()(DrawBorderCmd const &cmd) { canvas_.draw_border(cmd.rect, cmd.borders); }
 
     void operator()(DrawTextCmd const &cmd) {
         canvas_.draw_text(cmd.position, cmd.text, {cmd.font}, {cmd.size}, cmd.color);

--- a/gfx/canvas_command_saver_test.cpp
+++ b/gfx/canvas_command_saver_test.cpp
@@ -57,8 +57,19 @@ int main() {
 
     etest::test("CanvasCommandSaver::draw_border", [] {
         CanvasCommandSaver saver;
-        saver.draw_border({1, 2, 3, 4}, {5, 6, 7, 8}, {});
-        expect_eq(saver.take_commands(), CanvasCommands{DrawBorderCmd{{1, 2, 3, 4}, {5, 6, 7, 8}, {}}});
+
+        Borders borders;
+        borders.left.color = Color::from_rgb(0xFF00FF);
+        borders.left.size = 10;
+        borders.right.color = Color::from_rgb(0xFF00FF);
+        borders.right.size = 10;
+        borders.top.color = Color::from_rgb(0xFF00FF);
+        borders.top.size = 20;
+        borders.bottom.color = Color::from_rgb(0xFF00FF);
+        borders.bottom.size = 10;
+
+        saver.draw_border({1, 2, 3, 4}, borders);
+        expect_eq(saver.take_commands(), CanvasCommands{DrawBorderCmd{{1, 2, 3, 4}, borders}});
     });
 
     etest::test("CanvasCommandSaver::draw_text", [] {
@@ -75,7 +86,7 @@ int main() {
         saver.set_scale(1);
         saver.add_translation(1234, 5678);
         saver.fill_rect({9, 9, 9, 9}, {0x12, 0x34, 0x56});
-        saver.draw_border({9, 9, 9, 9}, {5, 5, 5, 5}, {});
+        saver.draw_border({9, 9, 9, 9}, {});
         saver.draw_text({10, 10}, "beep beep boop!"sv, {"helvetica"}, {42}, {3, 2, 1});
         auto cmds = saver.take_commands();
 

--- a/gfx/icanvas.h
+++ b/gfx/icanvas.h
@@ -13,9 +13,15 @@
 
 namespace gfx {
 
-struct BorderColor {
-    Color left{}, right{}, top{}, bottom{};
-    [[nodiscard]] bool operator==(BorderColor const &) const = default;
+struct BorderProperties {
+    Color color{};
+    int size{};
+    [[nodiscard]] bool operator==(BorderProperties const &) const = default;
+};
+
+struct Borders {
+    BorderProperties left{}, right{}, top{}, bottom{};
+    [[nodiscard]] bool operator==(Borders const &) const = default;
 };
 
 class ICanvas {
@@ -26,7 +32,7 @@ public:
     virtual void set_scale(int scale) = 0;
     virtual void add_translation(int dx, int dy) = 0;
     virtual void fill_rect(geom::Rect const &, Color) = 0;
-    virtual void draw_border(geom::Rect const &, geom::EdgeSize const &, BorderColor const &) = 0;
+    virtual void draw_border(geom::Rect const &, Borders const &) = 0;
     virtual void draw_text(geom::Position, std::string_view, Font, FontSize, Color) = 0;
 };
 

--- a/gfx/opengl_canvas.h
+++ b/gfx/opengl_canvas.h
@@ -22,7 +22,7 @@ public:
     }
 
     void fill_rect(geom::Rect const &, Color) override;
-    void draw_border(geom::Rect const &, geom::EdgeSize const &, BorderColor const &) override {}
+    void draw_border(geom::Rect const &, Borders const &) override {}
     void draw_text(geom::Position, std::string_view, Font, FontSize, Color) override {}
 
 private:

--- a/gfx/painter.h
+++ b/gfx/painter.h
@@ -15,9 +15,7 @@ public:
 
     void fill_rect(geom::Rect const &rect, Color color) { canvas_.fill_rect(rect, color); }
 
-    void draw_border(geom::Rect const &rect, geom::EdgeSize const &size, BorderColor const &color) {
-        canvas_.draw_border(rect, size, color);
-    }
+    void draw_border(geom::Rect const &rect, Borders const &borders) { canvas_.draw_border(rect, borders); }
 
     void draw_text(geom::Position p, std::string_view text, Font font, FontSize size, Color color) {
         canvas_.draw_text(p, text, font, size, color);

--- a/gfx/sfml_canvas.cpp
+++ b/gfx/sfml_canvas.cpp
@@ -145,10 +145,11 @@ void SfmlCanvas::fill_rect(geom::Rect const &rect, Color color) {
     target_.draw(drawable);
 }
 
-void SfmlCanvas::draw_border(geom::Rect const &rect, geom::EdgeSize const &edge_size, BorderColor const &color) {
+void SfmlCanvas::draw_border(geom::Rect const &rect, Borders const &borders) {
     auto translated{rect.translated(tx_, ty_)};
     auto inner_rect{translated.scaled(scale_)};
-    auto outer_rect = inner_rect.expanded(edge_size);
+    auto outer_rect =
+            inner_rect.expanded({borders.left.size, borders.right.size, borders.top.size, borders.bottom.size});
 
     sf::RectangleShape drawable{{static_cast<float>(outer_rect.width), static_cast<float>(outer_rect.height)}};
     drawable.setPosition(static_cast<float>(outer_rect.x), static_cast<float>(outer_rect.y));
@@ -165,10 +166,10 @@ void SfmlCanvas::draw_border(geom::Rect const &rect, geom::EdgeSize const &edge_
     border_shader_.setUniform("outer_bottom_left", to_vec3(outer_rect.left(), outer_rect.bottom()));
     border_shader_.setUniform("outer_bottom_right", to_vec3(outer_rect.right(), outer_rect.bottom()));
 
-    border_shader_.setUniform("left_border_color", to_vec4(color.left));
-    border_shader_.setUniform("right_border_color", to_vec4(color.right));
-    border_shader_.setUniform("top_border_color", to_vec4(color.top));
-    border_shader_.setUniform("bottom_border_color", to_vec4(color.bottom));
+    border_shader_.setUniform("left_border_color", to_vec4(borders.left.color));
+    border_shader_.setUniform("right_border_color", to_vec4(borders.right.color));
+    border_shader_.setUniform("top_border_color", to_vec4(borders.top.color));
+    border_shader_.setUniform("bottom_border_color", to_vec4(borders.bottom.color));
 
     target_.draw(drawable, &border_shader_);
 }

--- a/gfx/sfml_canvas.h
+++ b/gfx/sfml_canvas.h
@@ -32,7 +32,7 @@ public:
     }
 
     void fill_rect(geom::Rect const &, Color) override;
-    void draw_border(geom::Rect const &, geom::EdgeSize const &, BorderColor const &) override;
+    void draw_border(geom::Rect const &, Borders const &) override;
     void draw_text(geom::Position, std::string_view, Font, FontSize, Color) override;
 
 private:

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -114,13 +114,25 @@ void render_borders(gfx::Painter &painter, layout::LayoutBox const &layout) {
     auto color = style::get_property(*layout.node, "color"sv).value_or(kDefaultColor);
     auto const &border_size = layout.dimensions.border;
     if (border_size.left > 0 || border_size.right > 0 || border_size.top > 0 || border_size.bottom > 0) {
-        gfx::BorderColor border_color{
+        gfx::BorderProperties left_prop{
                 parse_color(style::get_property(*layout.node, "border-left-color"sv).value_or(color)),
-                parse_color(style::get_property(*layout.node, "border-right-color"sv).value_or(color)),
-                parse_color(style::get_property(*layout.node, "border-top-color"sv).value_or(color)),
-                parse_color(style::get_property(*layout.node, "border-bottom-color"sv).value_or(color)),
+                border_size.left,
         };
-        painter.draw_border(layout.dimensions.padding_box(), border_size, border_color);
+        gfx::BorderProperties right_prop{
+                parse_color(style::get_property(*layout.node, "border-right-color"sv).value_or(color)),
+                border_size.right,
+        };
+        gfx::BorderProperties top_prop{
+                parse_color(style::get_property(*layout.node, "border-top-color"sv).value_or(color)),
+                border_size.top,
+        };
+        gfx::BorderProperties bottom_prop{
+                parse_color(style::get_property(*layout.node, "border-bottom-color"sv).value_or(color)),
+                border_size.bottom,
+        };
+
+        painter.draw_border(
+                layout.dimensions.padding_box(), gfx::Borders{left_prop, right_prop, top_prop, bottom_prop});
     }
 }
 


### PR DESCRIPTION
A struct for grouping border properties is added to make
the draw_border function signature a bit more compact.
Border properties will be extended with radius, style etc.