### PR TITLE
Target C++23

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,7 +20,7 @@ build --incompatible_enable_cc_toolchain_resolution
 # not relying on transitive dependencies, so let's enable that!
 build:linux --features=layering_check
 
-build:linux --cxxopt='-std=c++20'
+build:linux --cxxopt='-std=c++2b'
 build:linux --cxxopt='-fno-rtti'
 
 # Force DWARF-4 format for debug symbols for compatibility with valgrind.
@@ -28,7 +28,7 @@ build:linux --cxxopt='-fno-rtti'
 build:linux --copt='-gdwarf-4'
 
 build:windows --enable_runfiles
-build:windows --cxxopt='/std:c++20'
+build:windows --cxxopt='/std:c++latest'
 build:windows --cxxopt='/GR-' # Disable rtti.
 build:windows --copt='/permissive-' # Conform to the standard.
 build:windows --copt='/Zc:__cplusplus' # Report the real supported C++ version, not just C++98.

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,10 @@
 ---
+# -clang-analyzer-cplusplus.NewDeleteLeaks: Lots of false positives w/
+# -std=c++2b when calling std::make_shared in the JS AST.
+# js/ast_executor_test.cpp:176:5: error: Potential leak of memory pointed to by
+# field '_M_pi' [clang-analyzer-cplusplus.NewDeleteLeaks,-warnings-as-errors]
+# Very similar call stack to https://github.com/llvm/llvm-project/issues/55219
+#
 # -clang-analyzer-optin.cplusplus.UninitializedObject: Triggered by libfmt
 # format strings on the line we instantiate them.
 #
@@ -10,6 +16,7 @@
 # -misc-non-private-member-variables-in-classes: TODO(robinlinden): Fix.
 Checks: >
   misc-*,
+  -clang-analyzer-cplusplus.NewDeleteLeaks,
   -clang-analyzer-optin.cplusplus.UninitializedObject,
   -clang-diagnostic-builtin-macro-redefined,
   -misc-no-recursion,

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 #### Compiler
 
 Right now GCC 11, Clang 14, and MSVC are tested against. The project makes use
-of C++20 features, so a reasonably recent compiler is required.
+of C++23 features, so a reasonably recent compiler is required.
 
 #### Build system
 

--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -49,7 +49,7 @@ std::optional<std::string_view> try_get_text_content(dom::Document const &doc, s
 }
 
 void ensure_has_scheme(std::string &url) {
-    if (url.find("://") == std::string::npos) {
+    if (!url.contains("://")) {
         spdlog::info("Url missing scheme, assuming https");
         url = fmt::format("https://{}", url);
     }

--- a/css/parser.h
+++ b/css/parser.h
@@ -412,7 +412,7 @@ private:
             } else if (maybe_font_style->starts_with("oblique")) {
                 font_style = *maybe_font_style;
                 if (auto maybe_angle = tokenizer.peek()) {
-                    if (maybe_angle->find("deg") != std::string_view::npos) {
+                    if (maybe_angle->contains("deg")) {
                         font_style += ' ';
                         font_style += *maybe_angle;
                         tokenizer.next();

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -829,10 +829,8 @@ int main() {
 
         // Very incorrect.
         auto const &src = rules[0].declarations.at(css::PropertyId::Unknown);
-        auto woff2 = src.find(R"(url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"))");
-        expect(woff2 != std::string::npos);
-        auto woff = src.find(R"(url("/fonts/OpenSans-Regular-webfont.woff") format("woff")");
-        expect(woff != std::string::npos);
+        expect(src.contains(R"(url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"))"));
+        expect(src.contains(R"(url("/fonts/OpenSans-Regular-webfont.woff") format("woff")"));
     });
 
     return etest::run_all_tests();


### PR DESCRIPTION
Now that we have a few C++23-features in all major compilers, I figure it's time we start playing around with them. :P
I'm working on some style property features that make use of [Monadic operations for `std::optional`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0798r8.html), and switching to C++23 feels like something major and separate from upcoming style property PR.