### PR TITLE
build: Drop support for Clang 12

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -67,15 +67,13 @@ build:linux --per_file_copt='external/xrender[:/]@-Wno-sign-compare'
 build:linux --per_file_copt='external/zlib[:/]@-Wno-format-nonliteral'
 build:linux --per_file_copt='external/zlib[:/]@-Wno-missing-declarations'
 
+# Bazel + Clang supports this really cool features where it checks that you're
+# not relying on transitive dependencies, so let's enable that!
+build:clang --features=layering_check
 build:clang --per_file_copt='external/boringssl[:/]@-Wno-extra-semi'
 build:clang --per_file_copt='external/boringssl[:/]@-Wno-gnu-binary-literal'
-
-build:clang13 --config=clang
-# Newer Bazel + Clang supports this really cool features where it checks that
-# you're not relying on transitive dependencies, so let's enable that!
-build:clang13 --features=layering_check
-build:clang13 --per_file_copt='external/libpng[:/]@-Wno-null-pointer-subtraction'
-build:clang13 --per_file_copt='external/libpng[:/]@-Wno-unused-but-set-variable'
+build:clang --per_file_copt='external/libpng[:/]@-Wno-null-pointer-subtraction'
+build:clang --per_file_copt='external/libpng[:/]@-Wno-unused-but-set-variable'
 
 build:gcc --per_file_copt='gfx:sfml_canvas@-Wno-implicit-fallthrough' # sfml leaks this into our code.
 build:gcc --per_file_copt='external/boringssl[:/]@-Wno-cast-function-type'
@@ -135,7 +133,6 @@ build:clang-cl --copt='-Wno-error'
 build:clang-cl --copt='-Wno-missing-field-initializers'
 build:clang-cl --copt='-Wno-unused-command-line-argument'
 
-# Currently only supported for Clang 13 and newer.
 build:libc++ --cxxopt=-stdlib=libc++
 build:libc++ --linkopt=-stdlib=libc++
 build:libc++ --copt=-D_LIBCPP_ENABLE_NODISCARD

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,39 +13,32 @@ jobs:
             os: ubuntu-22.04
             compiler: gcc
             version: 12
-            bazel: --config gcc12
-            apt: g++-12
-
-          - name: clang-12
-            os: ubuntu-20.04
-            compiler: clang
-            version: 12
-            bazel: --config clang --run_under="valgrind --leak-check=full --errors-for-leak-kinds=all --error-exitcode=1 --track-origins=yes --show-leak-kinds=all"
-            apt: valgrind
+            bazel: --config gcc12 --run_under="valgrind --leak-check=full --errors-for-leak-kinds=all --error-exitcode=1 --track-origins=yes --show-leak-kinds=all"
+            apt: g++-12 valgrind
 
           - name: clang-14-tsan
             os: ubuntu-22.04
             compiler: clang
             version: 14
-            bazel: --config clang13 --config tsan
+            bazel: --config clang --config tsan
 
           - name: clang-asan
             os: ubuntu-22.04
             compiler: clang
             version: 14
-            bazel: --config clang13 --config asan
+            bazel: --config clang --config asan
 
           - name: clang-ubsan
             os: ubuntu-22.04
             compiler: clang
             version: 14
-            bazel: --config clang13 --config ubsan
+            bazel: --config clang --config ubsan
 
           - name: clang-libc++
             os: ubuntu-22.04
             compiler: clang
             version: 14
-            bazel: --config clang13 --config libc++
+            bazel: --config clang --config libc++
             apt: libc++abi-14-dev libc++-14-dev
 
     steps:


### PR DESCRIPTION
We're currently experimenting with C++20's coroutine support, and it
doesn't seem to work with Clang 12. Ubuntu 20.04 is still supported
using GCC 10.