### PR TITLE
browser: Shorten the spdlog message boilerplate

### DIFF
--- a/browser/gui.cpp
+++ b/browser/gui.cpp
@@ -24,6 +24,7 @@ auto const kStartpage{"http://example.com"s};
 int main(int argc, char **argv) {
     spdlog::set_default_logger(spdlog::stderr_color_mt(kBrowserTitle));
     spdlog::cfg::load_env_levels();
+    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%L%$] %v");
 
     std::optional<std::string> page_provided{std::nullopt};
     std::optional<unsigned> scale{std::nullopt};

--- a/browser/tui.cpp
+++ b/browser/tui.cpp
@@ -21,6 +21,7 @@ char const *const kDefaultUri = "http://www.example.com";
 int main(int argc, char **argv) {
     spdlog::set_default_logger(spdlog::stderr_color_mt("hastur"));
     spdlog::cfg::load_env_levels();
+    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%L%$] %v");
 
     auto uri = argc > 1 ? uri::Uri::parse(argv[1]) : uri::Uri::parse(kDefaultUri);
     if (!uri) {


### PR DESCRIPTION
This patch drops the application name from the log and uses the short
log level instead of the full one.

Before: `[2022-09-04 20:46:20.272] [hastur] [info] Styling dom w/ 14 rules`
After: `[2022-09-04 20:49:10.403] [I] Styling dom w/ 14 rules`