### PR TITLE
Don't require heap allocations when doing map<string, T> lookups

### DIFF
--- a/css/parser.h
+++ b/css/parser.h
@@ -204,8 +204,9 @@ private:
         return {name, value};
     }
 
-    void add_declaration(
-            std::map<std::string, std::string> &declarations, std::string_view name, std::string_view value) const {
+    void add_declaration(std::map<std::string, std::string, std::less<>> &declarations,
+            std::string_view name,
+            std::string_view value) const {
         if (is_shorthand_edge_property(name)) {
             expand_edge_values(declarations, std::string{name}, value);
         } else if (name == "font") {
@@ -215,8 +216,9 @@ private:
         }
     }
 
-    void expand_edge_values(
-            std::map<std::string, std::string> &declarations, std::string property, std::string_view value) const {
+    void expand_edge_values(std::map<std::string, std::string, std::less<>> &declarations,
+            std::string property,
+            std::string_view value) const {
         std::string_view top = "", bottom = "", left = "", right = "";
         Tokenizer tokenizer(value, ' ');
         switch (tokenizer.size()) {
@@ -251,7 +253,7 @@ private:
         declarations.insert_or_assign(fmt::format("{}-right{}", property, post_fix), std::string{right});
     }
 
-    void expand_font(std::map<std::string, std::string> &declarations, std::string_view value) const {
+    void expand_font(std::map<std::string, std::string, std::less<>> &declarations, std::string_view value) const {
         Tokenizer tokenizer(value, ' ');
         if (tokenizer.size() == 1) {
             // TODO(mkiael): Handle system properties correctly. Just forward it for now.

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -27,7 +27,7 @@ namespace {
     return os;
 }
 
-auto const initial_font_values = std::map<std::string, std::string>{{"font-stretch", "normal"},
+auto const initial_font_values = std::map<std::string, std::string, std::less<>>{{"font-stretch", "normal"},
         {"font-variant", "normal"},
         {"font-weight", "normal"},
         {"line-height", "normal"},
@@ -46,7 +46,7 @@ auto const initial_font_values = std::map<std::string, std::string>{{"font-stret
         {"font-variant-position", "normal"},
         {"font-variant-east-asian", "normal"}};
 
-bool check_initial_font_values(std::map<std::string, std::string> declarations) {
+bool check_initial_font_values(std::map<std::string, std::string, std::less<>> declarations) {
     for (auto [property, value] : declarations) {
         auto it = initial_font_values.find(property);
         if (it != cend(initial_font_values) && it->second != value) {
@@ -57,7 +57,7 @@ bool check_initial_font_values(std::map<std::string, std::string> declarations) 
 }
 
 template<class KeyT, class ValueT>
-ValueT get_and_erase(std::map<KeyT, ValueT> &map, KeyT key) {
+ValueT get_and_erase(std::map<KeyT, ValueT, std::less<>> &map, KeyT key) {
     ValueT value = map[key];
     map.erase(key);
     return value;

--- a/css/rule.h
+++ b/css/rule.h
@@ -14,7 +14,7 @@ namespace css {
 
 struct Rule {
     std::vector<std::string> selectors;
-    std::map<std::string, std::string> declarations;
+    std::map<std::string, std::string, std::less<>> declarations;
     std::string media_query;
 };
 

--- a/dom/dom.h
+++ b/dom/dom.h
@@ -18,7 +18,7 @@ namespace dom {
 struct Text;
 struct Element;
 
-using AttrMap = std::map<std::string, std::string>;
+using AttrMap = std::map<std::string, std::string, std::less<>>;
 using Node = std::variant<Element, Text>;
 
 struct Text {


### PR DESCRIPTION
There is another map with string as the key in `//js`, but that's in `ast.h` which likely is going away in favour of `ast2.h`, so I didn't touch that.