### PR TITLE
html2: Drop use of spdlog

### DIFF
--- a/html2/BUILD
+++ b/html2/BUILD
@@ -13,7 +13,6 @@ cc_library(
         "//util:overloaded",
         "//util:string",
         "//util:unicode",
-        "@spdlog",
     ],
 )
 

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -8,8 +8,6 @@
 #include "util/string.h"
 #include "util/unicode.h"
 
-#include <spdlog/spdlog.h>
-
 #include <cstdint>
 #include <cstring>
 #include <exception>
@@ -123,12 +121,6 @@ void Tokenizer::set_state(State state) {
 
 void Tokenizer::run() {
     while (true) {
-        if (input_.size() > pos_) {
-            spdlog::trace("Running state {} w/ next char {}", static_cast<int>(state_), input_[pos_]);
-        } else {
-            spdlog::trace("Running state {} after input end", static_cast<int>(state_));
-        }
-
         switch (state_) {
             case State::Data: {
                 auto c = consume_next_input_character();

--- a/html2/tree_constructor.cpp
+++ b/html2/tree_constructor.cpp
@@ -6,8 +6,6 @@
 
 #include "dom2/document_type.h"
 
-#include <spdlog/spdlog.h>
-
 #include <exception>
 #include <functional>
 #include <string_view>
@@ -29,7 +27,6 @@ void TreeConstructor::run(std::vector<Token> tokens) {
 }
 
 void TreeConstructor::on_token(Tokenizer &, Token &&token) {
-    spdlog::error("{}: {}", static_cast<int>(mode_), to_string(token));
     switch (mode_) {
         // https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode
         case InsertionMode::Initial: {


### PR DESCRIPTION
It doesn't really add any value here as we abort in unhandled cases, and
errors are propagated to the caller for them to log if they wish.