### PR TITLE
Add very partial support for the background shorthand property

### DIFF
--- a/css/parser.h
+++ b/css/parser.h
@@ -209,10 +209,31 @@ private:
             std::string_view value) const {
         if (is_shorthand_edge_property(name)) {
             expand_edge_values(declarations, std::string{name}, value);
+        } else if (name == "background") {
+            expand_background(declarations, value);
         } else if (name == "font") {
             expand_font(declarations, value);
         } else {
             declarations.insert_or_assign(std::string{name}, std::string{value});
+        }
+    }
+
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/background
+    // TODO(robinlinden): This only handles a color being named, and assumes any single item listed is a color.
+    static void expand_background(
+            std::map<std::string, std::string, std::less<>> &declarations, std::string_view value) {
+        declarations["background-image"] = "none";
+        declarations["background-position"] = "0% 0%";
+        declarations["background-size"] = "auto auto";
+        declarations["background-repeat"] = "repeat";
+        declarations["background-origin"] = "padding-box";
+        declarations["background-clip"] = "border-box";
+        declarations["background-attachment"] = "scroll";
+        declarations["background-color"] = "transparent";
+
+        Tokenizer tokenizer{value, ' '};
+        if (tokenizer.size() == 1) {
+            declarations["background-color"] = tokenizer.get().value();
         }
     }
 

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -70,8 +70,11 @@ bool check_initial_font_values(std::map<std::string, std::string, std::less<>> c
 }
 
 template<class KeyT, class ValueT>
-ValueT get_and_erase(std::map<KeyT, ValueT, std::less<>> &map, KeyT key) {
-    ValueT value = map[key];
+ValueT get_and_erase(std::map<KeyT, ValueT, std::less<>> &map,
+        KeyT key,
+        etest::source_location const &loc = etest::source_location::current()) {
+    require(map.contains(key), loc);
+    ValueT value = map.at(key);
     map.erase(key);
     return value;
 }

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -62,14 +62,11 @@ auto const initial_font_values = std::map<std::string, std::string, std::less<>>
         {"font-variant-position", "normal"},
         {"font-variant-east-asian", "normal"}};
 
-bool check_initial_font_values(std::map<std::string, std::string, std::less<>> declarations) {
-    for (auto [property, value] : declarations) {
-        auto it = initial_font_values.find(property);
-        if (it != cend(initial_font_values) && it->second != value) {
-            return false;
-        }
-    }
-    return true;
+bool check_initial_font_values(std::map<std::string, std::string, std::less<>> const &declarations) {
+    return std::all_of(cbegin(declarations), cend(declarations), [](auto const &decl) {
+        auto it = initial_font_values.find(decl.first);
+        return it != cend(initial_font_values) && it->second == decl.second;
+    });
 }
 
 template<class KeyT, class ValueT>

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -27,6 +27,22 @@ namespace {
     return os;
 }
 
+auto const initial_background_values = std::map<std::string, std::string, std::less<>>{{"background-image", "none"},
+        {"background-position", "0% 0%"},
+        {"background-size", "auto auto"},
+        {"background-repeat", "repeat"},
+        {"background-origin", "padding-box"},
+        {"background-clip", "border-box"},
+        {"background-attachment", "scroll"},
+        {"background-color", "transparent"}};
+
+bool check_initial_background_values(std::map<std::string, std::string, std::less<>> const &declarations) {
+    return std::all_of(cbegin(declarations), cend(declarations), [](auto const &decl) {
+        auto it = initial_background_values.find(decl.first);
+        return it != cend(initial_background_values) && it->second == decl.second;
+    });
+}
+
 auto const initial_font_values = std::map<std::string, std::string, std::less<>>{{"font-stretch", "normal"},
         {"font-variant", "normal"},
         {"font-weight", "normal"},
@@ -409,6 +425,15 @@ int main() {
         etest::test("parser: override border-style with shorthand",
                 box_override_with_shorthand("border-style", border_styles, "-style"));
     }
+
+    etest::test("parser: shorthand background color", [] {
+        auto rules = css::parse("p { background: red }"sv);
+        require(rules.size() == 1);
+
+        auto &p = rules[0];
+        expect_eq(get_and_erase(p.declarations, "background-color"s), "red"sv);
+        expect(check_initial_background_values(p.declarations));
+    });
 
     etest::test("parser: shorthand font with only size and generic font family", [] {
         auto rules = css::parse("p { font: 1.5em sans-serif; }"sv);


### PR DESCRIPTION
When working on my other css property work I noticed a website I expected to have a gray background was white even though we support the background-color property. Turns out there's a background shorthand property that a lot of people use.