### PR TITLE
css: Embed the default css in the css library

### DIFF
--- a/css/BUILD
+++ b/css/BUILD
@@ -1,11 +1,19 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
+genrule(
+    name = "default_css",
+    srcs = ["default.css"],
+    outs = ["default_css.h"],
+    cmd = "xxd -i $< >$@",
+)
+
 cc_library(
     name = "css",
     srcs = [
         "default.cpp",
         "parse.cpp",
         "rule.cpp",
+        ":default_css.h",
     ],
     hdrs = [
         "default.h",
@@ -13,7 +21,6 @@ cc_library(
         "parser.h",
         "rule.h",
     ],
-    data = ["default.css"],
     visibility = ["//visibility:public"],
     deps = [
         "//util:base_parser",

--- a/css/default.cpp
+++ b/css/default.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -6,23 +6,15 @@
 
 #include "css/parse.h"
 
-#include <filesystem>
-#include <fstream>
-#include <string>
+#include <string_view>
 
 namespace css {
+namespace {
+#include "css/default_css.h"
+} // namespace
 
 std::vector<css::Rule> default_style() {
-    auto path = std::filesystem::path("css/default.css");
-    if (!exists(path) || !is_regular_file(path)) {
-        return {};
-    }
-
-    auto file = std::ifstream(path, std::ios::in | std::ios::binary);
-    auto size = file_size(path);
-    auto content = std::string(size, '\0');
-    file.read(content.data(), size);
-    return css::parse(content);
+    return css::parse(std::string_view{reinterpret_cast<char const *>(css_default_css), css_default_css_len});
 }
 
 } // namespace css


### PR DESCRIPTION
This was the only part of the browser relying on having a specific working directory or it being started using `bazel run`.