### PR TITLE
Reduce the number of places where we use exceptions

### DIFF
--- a/gfx/sfml_canvas.cpp
+++ b/gfx/sfml_canvas.cpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <system_error>
 
 using namespace std::literals;
 
@@ -81,10 +82,13 @@ constexpr std::string_view border_fragment_shader{
         }
         )"sv};
 
-auto get_font_dir_iterator(std::filesystem::path const &path) try {
-    return std::filesystem::recursive_directory_iterator(path);
-} catch (std::filesystem::filesystem_error const &) {
-    return std::filesystem::recursive_directory_iterator();
+std::filesystem::recursive_directory_iterator get_font_dir_iterator(std::filesystem::path const &path) {
+    std::error_code errc;
+    if (auto it = std::filesystem::recursive_directory_iterator(path, errc); !errc) {
+        return it;
+    }
+
+    return {};
 }
 
 // TODO(robinlinden): We should be looking at font names rather than filenames.

--- a/third_party/spdlog.BUILD
+++ b/third_party/spdlog.BUILD
@@ -10,6 +10,7 @@ cc_library(
     defines = [
         "SPDLOG_COMPILED_LIB",
         "SPDLOG_FMT_EXTERNAL",
+        "SPDLOG_NO_EXCEPTIONS",
     ],
     linkopts = select({
         "@platforms//os:linux": ["-lpthread"],


### PR DESCRIPTION
This is me dusting off my oldish wip `-fno-exceptions` branch. We can't quite build with it yet, but it's closer.

The main thing remaining is asio, which requires us to provide our own exception handler by defining a template function that's visible everywhere they want to throw.