### PR TITLE
Add locale-independent character helpers to `//util:string`

### DIFF
--- a/html/BUILD
+++ b/html/BUILD
@@ -14,6 +14,7 @@ cc_library(
     deps = [
         "//dom",
         "//html2",
+        "//util:string",
         "@spdlog",
     ],
 )

--- a/html/parser.cpp
+++ b/html/parser.cpp
@@ -4,12 +4,13 @@
 
 #include "html/parser.h"
 
+#include "util/string.h"
+
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <cctype>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -125,7 +126,7 @@ void Parser::operator()(html2::EndOfFileToken const &) {
 void Parser::generate_text_node_if_needed() {
     assert(!open_elements_.empty());
     auto text = std::exchange(current_text_, {}).str();
-    bool is_uninteresting = std::all_of(cbegin(text), cend(text), [](unsigned char c) { return std::isspace(c); });
+    bool is_uninteresting = std::all_of(cbegin(text), cend(text), [](char c) { return util::is_whitespace(c); });
     if (is_uninteresting) {
         return;
     }

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -41,42 +41,6 @@ constexpr bool is_ascii_whitespace(int code_point) {
     }
 }
 
-constexpr bool is_ascii_upper_alpha(char c) {
-    return c >= 'A' && c <= 'Z';
-}
-
-constexpr bool is_ascii_lower_alpha(char c) {
-    return c >= 'a' && c <= 'z';
-}
-
-constexpr bool is_ascii_alpha(char c) {
-    return is_ascii_upper_alpha(c) || is_ascii_lower_alpha(c);
-}
-
-constexpr bool is_ascii_digit(char c) {
-    return c >= '0' && c <= '9';
-}
-
-constexpr bool is_ascii_alphanumeric(char c) {
-    return is_ascii_digit(c) || is_ascii_alpha(c);
-}
-
-constexpr bool is_ascii_upper_hex_digit(char c) {
-    return is_ascii_digit(c) || (c >= 'A' && c <= 'F');
-}
-
-constexpr bool is_ascii_lower_hex_digit(char c) {
-    return is_ascii_digit(c) || (c >= 'a' && c <= 'f');
-}
-
-constexpr bool is_ascii_hex_digit(char c) {
-    return is_ascii_upper_hex_digit(c) || is_ascii_lower_hex_digit(c);
-}
-
-constexpr char to_lower(char c) {
-    return c + 0x20;
-}
-
 // https://infra.spec.whatwg.org/#surrogate
 constexpr bool is_unicode_surrogate(int code_point) {
     return code_point >= 0xD800 && code_point <= 0xDFFF;
@@ -194,7 +158,7 @@ void Tokenizer::run() {
                     return;
                 }
 
-                if (is_ascii_alpha(*c)) {
+                if (util::is_alpha(*c)) {
                     current_token_ = StartTagToken{};
                     reconsume_in(State::TagName);
                     continue;
@@ -226,7 +190,7 @@ void Tokenizer::run() {
                     return;
                 }
 
-                if (is_ascii_alpha(*c)) {
+                if (util::is_alpha(*c)) {
                     current_token_ = EndTagToken{};
                     reconsume_in(State::TagName);
                     continue;
@@ -251,8 +215,8 @@ void Tokenizer::run() {
                     }
                 };
 
-                if (is_ascii_upper_alpha(*c)) {
-                    append_to_tag_name(to_lower(*c));
+                if (util::is_upper_alpha(*c)) {
+                    append_to_tag_name(util::to_lower(*c));
                     continue;
                 }
 
@@ -307,7 +271,7 @@ void Tokenizer::run() {
 
             case State::ScriptDataEndTagOpen: {
                 auto c = consume_next_input_character();
-                if (c && is_ascii_alpha(*c)) {
+                if (c && util::is_alpha(*c)) {
                     current_token_ = EndTagToken{};
                     reconsume_in(State::ScriptDataEndTagName);
                     continue;
@@ -334,13 +298,13 @@ void Tokenizer::run() {
                     continue;
                 }
 
-                if (is_ascii_upper_alpha(*c)) {
-                    std::get<EndTagToken>(current_token_).tag_name.append(1, to_lower(*c));
+                if (util::is_upper_alpha(*c)) {
+                    std::get<EndTagToken>(current_token_).tag_name.append(1, util::to_lower(*c));
                     temporary_buffer_.append(1, *c);
                     continue;
                 }
 
-                if (is_ascii_lower_alpha(*c)) {
+                if (util::is_lower_alpha(*c)) {
                     std::get<EndTagToken>(current_token_).tag_name.append(1, *c);
                     temporary_buffer_.append(1, *c);
                     continue;
@@ -507,7 +471,7 @@ void Tokenizer::run() {
                     continue;
                 }
 
-                if (c && is_ascii_alpha(*c)) {
+                if (c && util::is_alpha(*c)) {
                     temporary_buffer_ = "";
                     emit(CharacterToken{'<'});
                     reconsume_in(State::ScriptDataDoubleEscapeStart);
@@ -521,7 +485,7 @@ void Tokenizer::run() {
 
             case State::ScriptDataEscapedEndTagOpen: {
                 auto c = consume_next_input_character();
-                if (c && is_ascii_alpha(*c)) {
+                if (c && util::is_alpha(*c)) {
                     current_token_ = EndTagToken{};
                     reconsume_in(State::ScriptDataEscapedEndTagName);
                     continue;
@@ -548,13 +512,13 @@ void Tokenizer::run() {
                     continue;
                 }
 
-                if (is_ascii_upper_alpha(*c)) {
-                    std::get<EndTagToken>(current_token_).tag_name.append(1, to_lower(*c));
+                if (util::is_upper_alpha(*c)) {
+                    std::get<EndTagToken>(current_token_).tag_name.append(1, util::to_lower(*c));
                     temporary_buffer_.append(1, *c);
                     continue;
                 }
 
-                if (is_ascii_lower_alpha(*c)) {
+                if (util::is_lower_alpha(*c)) {
                     std::get<EndTagToken>(current_token_).tag_name.append(1, *c);
                     temporary_buffer_.append(1, *c);
                     continue;
@@ -599,13 +563,13 @@ void Tokenizer::run() {
                     continue;
                 }
 
-                if (is_ascii_upper_alpha(*c)) {
-                    temporary_buffer_.append(1, to_lower(*c));
+                if (util::is_upper_alpha(*c)) {
+                    temporary_buffer_.append(1, util::to_lower(*c));
                     emit(CharacterToken{*c});
                     continue;
                 }
 
-                if (is_ascii_lower_alpha(*c)) {
+                if (util::is_lower_alpha(*c)) {
                     temporary_buffer_.append(1, *c);
                     emit(CharacterToken{*c});
                     continue;
@@ -739,13 +703,13 @@ void Tokenizer::run() {
                     continue;
                 }
 
-                if (is_ascii_upper_alpha(*c)) {
-                    temporary_buffer_.append(1, to_lower(*c));
+                if (util::is_upper_alpha(*c)) {
+                    temporary_buffer_.append(1, util::to_lower(*c));
                     emit(CharacterToken{*c});
                     continue;
                 }
 
-                if (is_ascii_lower_alpha(*c)) {
+                if (util::is_lower_alpha(*c)) {
                     temporary_buffer_.append(1, *c);
                     emit(CharacterToken{*c});
                     continue;
@@ -811,8 +775,8 @@ void Tokenizer::run() {
                     }
                 };
 
-                if (is_ascii_upper_alpha(*c)) {
-                    append_to_current_attribute_name(to_lower(*c));
+                if (util::is_upper_alpha(*c)) {
+                    append_to_current_attribute_name(util::to_lower(*c));
                     continue;
                 }
 
@@ -1306,9 +1270,9 @@ void Tokenizer::run() {
                     return;
                 }
 
-                if (is_ascii_upper_alpha(*c)) {
+                if (util::is_upper_alpha(*c)) {
                     current_token_ = DoctypeToken{.name = std::string{}};
-                    std::get<DoctypeToken>(current_token_).name->append(1, to_lower(*c));
+                    std::get<DoctypeToken>(current_token_).name->append(1, util::to_lower(*c));
                     state_ = State::DoctypeName;
                     continue;
                 }
@@ -1349,8 +1313,8 @@ void Tokenizer::run() {
                     return;
                 }
 
-                if (is_ascii_upper_alpha(*c)) {
-                    std::get<DoctypeToken>(current_token_).name->append(1, to_lower(*c));
+                if (util::is_upper_alpha(*c)) {
+                    std::get<DoctypeToken>(current_token_).name->append(1, util::to_lower(*c));
                     continue;
                 }
 
@@ -1615,7 +1579,7 @@ void Tokenizer::run() {
                     continue;
                 }
 
-                if (is_ascii_alphanumeric(*c)) {
+                if (util::is_alphanumeric(*c)) {
                     reconsume_in(State::NamedCharacterReference);
                     continue;
                 }
@@ -1648,7 +1612,7 @@ void Tokenizer::run() {
 
                 auto c = peek_next_input_character();
                 if (c.has_value() && consumed_as_part_of_an_attribute() && temporary_buffer_.back() != ';'
-                        && (c == '=' || is_ascii_alphanumeric(*c))) {
+                        && (c == '=' || util::is_alphanumeric(*c))) {
                     flush_code_points_consumed_as_a_character_reference();
                     state_ = return_state_;
                     continue;
@@ -1676,7 +1640,7 @@ void Tokenizer::run() {
                     continue;
                 }
 
-                if (is_ascii_alphanumeric(*c)) {
+                if (util::is_alphanumeric(*c)) {
                     if (consumed_as_part_of_an_attribute()) {
                         current_attribute().value += *c;
                     } else {
@@ -1715,7 +1679,7 @@ void Tokenizer::run() {
 
             case State::HexadecimalCharacterReferenceStart: {
                 auto c = consume_next_input_character();
-                if (c && is_ascii_hex_digit(*c)) {
+                if (c && util::is_hex_digit(*c)) {
                     reconsume_in(State::HexadecimalCharacterReference);
                     continue;
                 }
@@ -1728,7 +1692,7 @@ void Tokenizer::run() {
 
             case State::DecimalCharacterReferenceStart: {
                 auto c = consume_next_input_character();
-                if (!c || !is_ascii_digit(*c)) {
+                if (!c || !util::is_digit(*c)) {
                     // This is an absence-of-digits-in-numeric-character-reference parse error.
                     flush_code_points_consumed_as_a_character_reference();
                     reconsume_in(return_state_);
@@ -1747,19 +1711,19 @@ void Tokenizer::run() {
                     continue;
                 }
 
-                if (is_ascii_digit(*c)) {
+                if (util::is_digit(*c)) {
                     character_reference_code_ *= 16;
                     character_reference_code_ += *c - 0x30;
                     continue;
                 }
 
-                if (is_ascii_upper_hex_digit(*c)) {
+                if (util::is_upper_hex_digit(*c)) {
                     character_reference_code_ *= 16;
                     character_reference_code_ += *c - 0x37;
                     continue;
                 }
 
-                if (is_ascii_lower_hex_digit(*c)) {
+                if (util::is_lower_hex_digit(*c)) {
                     character_reference_code_ *= 16;
                     character_reference_code_ += *c - 0x57;
                     continue;
@@ -1783,7 +1747,7 @@ void Tokenizer::run() {
                     continue;
                 }
 
-                if (is_ascii_digit(*c)) {
+                if (util::is_digit(*c)) {
                     character_reference_code_ *= 10;
                     character_reference_code_ += *c - 0x30;
                     continue;

--- a/protocol/response.cpp
+++ b/protocol/response.cpp
@@ -1,13 +1,14 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "protocol/response.h"
 
+#include "util/string.h"
+
 #include <range/v3/algorithm/lexicographical_compare.hpp>
 
-#include <cctype>
 #include <sstream>
 #include <utility>
 
@@ -38,7 +39,7 @@ std::size_t Headers::size() const {
 
 bool Headers::CaseInsensitiveLess::operator()(std::string_view s1, std::string_view s2) const {
     return ranges::lexicographical_compare(
-            s1, s2, [](unsigned char c1, unsigned char c2) { return std::tolower(c1) < std::tolower(c2); });
+            s1, s2, [](char c1, char c2) { return util::to_lower(c1) < util::to_lower(c2); });
 }
 
 } // namespace protocol

--- a/render/BUILD
+++ b/render/BUILD
@@ -10,6 +10,7 @@ cc_library(
         "//gfx",
         "//layout",
         "//style",
+        "//util:string",
         "@range-v3",
         "@spdlog",
     ],

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -8,11 +8,11 @@
 #include "dom/dom.h"
 #include "gfx/color.h"
 #include "style/style.h"
+#include "util/string.h"
 
 #include <range/v3/algorithm/lexicographical_compare.hpp>
 #include <spdlog/spdlog.h>
 
-#include <cctype>
 #include <charconv>
 #include <cstdint>
 #include <map>
@@ -31,7 +31,7 @@ struct CaseInsensitiveLess {
     using is_transparent = void;
     bool operator()(std::string_view s1, std::string_view s2) const {
         return ranges::lexicographical_compare(
-                s1, s2, [](unsigned char c1, unsigned char c2) { return std::tolower(c1) < std::tolower(c2); });
+                s1, s2, [](char c1, char c2) { return util::to_lower(c1) < util::to_lower(c2); });
     }
 };
 

--- a/util/string.h
+++ b/util/string.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -16,6 +16,46 @@
 #include <vector>
 
 namespace util {
+
+constexpr bool is_upper_alpha(char c) {
+    return c >= 'A' && c <= 'Z';
+}
+
+constexpr bool is_lower_alpha(char c) {
+    return c >= 'a' && c <= 'z';
+}
+
+constexpr bool is_alpha(char c) {
+    return is_upper_alpha(c) || is_lower_alpha(c);
+}
+
+constexpr bool is_digit(char c) {
+    return c >= '0' && c <= '9';
+}
+
+constexpr bool is_alphanumeric(char c) {
+    return is_digit(c) || is_alpha(c);
+}
+
+constexpr bool is_upper_hex_digit(char c) {
+    return is_digit(c) || (c >= 'A' && c <= 'F');
+}
+
+constexpr bool is_lower_hex_digit(char c) {
+    return is_digit(c) || (c >= 'a' && c <= 'f');
+}
+
+constexpr bool is_hex_digit(char c) {
+    return is_upper_hex_digit(c) || is_lower_hex_digit(c);
+}
+
+constexpr char to_lower(char c) {
+    if (!is_upper_alpha(c)) {
+        return c;
+    }
+
+    return c + ('a' - 'A');
+}
 
 constexpr bool no_case_compare(std::string_view a, std::string_view b) {
     return ranges::equal(a, b, [](auto c1, auto c2) { return std::tolower(c1) == std::tolower(c2); });

--- a/util/string.h
+++ b/util/string.h
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cctype>
 #include <iterator>
 #include <string_view>
 #include <vector>
@@ -58,7 +57,7 @@ constexpr char to_lower(char c) {
 }
 
 constexpr bool no_case_compare(std::string_view a, std::string_view b) {
-    return ranges::equal(a, b, [](auto c1, auto c2) { return std::tolower(c1) == std::tolower(c2); });
+    return ranges::equal(a, b, [](auto c1, auto c2) { return to_lower(c1) == to_lower(c2); });
 }
 
 inline std::vector<std::string_view> split(std::string_view str, std::string_view sep) {

--- a/util/string_test.cpp
+++ b/util/string_test.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2021 Mikael Larsson <c.mikael.larsson@gmail.com>
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -14,6 +15,51 @@ using etest::expect_eq;
 using etest::require;
 
 int main() {
+    etest::test("is_upper_alpha", [] {
+        expect(is_upper_alpha('A'));
+        expect(!is_upper_alpha('a'));
+    });
+
+    etest::test("is_lower_alpha", [] {
+        expect(is_lower_alpha('a'));
+        expect(!is_lower_alpha('A'));
+    });
+
+    etest::test("is_alpha", [] {
+        expect(is_alpha('a'));
+        expect(!is_alpha('!'));
+    });
+
+    etest::test("is_digit", [] {
+        expect(is_digit('0'));
+        expect(!is_digit('a'));
+    });
+
+    etest::test("is_alphanumeric", [] {
+        expect(is_alphanumeric('a'));
+        expect(!is_alphanumeric('!'));
+    });
+
+    etest::test("is_upper_hex_digit", [] {
+        expect(is_upper_hex_digit('F'));
+        expect(!is_upper_hex_digit('f'));
+    });
+
+    etest::test("is_lower_hex_digit", [] {
+        expect(is_lower_hex_digit('f'));
+        expect(!is_lower_hex_digit('F'));
+    });
+
+    etest::test("is_hex_digit", [] {
+        expect(is_hex_digit('f'));
+        expect(!is_hex_digit('!'));
+    });
+
+    etest::test("to_lower", [] {
+        expect_eq(to_lower('A'), 'a');
+        expect_eq(to_lower('a'), 'a');
+    });
+
     etest::test("no case compare", [] {
         expect(no_case_compare("word"sv, "word"sv));
         expect(no_case_compare("WORD"sv, "WORD"sv));


### PR DESCRIPTION
We had a bunch of issues if the locale wasn't the default `C` one, so I replaced the sort of error-prone `<cctype>` functions with the constexpr versions of them we were already using in `html2`.