### PR TITLE
Set up fuzz testing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -60,6 +60,13 @@ build:linux --per_file_copt='external/ftxui[:/]@-Wno-double-promotion'
 build:linux --per_file_copt='external/ftxui[:/]@-Wno-missing-declarations'
 build:linux --per_file_copt='external/glew[:/]@-Wno-strict-prototypes'
 build:linux --per_file_copt='external/glew[:/]@-Wno-undef'
+build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-empty-translation-unit'
+build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-format-nonliteral'
+build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-gnu-case-range'
+build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-gnu-designator'
+build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-pedantic'
+build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-shadow'
+build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-undef'
 build:linux --per_file_copt='external/imgui-sfml[:/]@-Wno-double-promotion'
 build:linux --per_file_copt='external/imgui-sfml[:/]@-Wno-implicit-fallthrough'
 build:linux --per_file_copt='external/imgui[:/]@-Wno-deprecated-enum-enum-conversion'
@@ -181,6 +188,11 @@ build:asan-libfuzzer --config=asan
 build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
 build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
 build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
+
+build:asan-honggfuzz --config=asan
+build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:honggfuzz
+build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=honggfuzz
+build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 
 # Misc configuration
 # =========================================================

--- a/.bazelrc
+++ b/.bazelrc
@@ -47,6 +47,10 @@ build:linux --per_file_copt='external/boringssl[:/]@-Wno-gnu-binary-literal'
 build:linux --per_file_copt='external/boringssl[:/]@-Wno-overlength-strings'
 build:linux --per_file_copt='external/boringssl[:/]@-Wno-pedantic'
 build:linux --per_file_copt='external/boringssl[:/]@-Wno-unused-parameter'
+build:linux --per_file_copt='external/com_google_absl[:/]@-Wno-double-promotion'
+build:linux --per_file_copt='external/com_google_absl[:/]@-Wno-format-nonliteral'
+build:linux --per_file_copt='external/com_google_absl[:/]@-Wno-gcc-compat'
+build:linux --per_file_copt='external/com_google_absl[:/]@-Wno-pedantic'
 build:linux --per_file_copt='external/freetype2[:/]@-Wno-cast-function-type'
 build:linux --per_file_copt='external/freetype2[:/]@-Wno-implicit-fallthrough'
 build:linux --per_file_copt='external/freetype2[:/]@-Wno-missing-declarations'
@@ -63,6 +67,9 @@ build:linux --per_file_copt='external/imgui[:/]@-Wno-double-promotion'
 build:linux --per_file_copt='external/libpng[:/]@-Wno-null-pointer-subtraction'
 build:linux --per_file_copt='external/libpng[:/]@-Wno-undef'
 build:linux --per_file_copt='external/libpng[:/]@-Wno-unused-but-set-variable'
+build:linux --per_file_copt='external/rules_fuzzing[:/]@-Wno-double-promotion'
+build:linux --per_file_copt='external/rules_fuzzing[:/]@-Wno-gcc-compat'
+build:linux --per_file_copt='external/rules_fuzzing[:/]@-Wno-pedantic'
 build:linux --per_file_copt='external/sfml[:/]@-Wno-double-promotion'
 build:linux --per_file_copt='external/sfml[:/]@-Wno-implicit-fallthrough'
 build:linux --per_file_copt='external/sfml[:/]@-Wno-missing-declarations'
@@ -169,6 +176,11 @@ build:clang14-coverage --action_env=BAZEL_LLVM_COV=llvm-cov-14
 build:clang14-coverage --action_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
 build:clang14-coverage --action_env=GCOV=llvm-profdata-14
 build:clang14-coverage --experimental_generate_llvm_lcov
+
+build:asan-libfuzzer --config=asan
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 
 # Misc configuration
 # =========================================================

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,21 @@ http_archive(
     url = "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
 )
 
+http_archive(
+    name = "rules_fuzzing",
+    sha256 = "d9002dd3cd6437017f08593124fdd1b13b3473c7b929ceb0e60d317cb9346118",
+    strip_prefix = "rules_fuzzing-0.3.2",
+    url = "https://github.com/bazelbuild/rules_fuzzing/archive/v0.3.2.zip",
+)
+
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+
+rules_fuzzing_dependencies()
+
+load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
+
+rules_fuzzing_init()
+
 # Misc tools
 # =========================================================
 

