### PR TITLE
ci: Fix codecov not being updated if PRs are merged via the web gui

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,8 @@
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: [master]
 name: ci
 jobs:
   linux-ci:


### PR DESCRIPTION
If PRs are merged using the web gui merge button, GitHub changes the commit hash even if the PR could be merged by a fast-forward merge, meaning the commit hash we've run CI and sent code coverage info for isn't the same hash as the one on the master branch after the merge.

This commit works around this by also always running CI on commits pushed to master. This will lead to running CI twice on every commit we merge, but at least it doesn't have to be done manually.