### PR TITLE
build: Drop untested gcc11 config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -90,11 +90,9 @@ build:linux --copt='-gdwarf-4'
 
 build:gcc10 --cxxopt='-fcoroutines'
 
-build:gcc11 --per_file_copt='external/libpng[:/]@-Wno-maybe-uninitialized'
-
-build:gcc12 --config=gcc11
 build:gcc12 --per_file_copt='external/freetype2[:/]@-Wno-dangling-pointer'
 build:gcc12 --per_file_copt='external/glew[:/]@-Wno-address'
+build:gcc12 --per_file_copt='external/libpng[:/]@-Wno-maybe-uninitialized'
 
 build:clang15 --per_file_copt='external/ftxui[:/]@-Wno-deprecated-declarations'
 build:clang15 --per_file_copt='external/xext[:/]@-Wno-invalid-utf8'

--- a/.bazelrc.local.example
+++ b/.bazelrc.local.example
@@ -12,7 +12,6 @@ build -c dbg
 ## Linux
 # build --config clang15
 # build --config gcc10
-# build --config gcc11
 # build --config gcc12
 ## Windows
 # build --config clang-cl


### PR DESCRIPTION
Ubuntu 20.04 only has up to gcc 10, and Ubuntu 22.04 skips past gcc 11 to also support gcc 12, so supporting gcc 11 doesn't really get us anything.