### PR TITLE
render: Fix fully transparent boxes being rendered

### DIFF
--- a/render/render.cpp
+++ b/render/render.cpp
@@ -25,7 +25,6 @@ namespace render {
 namespace {
 
 constexpr gfx::Color kDefaultColor{0x0, 0x0, 0x0};
-constexpr gfx::Color kTransparentColor{0xFF, 0xFF, 0xFF, 0x0};
 
 struct CaseInsensitiveLess {
     using is_transparent = void;
@@ -69,6 +68,10 @@ bool has_any_border(geom::EdgeSize const &border) {
 
 dom::Text const *try_get_text(layout::LayoutBox const &layout) {
     return std::get_if<dom::Text>(&layout.node->node);
+}
+
+constexpr bool is_fully_transparent(gfx::Color const &c) {
+    return c.a == 0;
 }
 
 gfx::Color from_hex_chars(std::string_view hex_chars) {
@@ -117,7 +120,7 @@ void render_text(gfx::Painter &painter, layout::LayoutBox const &layout, dom::Te
 }
 
 void render_element(gfx::Painter &painter, layout::LayoutBox const &layout) {
-    auto background_color = try_get_color(layout, "background-color"sv).value_or(kTransparentColor);
+    auto background_color = try_get_color(layout, "background-color"sv).value_or(named_colors.at("transparent"));
     auto const &border_size = layout.dimensions.border;
     if (has_any_border(border_size)) {
         gfx::Borders borders{};
@@ -131,7 +134,7 @@ void render_element(gfx::Painter &painter, layout::LayoutBox const &layout) {
         borders.bottom.size = border_size.bottom;
 
         painter.draw_rect(layout.dimensions.padding_box(), background_color, borders);
-    } else if (background_color != kTransparentColor) {
+    } else if (!is_fully_transparent(background_color)) {
         painter.draw_rect(layout.dimensions.padding_box(), background_color, gfx::Borders{});
     }
 }

--- a/render/render_test.cpp
+++ b/render/render_test.cpp
@@ -64,6 +64,26 @@ int main() {
         expect_eq(saver.take_commands(), CanvasCommands{gfx::DrawRectCmd{expected_rect, expected_color, {}}});
     });
 
+    etest::test("render block with transparent background-color", [] {
+        auto dom = dom::create_element_node("div", {}, {dom::create_element_node("first", {}, {})});
+        auto styled = style::StyledNode{
+                .node = dom,
+                .properties = {{"display", "block"}, {"background-color", "transparent"}},
+        };
+
+        auto layout = layout::LayoutBox{
+                .node = &styled,
+                .type = layout::LayoutType::Block,
+                .dimensions = {{10, 20, 100, 100}, {}, {}, {}},
+        };
+
+        gfx::CanvasCommandSaver saver;
+        gfx::Painter painter{saver};
+        render::render_layout(painter, layout);
+
+        expect_eq(saver.take_commands(), CanvasCommands{});
+    });
+
     etest::test("render block with borders, default color", [] {
         auto dom = dom::create_element_node("div", {}, {dom::create_element_node("first", {}, {})});
         auto styled = style::StyledNode{
@@ -111,7 +131,7 @@ int main() {
         render::render_layout(painter, layout);
 
         geom::Rect expected_rect{0, 0, 20, 40};
-        gfx::Color expected_color{0xFF, 0xFF, 0xFF, 0x0};
+        gfx::Color expected_color{0, 0, 0, 0};
         gfx::Borders expected_borders{{{1, 1, 1}, 2}, {{2, 2, 2}, 4}, {{3, 3, 3}, 6}, {{4, 4, 4}, 8}};
 
         expect_eq(saver.take_commands(),


### PR DESCRIPTION
Without this patch, we only ignore fully transparent boxes if they also
match the render-internal magical transparent color constant.