### PR TITLE
css2: Handle comments during tokenization

### DIFF
--- a/css2/tokenizer.cpp
+++ b/css2/tokenizer.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022 Mikael Larsson <c.mikael.larsson@gmail.com>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "css2/tokenizer.h"
+
+namespace css2 {
+
+void Tokenizer::run() {
+    while (true) {
+        switch (state_) {
+            case State::Main: {
+                auto c = consume_next_input_character();
+                if (!c) {
+                    return;
+                }
+
+                switch (*c) {
+                    case '/':
+                        state_ = State::CommentStart;
+                        continue;
+                    default:
+                        emit(DelimToken{*c});
+                        continue;
+                }
+            }
+
+            case State::CommentStart: {
+                auto c = consume_next_input_character();
+                if (!c) {
+                    return;
+                }
+
+                if (*c == '*') {
+                    state_ = State::Comment;
+                } else {
+                    emit(DelimToken{'/'});
+                    reconsume_in(State::Main);
+                }
+                continue;
+            }
+
+            case State::Comment: {
+                auto c = consume_next_input_character();
+                if (!c) {
+                    emit(ParseError::EofInComment);
+                    return;
+                }
+
+                if (*c == '*') {
+                    state_ = State::CommentEnd;
+                }
+                continue;
+            }
+
+            case State::CommentEnd: {
+                auto c = consume_next_input_character();
+                if (!c) {
+                    emit(ParseError::EofInComment);
+                    return;
+                }
+
+                switch (*c) {
+                    case '*':
+                        continue;
+                    case '/':
+                        state_ = State::Main;
+                        continue;
+                    default:
+                        state_ = State::Comment;
+                        continue;
+                }
+            }
+        }
+    }
+}
+
+void Tokenizer::emit(ParseError e) {
+    on_error_(e);
+}
+
+void Tokenizer::emit(Token &&token) {
+    on_emit_(std::move(token));
+}
+
+std::optional<char> Tokenizer::consume_next_input_character() {
+    if (is_eof()) {
+        pos_ += 1;
+        return std::nullopt;
+    }
+
+    return input_[pos_++];
+}
+
+bool Tokenizer::is_eof() const {
+    return pos_ >= input_.size();
+}
+
+void Tokenizer::reconsume_in(State state) {
+    --pos_;
+    state_ = state;
+}
+
+} // namespace css2

--- a/css2/tokenizer.h
+++ b/css2/tokenizer.h
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022 Mikael Larsson <c.mikael.larsson@gmail.com>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef CSS2_TOKENIZER_H_
+#define CSS2_TOKENIZER_H_
+
+#include "css2/token.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string_view>
+
+namespace css2 {
+
+// https://www.w3.org/TR/css-syntax-3/#tokenizer-algorithms
+enum class State {
+    Main,
+    CommentStart,
+    Comment,
+    CommentEnd,
+};
+
+enum class ParseError {
+    EofInComment,
+};
+
+class Tokenizer {
+public:
+    Tokenizer(std::string_view input, std::function<void(Token &&)> on_emit, std::function<void(ParseError)> on_error)
+        : input_(input), on_emit_(on_emit), on_error_(on_error) {}
+
+    void run();
+
+private:
+    std::string_view input_;
+    std::size_t pos_{0};
+    State state_{State::Main};
+
+    std::function<void(Token &&)> on_emit_;
+    std::function<void(ParseError)> on_error_;
+
+    void emit(ParseError);
+    void emit(Token &&);
+    std::optional<char> consume_next_input_character();
+    bool is_eof() const;
+    void reconsume_in(State);
+};
+
+} // namespace css2
+
+#endif

--- a/css2/tokenizer_test.cpp
+++ b/css2/tokenizer_test.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022 Mikael Larsson <c.mikael.larsson@gmail.com>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "css2/tokenizer.h"
+
+#include "etest/etest.h"
+
+#include <vector>
+
+using etest::expect;
+using etest::expect_eq;
+using etest::require;
+
+using namespace css2;
+
+namespace {
+
+class TokenizerOutput {
+public:
+    ~TokenizerOutput() {
+        expect(tokens.empty(), loc);
+        expect(errors.empty(), loc);
+    }
+
+    std::vector<Token> tokens;
+    std::vector<ParseError> errors;
+    etest::source_location loc;
+};
+
+TokenizerOutput run_tokenizer(std::string_view input, etest::source_location loc = etest::source_location::current()) {
+    std::vector<Token> tokens;
+    std::vector<ParseError> errors;
+    Tokenizer{input,
+            [&](Token &&t) { tokens.push_back(std::move(t)); },
+            [&](ParseError e) {
+                errors.push_back(e);
+            }}
+            .run();
+    return {std::move(tokens), std::move(errors), std::move(loc)};
+}
+
+void expect_token(
+        TokenizerOutput &output, Token t, etest::source_location const &loc = etest::source_location::current()) {
+    require(!output.tokens.empty(), loc);
+    expect_eq(output.tokens.front(), t, loc);
+    output.tokens.erase(begin(output.tokens));
+}
+
+void expect_error(
+        TokenizerOutput &output, ParseError e, etest::source_location const &loc = etest::source_location::current()) {
+    require(!output.errors.empty(), loc);
+    expect_eq(output.errors.front(), e, loc);
+    output.errors.erase(begin(output.errors));
+}
+
+} // namespace
+
+int main() {
+    etest::test("delimiter", [] {
+        auto output = run_tokenizer("a");
+
+        expect_token(output, DelimToken{'a'});
+    });
+
+    etest::test("comment", [] {
+        auto output = run_tokenizer("/* foo */");
+
+        expect(output.tokens.empty());
+    });
+
+    etest::test("comment with asterisks", [] {
+        auto output = run_tokenizer("/*****/");
+
+        expect(output.tokens.empty());
+    });
+
+    etest::test("comment almost started", [] {
+        auto output = run_tokenizer("/a");
+
+        expect_token(output, DelimToken{'/'});
+        expect_token(output, DelimToken{'a'});
+    });
+
+    etest::test("delimiter after comment", [] {
+        auto output = run_tokenizer("/*/*/,");
+
+        expect_token(output, DelimToken{','});
+    });
+
+    etest::test("eof in comment", [] {
+        auto output = run_tokenizer("/* foo");
+
+        expect_error(output, ParseError::EofInComment);
+    });
+
+    etest::test("eof at comment ending", [] {
+        auto output = run_tokenizer("/* foo *");
+
+        expect_error(output, ParseError::EofInComment);
+    });
+
+    return etest::run_all_tests();
+}


### PR DESCRIPTION
Trying out a similar tokenizer for css2 as for html2. Some code duplication here now, but I guess we could make a base class for the tokenizer to reduce it.

Part of #31 