### PR TITLE
all: Move the string out of stringstreams whenever possible

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -89,7 +89,7 @@ std::string stylesheet_to_string(std::vector<css::Rule> const &stylesheet) {
     for (auto const &rule : stylesheet) {
         ss << css::to_string(rule) << std::endl;
     }
-    return ss.str();
+    return std::move(ss).str();
 }
 
 // Returns a vector containing [child, child->parent, child->parent->parent, ...].

--- a/css/rule.cpp
+++ b/css/rule.cpp
@@ -5,6 +5,7 @@
 #include "css/rule.h"
 
 #include <sstream>
+#include <utility>
 
 namespace css {
 
@@ -29,7 +30,7 @@ std::string to_string(Rule const &rule) {
         ss << "Media query:\n";
         ss << "  " << rule.media_query << '\n';
     }
-    return ss.str();
+    return std::move(ss).str();
 }
 
 } // namespace css

--- a/dom/dom.cpp
+++ b/dom/dom.cpp
@@ -14,6 +14,7 @@
 #include <iterator>
 #include <ostream>
 #include <sstream>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -42,7 +43,7 @@ std::string to_string(Document const &document) {
     std::stringstream ss;
     ss << "doctype: " << document.doctype << '\n';
     print_node(document.html_node, ss);
-    return ss.str();
+    return std::move(ss).str();
 }
 
 std::vector<Element const *> nodes_by_path(std::reference_wrapper<Node const> root, std::string_view path) {

--- a/etest/etest.cpp
+++ b/etest/etest.cpp
@@ -48,7 +48,6 @@ int run_all_tests() noexcept {
 
     for (auto const &test : registry()) {
         std::cout << std::left << std::setw(longest_name->name.size()) << test.name << ": ";
-        test_log = std::stringstream{};
 
         int const before = assertion_failures;
 
@@ -68,7 +67,7 @@ int run_all_tests() noexcept {
             std::cout << "\u001b[32mPASSED\u001b[0m\n";
         } else {
             std::cout << "\u001b[31;1mFAILED\u001b[0m\n";
-            std::cout << test_log.str();
+            std::cout << std::exchange(test_log, {}).str();
         }
     }
 

--- a/html/parser.cpp
+++ b/html/parser.cpp
@@ -124,8 +124,7 @@ void Parser::operator()(html2::EndOfFileToken const &) {
 
 void Parser::generate_text_node_if_needed() {
     assert(!open_elements_.empty());
-    auto text = current_text_.str();
-    current_text_ = std::stringstream{};
+    auto text = std::exchange(current_text_, {}).str();
     bool is_uninteresting = std::all_of(cbegin(text), cend(text), [](unsigned char c) { return std::isspace(c); });
     if (is_uninteresting) {
         return;

--- a/html2/token.cpp
+++ b/html2/token.cpp
@@ -10,6 +10,7 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <variant>
 
 namespace html2 {
@@ -38,7 +39,7 @@ std::string to_string(Token const &token) {
                        [&ss](EndOfFileToken const &) { ss << "EndOfFile"; },
                },
             token);
-    return ss.str();
+    return std::move(ss).str();
 }
 
 } // namespace html2

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -277,13 +277,13 @@ std::string_view to_str(dom::Node const &node) {
 std::string to_str(geom::Rect const &rect) {
     std::stringstream ss;
     ss << "{" << rect.x << "," << rect.y << "," << rect.width << "," << rect.height << "}";
-    return ss.str();
+    return std::move(ss).str();
 }
 
 std::string to_str(geom::EdgeSize const &edge) {
     std::stringstream ss;
     ss << "{" << edge.top << "," << edge.right << "," << edge.bottom << "," << edge.left << "}";
-    return ss.str();
+    return std::move(ss).str();
 }
 
 void print_box(LayoutBox const &box, std::ostream &os, uint8_t depth = 0) {
@@ -334,7 +334,7 @@ LayoutBox const *box_at_position(LayoutBox const &box, geom::Position p) {
 std::string to_string(LayoutBox const &box) {
     std::stringstream ss;
     print_box(box, ss);
-    return ss.str();
+    return std::move(ss).str();
 }
 
 } // namespace layout

--- a/protocol/http.cpp
+++ b/protocol/http.cpp
@@ -11,6 +11,7 @@
 
 #include <charconv>
 #include <sstream>
+#include <utility>
 
 using namespace std::string_view_literals;
 
@@ -40,7 +41,7 @@ std::string Http::create_get_request(uri::Uri const &uri) {
     ss << "Accept: text/html\r\n";
     ss << "Connection: close\r\n\r\n";
 
-    return ss.str();
+    return std::move(ss).str();
 }
 
 std::optional<StatusLine> Http::parse_status_line(std::string_view status_line) {

--- a/protocol/response.cpp
+++ b/protocol/response.cpp
@@ -9,6 +9,7 @@
 
 #include <cctype>
 #include <sstream>
+#include <utility>
 
 namespace protocol {
 
@@ -28,7 +29,7 @@ std::string Headers::to_string() const {
     for (auto const &[name, value] : headers_) {
         ss << name << ": " << value << "\n";
     }
-    return ss.str();
+    return std::move(ss).str();
 }
 
 std::size_t Headers::size() const {


### PR DESCRIPTION
`std::stringstream` has a moving rvalue overload of `str()` since C++20, so let's use that when possible.