### PR TITLE
os: Allow overriding the default scale

### DIFF
--- a/os/linux.cpp
+++ b/os/linux.cpp
@@ -32,9 +32,9 @@ std::vector<std::string> font_paths() {
 }
 
 unsigned active_window_scale_factor() {
-    // Qt, Gnome, and Elementary in that order.
+    // Hastur, Qt, Gnome, and Elementary in that order.
     // Environment variables from https://wiki.archlinux.org/title/HiDPI#GUI_toolkits
-    for (auto *env_var : std::array{"QT_SCALE_FACTOR", "GDK_SCALE", "ELM_SCALE"}) {
+    for (auto *env_var : std::array{"HST_SCALE", "QT_SCALE_FACTOR", "GDK_SCALE", "ELM_SCALE"}) {
         if (char const *scale = std::getenv(env_var)) {
             int result{};
             if (std::from_chars(scale, scale + std::strlen(scale), result).ec == std::errc{}) {

--- a/os/linux_test.cpp
+++ b/os/linux_test.cpp
@@ -18,6 +18,7 @@ using etest::expect_eq;
 
 int main() {
     // Ensure that the system's environment doesn't affect the test result.
+    unsetenv("HST_SCALE");
     unsetenv("QT_SCALE_FACTOR");
     unsetenv("GDK_SCALE");
     unsetenv("ELM_SCALE");
@@ -34,6 +35,9 @@ int main() {
 
         setenv("QT_SCALE_FACTOR", "10", false);
         expect_eq(os::active_window_scale_factor(), 10u);
+
+        setenv("HST_SCALE", "50", false);
+        expect_eq(os::active_window_scale_factor(), 50u);
     });
 
     return etest::run_all_tests();

--- a/os/windows.cpp
+++ b/os/windows.cpp
@@ -23,7 +23,10 @@
 #include <Shlobj.h>
 #include <shellscalingapi.h>
 
+#include <charconv>
 #include <cmath>
+#include <cstdlib>
+#include <cstring>
 #include <cwchar>
 
 namespace os {
@@ -41,6 +44,12 @@ std::vector<std::string> font_paths() {
 }
 
 unsigned active_window_scale_factor() {
+    if (auto const *env_var = std::getenv("HST_SCALE")) {
+        if (int result{}; std::from_chars(env_var, env_var + std::strlen(env_var), result).ec == std::errc{}) {
+            return result;
+        }
+    }
+
     DEVICE_SCALE_FACTOR scale_factor{};
     if (GetScaleFactorForMonitor(MonitorFromWindow(GetActiveWindow(), MONITOR_DEFAULTTONEAREST), &scale_factor)
             != S_OK) {


### PR DESCRIPTION
This patch makes it possible to set the default scale by setting the
environment variable `HST_SCALE`.