--- a/css/BUILD
+++ b/css/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 
 genrule(
     name = "default_css",
@@ -37,6 +38,14 @@ cc_test(
         "//etest",
         "@fmt",
     ],
+)
+
+cc_fuzz_test(
+    name = "css_parser_fuzz_test",
+    srcs = ["parser_fuzz_test.cpp"],
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [":css"],
 )
 
 cc_test(

--- a/css/parser_fuzz_test.cpp
+++ b/css/parser_fuzz_test.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "css/parse.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <tuple>
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size);
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size) {
+    std::ignore = css::parse(std::string_view{reinterpret_cast<char const *>(data), size});
+    return 0;
+}

--- a/html2/BUILD
+++ b/html2/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 
 cc_library(
     name = "html2",
@@ -32,4 +33,16 @@ dependencies = {
         "//etest",
         "@fmt",
     ],
-) for src in glob(["*_test.cpp"])]
+) for src in glob(
+    include = ["*_test.cpp"],
+    exclude = ["*_fuzz_test.cpp"],
+)]
+
+[cc_fuzz_test(
+    name = src[:-4],
+    size = "small",
+    srcs = [src],
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [":html2"],
+) for src in glob(["*_fuzz_test.cpp"])]

--- a/html2/tokenizer_fuzz_test.cpp
+++ b/html2/tokenizer_fuzz_test.cpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "html2/tokenizer.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size);
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size) {
+    html2::Tokenizer{std::string_view{reinterpret_cast<char const *>(data), size},
+            [](html2::Tokenizer &tokenizer, html2::Token &&token) {
+                if (auto const *start_tag = std::get_if<html2::StartTagToken>(&token)) {
+                    if (start_tag->tag_name == "script") {
+                        tokenizer.set_state(html2::State::ScriptData);
+                    }
+                }
+            }}
+            .run();
+    return 0;
+}

--- a/uri/BUILD
+++ b/uri/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 
 cc_library(
     name = "uri",
@@ -16,4 +17,19 @@ cc_test(
         ":uri",
         "//etest",
     ],
+)
+
+config_setting(
+    name = "is_clang",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang"},
+)
+
+cc_fuzz_test(
+    name = "uri_fuzz_test",
+    srcs = ["uri_fuzz_test.cpp"],
+    target_compatible_with = select({
+        ":is_clang": ["@platforms//os:linux"],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [":uri"],
 )

--- a/uri/uri_fuzz_test.cpp
+++ b/uri/uri_fuzz_test.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "uri/uri.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <tuple>
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size);
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size) {
+    std::ignore = uri::Uri::parse(std::string{reinterpret_cast<char const *>(data), size}).value();
+    return 0;
+}


### PR DESCRIPTION
This mostly serves as an example for further work on fuzzing things as the tokenizer is still too incomplete for this to be useful.

