### PR TITLE
browser/gui: Add support for simple navigation history

### DIFF
--- a/browser/BUILD
+++ b/browser/BUILD
@@ -37,6 +37,7 @@ cc_binary(
         "//protocol",
         "//render",
         "//uri",
+        "//util:history",
         "@fmt",
         "@imgui",
         "@imgui-sfml",

--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -180,6 +180,35 @@ int App::run() {
                             switch_canvas();
                             break;
                         }
+                        case sf::Keyboard::Key::Left: {
+                            if (!event.key.alt) {
+                                break;
+                            }
+
+                            auto entry = browse_history_.previous();
+                            if (!entry) {
+                                break;
+                            }
+
+                            browse_history_.pop();
+                            url_buf_ = entry->uri;
+                            navigate();
+                            break;
+                        }
+                        case sf::Keyboard::Key::Right: {
+                            if (!event.key.alt) {
+                                break;
+                            }
+
+                            auto entry = browse_history_.next();
+                            if (!entry) {
+                                break;
+                            }
+
+                            url_buf_ = entry->uri;
+                            navigate();
+                            break;
+                        }
                         default:
                             break;
                     }
@@ -269,6 +298,7 @@ void App::navigate() {
         return;
     }
 
+    browse_history_.push(*uri);
     engine_.navigate(std::move(*uri));
 
     // Make sure the displayed url is still correct if we followed any redirects.

--- a/browser/gui/app.h
+++ b/browser/gui/app.h
@@ -11,6 +11,8 @@
 #include "gfx/sfml_canvas.h"
 #include "layout/layout.h"
 #include "protocol/handler_factory.h"
+#include "uri/uri.h"
+#include "util/history.h"
 
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/System/Clock.hpp>
@@ -61,6 +63,8 @@ private:
     bool render_debug_{};
 
     unsigned scale_{1};
+
+    util::History<uri::Uri> browse_history_;
 
     void on_navigation_failure(protocol::Error);
     void on_page_loaded();

--- a/util/history.h
+++ b/util/history.h
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef UTIL_HISTORY_H_
+#define UTIL_HISTORY_H_
+
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace util {
+
+template<typename T>
+class History {
+public:
+    constexpr void push(T entry) {
+        // Are we already on this entry?
+        if (current_index_ >= 0 && entries_[current_index_] == entry) {
+            return;
+        }
+
+        current_index_ += 1;
+
+        // Does the entry already exist in the history where we want it to be?
+        if (static_cast<std::size_t>(current_index_) < entries_.size() && entries_[current_index_] == entry) {
+            return;
+        }
+
+        // Does the entry require more space in the list?
+        if (static_cast<std::size_t>(current_index_) == entries_.size()) {
+            entries_.push_back(std::move(entry));
+            return;
+        }
+
+        // This entry should go in the middle of the history. Add it and nuke everything after it.
+        entries_[current_index_] = std::move(entry);
+        entries_.erase(cbegin(entries_) + current_index_ + 1, cend(entries_));
+    }
+
+    constexpr std::optional<T> pop() {
+        if (current_index_ >= 0) {
+            return entries_[std::exchange(current_index_, current_index_ - 1)];
+        }
+
+        return std::nullopt;
+    }
+
+    constexpr std::optional<T> previous() const {
+        if (auto previous_index = current_index_ - 1; previous_index >= 0) {
+            return entries_[previous_index];
+        }
+
+        return std::nullopt;
+    }
+
+    constexpr std::optional<T> current() const {
+        if (current_index_ >= 0 && static_cast<std::size_t>(current_index_) < entries_.size()) {
+            return entries_[current_index_];
+        }
+
+        return std::nullopt;
+    }
+
+    constexpr std::optional<T> next() const {
+        if (auto next_index = static_cast<std::size_t>(current_index_ + 1); next_index < entries_.size()) {
+            return entries_[next_index];
+        }
+
+        return std::nullopt;
+    }
+
+    constexpr std::vector<T> const &entries() const { return entries_; }
+
+private:
+    int current_index_{-1};
+    std::vector<T> entries_;
+};
+
+} // namespace util
+
+#endif

--- a/util/history_test.cpp
+++ b/util/history_test.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "util/history.h"
+
+#include "etest/etest.h"
+
+#include <optional>
+#include <vector>
+
+using etest::expect_eq;
+using util::History;
+
+int main() {
+    etest::test("no history", [] {
+        History<int> h;
+        expect_eq(h.current(), std::nullopt);
+        expect_eq(h.next(), std::nullopt);
+        expect_eq(h.previous(), std::nullopt);
+        expect_eq(h.pop(), std::nullopt);
+    });
+
+    etest::test("pushing", [] {
+        History<int> h;
+
+        h.push(1);
+        expect_eq(h.current(), 1);
+        expect_eq(h.next(), std::nullopt);
+        expect_eq(h.previous(), std::nullopt);
+
+        h.push(2);
+        expect_eq(h.current(), 2);
+        expect_eq(h.next(), std::nullopt);
+        expect_eq(h.previous(), 1);
+    });
+
+    etest::test("popping", [] {
+        History<int> h;
+
+        h.push(1);
+        h.push(2);
+
+        expect_eq(h.pop(), 2);
+        expect_eq(h.current(), 1);
+        expect_eq(h.next(), 2);
+        expect_eq(h.previous(), std::nullopt);
+
+        expect_eq(h.pop(), 1);
+        expect_eq(h.current(), std::nullopt);
+        expect_eq(h.next(), 1);
+        expect_eq(h.previous(), std::nullopt);
+
+        expect_eq(h.pop(), std::nullopt);
+        expect_eq(h.current(), std::nullopt);
+        expect_eq(h.next(), 1);
+        expect_eq(h.previous(), std::nullopt);
+    });
+
+    etest::test("rewriting history", [] {
+        History<int> h;
+
+        h.push(1);
+        h.push(2);
+        h.push(3);
+        h.push(4);
+
+        expect_eq(h.pop(), 4);
+        expect_eq(h.pop(), 3);
+        h.push(5);
+
+        expect_eq(h.current(), 5);
+        expect_eq(h.next(), std::nullopt);
+        expect_eq(h.previous(), 2);
+        expect_eq(h.entries(), std::vector<int>{1, 2, 5});
+    });
+
+    etest::test("duplicate entries aren't added", [] {
+        History<int> h;
+
+        h.push(1);
+        h.push(1);
+
+        expect_eq(h.current(), 1);
+        expect_eq(h.next(), std::nullopt);
+        expect_eq(h.previous(), std::nullopt);
+        expect_eq(h.entries(), std::vector<int>{1});
+    });
+
+    etest::test("pushing an entry already in history doesn't clear entries after it", [] {
+        History<int> h;
+
+        h.push(1);
+        h.push(2);
+        h.push(3);
+        h.push(4);
+        expect_eq(h.entries(), std::vector<int>{1, 2, 3, 4});
+        expect_eq(h.pop(), 4);
+        expect_eq(h.pop(), 3);
+        expect_eq(h.pop(), 2);
+
+        expect_eq(h.entries(), std::vector<int>{1, 2, 3, 4});
+
+        h.push(2);
+        expect_eq(h.entries(), std::vector<int>{1, 2, 3, 4});
+    });
+
+    return etest::run_all_tests();
+}


### PR DESCRIPTION
Currently set to `alt+left` and `alt+right`.