### PR TITLE
Move uri path normalization from the browser engine to the uri parser

### DIFF
--- a/browser/engine.cpp
+++ b/browser/engine.cpp
@@ -35,10 +35,6 @@ protocol::Error Engine::navigate(uri::Uri uri) {
         return status_code == 301 || status_code == 302 || status_code == 307 || status_code == 308;
     };
 
-    if (uri.path.empty()) {
-        uri.path = "/";
-    }
-
     if (uri.scheme.empty() && uri.authority.host.empty() && uri.path.starts_with('/')) {
         spdlog::info("Handling origin-relative URL {}", uri.uri);
         uri = uri::Uri::parse(fmt::format("{}://{}{}", uri_.scheme, uri_.authority.host, uri.uri)).value();
@@ -53,9 +49,6 @@ protocol::Error Engine::navigate(uri::Uri uri) {
                 uri_.uri,
                 response_.headers.get("Location").value());
         uri_ = *uri::Uri::parse(std::string(response_.headers.get("Location").value()));
-        if (uri_.path.empty()) {
-            uri_.path = "/";
-        }
         response_ = protocol_handler_->handle(uri_);
     }
 

--- a/browser/engine_test.cpp
+++ b/browser/engine_test.cpp
@@ -79,12 +79,8 @@ int main() {
     etest::test("origin-relative uri", [] {
         browser::Engine e{std::make_unique<FakeProtocolHandler>(protocol::Response{.err = protocol::Error::Ok})};
 
-        // TOOD(robinlinden)
-        // `/` being included as the path here is important as the uri-parser
-        // currently doesn't do normalization, and the browser engine patches
-        // the uri to work when the path is empty.
-        e.navigate(*uri::Uri::parse("hax://example.com/"));
-        expect_eq(e.uri(), *uri::Uri::parse("hax://example.com/"));
+        e.navigate(*uri::Uri::parse("hax://example.com"));
+        expect_eq(e.uri(), *uri::Uri::parse("hax://example.com"));
 
         e.navigate(*uri::Uri::parse("/test"));
         expect_eq(e.uri(), *uri::Uri::parse("hax://example.com/test"));

--- a/uri/uri.cpp
+++ b/uri/uri.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2021 David Zero <zero-one@zer0-one.net>
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -8,6 +9,18 @@
 #include <utility>
 
 namespace uri {
+namespace {
+
+// https://en.wikipedia.org/wiki/URI_normalization#Normalization_process
+void normalize(Uri &uri) {
+    // In presence of an authority component, an empty path component should be
+    // normalized to a path component of "/".
+    if (!uri.authority.empty() && uri.path.empty()) {
+        uri.path = "/";
+    }
+}
+
+} // namespace
 
 std::optional<Uri> Uri::parse(std::string uristr) {
     std::smatch match;
@@ -53,6 +66,9 @@ std::optional<Uri> Uri::parse(std::string uristr) {
             .fragment{match.str(9)},
     };
     uri.uri = std::move(uristr);
+
+    normalize(uri);
+
     return uri;
 }
 

--- a/uri/uri.h
+++ b/uri/uri.h
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2021 David Zero <zero-one@zer0-one.net>
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -15,6 +16,8 @@ struct Authority {
     std::string passwd;
     std::string host;
     std::string port;
+
+    [[nodiscard]] bool empty() const { return user.empty() && passwd.empty() && host.empty() && port.empty(); }
 
     [[nodiscard]] bool operator==(Authority const &) const = default;
 };

--- a/uri/uri_test.cpp
+++ b/uri/uri_test.cpp
@@ -18,6 +18,7 @@ int main() {
                 .uri = "https://example.com",
                 .scheme = "https",
                 .authority = {.host = "example.com"},
+                .path = "/",
         };
 
         expect(uri == expected);
@@ -29,6 +30,7 @@ int main() {
                 .uri = "https://gr.ht",
                 .scheme = "https",
                 .authority = {.host = "gr.ht"},
+                .path = "/",
         };
 
         expect(uri == expected);

--- a/uri/uri_test.cpp
+++ b/uri/uri_test.cpp
@@ -17,10 +17,7 @@ int main() {
         Uri expected{
                 .uri = "https://example.com",
                 .scheme = "https",
-                .authority =
-                        {
-                                .host = "example.com",
-                        },
+                .authority = {.host = "example.com"},
         };
 
         expect(uri == expected);
@@ -31,10 +28,7 @@ int main() {
         Uri expected{
                 .uri = "https://gr.ht",
                 .scheme = "https",
-                .authority =
-                        {
-                                .host = "gr.ht",
-                        },
+                .authority = {.host = "gr.ht"},
         };
 
         expect(uri == expected);


### PR DESCRIPTION
Part of #238