Here's what a running it looks like right now:
```
robin@x:~/code/hastur$ CC=clang-14 CXX=clang++14 bazel run html2/tokenizer_fuzz_test_run --config asan-libfuzzer -c dbg
INFO: Analyzed target //html2:tokenizer_fuzz_test_run (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //html2:tokenizer_fuzz_test_run up-to-date:
  bazel-bin/html2/tokenizer_fuzz_test_run
INFO: Elapsed time: 0.075s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
Launching html2/tokenizer_fuzz_test_bin as a libFuzzer fuzz test...
Using test output root: /tmp/fuzzing
Writing new corpus elements at: /tmp/fuzzing/corpus
Writing new artifacts at: /tmp/fuzzing/artifacts
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1726011173
INFO: Loaded 1 modules   (1796 inline 8-bit counters): 1796 [0x55ffed2e9300, 0x55ffed2e9a04),
INFO: Loaded 1 PC tables (1796 PCs): 1796 [0x55ffed2e9a08,0x55ffed2f0a48),
INFO:      150 files found in /tmp/fuzzing/corpus
INFO:        0 files found in html2/tokenizer_fuzz_test_corpus
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 150 min: 1b max: 11b total: 971b rss: 31Mb
#152    INITED cov: 838 ft: 2035 corp: 119/770b exec/s: 0 rss: 35Mb
#217    NEW    cov: 838 ft: 2037 corp: 120/781b lim: 11 exec/s: 0 rss: 35Mb L: 11/11 MS: 5 ShuffleBytes-ChangeBinInt-ShuffleBytes-ShuffleBytes-CrossOver-
terminate called without an active exception
==14147== ERROR: libFuzzer: deadly signal
    #0 0x55ffed1d20a1 in __sanitizer_print_stack_trace (/home/robin/.cache/bazel/_bazel_robin/57b3a6c7210188a99da0ed065bbc8d18/execroot/__main__/bazel-out/k8-dbg-ST-e961b0c8aa9c/bin/html2/tokenizer_fuzz_test_raw_+0x1410a1) (BuildId: 9a54ad4cd69b64379362854635c1f120f69bfc32)
    #1 0x55ffed144938 in fuzzer::PrintStackTrace() crtstuff.c
    #2 0x55ffed12a3a3 in fuzzer::Fuzzer::CrashCallback() crtstuff.c
    #3 0x7fa9fe4ec51f  (/lib/x86_64-linux-gnu/libc.so.6+0x4251f) (BuildId: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d)
    #4 0x7fa9fe540a7b in __pthread_kill_implementation nptl/./nptl/pthread_kill.c:43:17
    #5 0x7fa9fe540a7b in __pthread_kill_internal nptl/./nptl/pthread_kill.c:78:10
    #6 0x7fa9fe540a7b in pthread_kill nptl/./nptl/pthread_kill.c:89:10
    #7 0x7fa9fe4ec475 in gsignal signal/../sysdeps/posix/raise.c:26:13
    #8 0x7fa9fe4d27f2 in abort stdlib/./stdlib/abort.c:79:7
    #9 0x7fa9fe87bbfd  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xa2bfd) (BuildId: 725ef5da52ee6d881f9024d8238a989903932637)
    #10 0x7fa9fe88728b  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xae28b) (BuildId: 725ef5da52ee6d881f9024d8238a989903932637)
    #11 0x7fa9fe8872f6 in std::terminate() (/lib/x86_64-linux-gnu/libstdc++.so.6+0xae2f6) (BuildId: 725ef5da52ee6d881f9024d8238a989903932637)
    #12 0x55ffed20edbc in html2::Tokenizer::run() /proc/self/cwd/html2/tokenizer.cpp:199:17
    #13 0x55ffed202ff9 in LLVMFuzzerTestOneInput /proc/self/cwd/html2/tokenizer_fuzz_test.cpp:21:14
    #14 0x55ffed12b933 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) crtstuff.c
    #15 0x55ffed12b089 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) crtstuff.c
    #16 0x55ffed12c879 in fuzzer::Fuzzer::MutateAndTestOne() crtstuff.c
    #17 0x55ffed12d3f5 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile> >&) crtstuff.c
    #18 0x55ffed11b522 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) crtstuff.c
    #19 0x55ffed145232 in main (/home/robin/.cache/bazel/_bazel_robin/57b3a6c7210188a99da0ed065bbc8d18/execroot/__main__/bazel-out/k8-dbg-ST-e961b0c8aa9c/bin/html2/tokenizer_fuzz_test_raw_+0xb4232) (BuildId: 9a54ad4cd69b64379362854635c1f120f69bfc32)
    #20 0x7fa9fe4d3d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #21 0x7fa9fe4d3e3f in __libc_start_main csu/../csu/libc-start.c:392:3
    #22 0x55ffed10ff64 in _start (/home/robin/.cache/bazel/_bazel_robin/57b3a6c7210188a99da0ed065bbc8d18/execroot/__main__/bazel-out/k8-dbg-ST-e961b0c8aa9c/bin/html2/tokenizer_fuzz_test_raw_+0x7ef64) (BuildId: 9a54ad4cd69b64379362854635c1f120f69bfc32)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 2 CMP-CopyPart- DE: "\001\000\000\000"-; base unit: f44bc7149f03c230908da845fbdf8eab4e2896f6
0x26,0x3c,0x1,0x0,0x0,0x0,0x70,0x3c,0x3c,0x2f,0x2f,
&<\001\000\000\000p<<//
artifact_prefix='/tmp/fuzzing/artifacts/'; Test unit written to /tmp/fuzzing/artifacts/crash-2c65af91cc839c1d1e99dedec427c29147530f7a
Base64: JjwBAAAAcDw8Ly8=
```