### PR TITLE
ci: Only run CI for PRs and when manually triggered

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request, workflow_dispatch]
 name: ci
 jobs:
   linux-ci:


### PR DESCRIPTION
This saves us running CI on every push while still allowing us to manually trigger it on non-PR branches if we want.