### PR TITLE
uri: Never fail in uri parsing

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -295,12 +295,8 @@ int App::run() {
 void App::navigate() {
     page_loaded_ = false;
     auto uri = uri::Uri::parse(url_buf_);
-    if (!uri) {
-        return;
-    }
-
-    browse_history_.push(*uri);
-    engine_.navigate(std::move(*uri));
+    browse_history_.push(uri);
+    engine_.navigate(std::move(uri));
 
     // Make sure the displayed url is still correct if we followed any redirects.
     url_buf_ = engine_.uri().uri;

--- a/browser/tui.cpp
+++ b/browser/tui.cpp
@@ -24,14 +24,9 @@ int main(int argc, char **argv) {
     spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%L%$] %v");
 
     auto uri = argc > 1 ? uri::Uri::parse(argv[1]) : uri::Uri::parse(kDefaultUri);
-    if (!uri) {
-        spdlog::error("Unable to parse uri from {}", argc > 1 ? argv[1] : kDefaultUri);
-        return 1;
-    }
-
     engine::Engine engine{protocol::HandlerFactory::create()};
-    if (auto err = engine.navigate(*uri); err != protocol::Error::Ok) {
-        spdlog::error("Got error {} from {}", static_cast<int>(err), uri->uri);
+    if (auto err = engine.navigate(uri); err != protocol::Error::Ok) {
+        spdlog::error("Got error {} from {}", static_cast<int>(err), uri.uri);
         std::exit(1);
     }
 

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -37,11 +37,11 @@ protocol::Error Engine::navigate(uri::Uri uri) {
 
     if (uri.scheme.empty() && uri.authority.host.empty() && uri.path.starts_with('/')) {
         spdlog::info("Handling origin-relative URL {}", uri.uri);
-        uri = uri::Uri::parse(fmt::format("{}://{}{}", uri_.scheme, uri_.authority.host, uri.uri)).value();
+        uri = uri::Uri::parse(fmt::format("{}://{}{}", uri_.scheme, uri_.authority.host, uri.uri));
         spdlog::info("Transformed origin-relative URL to {}", uri.uri);
     } else if (uri.scheme.empty() && !uri.authority.host.empty() && uri.uri.starts_with("//")) {
         spdlog::info("Handling scheme-relative URL {}", uri.uri);
-        uri = uri::Uri::parse(fmt::format("{}:{}", uri_.scheme, uri.uri)).value();
+        uri = uri::Uri::parse(fmt::format("{}:{}", uri_.scheme, uri.uri));
         spdlog::info("Transformed scheme-relative URL to {}", uri.uri);
     }
 
@@ -52,7 +52,7 @@ protocol::Error Engine::navigate(uri::Uri uri) {
                 response_.status_line.status_code,
                 uri_.uri,
                 response_.headers.get("Location").value());
-        uri_ = *uri::Uri::parse(std::string(response_.headers.get("Location").value()));
+        uri_ = uri::Uri::parse(std::string(response_.headers.get("Location").value()));
         response_ = protocol_handler_->handle(uri_);
     }
 
@@ -111,7 +111,7 @@ void Engine::on_navigation_success() {
             }();
 
             spdlog::info("Downloading stylesheet from {}", stylesheet_url);
-            auto style_data = protocol_handler_->handle(*uri::Uri::parse(stylesheet_url));
+            auto style_data = protocol_handler_->handle(uri::Uri::parse(stylesheet_url));
             if (style_data.err != protocol::Error::Ok) {
                 spdlog::warn("Error {} downloading {}", static_cast<int>(style_data.err), stylesheet_url);
                 return {};

--- a/engine/engine_test.cpp
+++ b/engine/engine_test.cpp
@@ -37,7 +37,7 @@ int main() {
         e.set_on_page_loaded([] { require(false); });
         e.set_on_layout_updated([] { require(false); });
 
-        e.navigate(*uri::Uri::parse("hax://example.com"));
+        e.navigate(uri::Uri::parse("hax://example.com"));
         expect(success);
     });
 
@@ -48,7 +48,7 @@ int main() {
         e.set_on_page_loaded([&] { success = true; });
         e.set_on_layout_updated([] { require(false); });
 
-        e.navigate(*uri::Uri::parse("hax://example.com"));
+        e.navigate(uri::Uri::parse("hax://example.com"));
         expect(success);
     });
 
@@ -63,7 +63,7 @@ int main() {
         bool success{false};
         e.set_on_page_loaded([&] { success = true; });
 
-        e.navigate(*uri::Uri::parse("hax://example.com"));
+        e.navigate(uri::Uri::parse("hax://example.com"));
 
         expect(success);
 
@@ -78,21 +78,21 @@ int main() {
     etest::test("origin-relative uri", [] {
         engine::Engine e{std::make_unique<FakeProtocolHandler>(protocol::Response{.err = protocol::Error::Ok})};
 
-        e.navigate(*uri::Uri::parse("hax://example.com"));
-        expect_eq(e.uri(), *uri::Uri::parse("hax://example.com"));
+        e.navigate(uri::Uri::parse("hax://example.com"));
+        expect_eq(e.uri(), uri::Uri::parse("hax://example.com"));
 
-        e.navigate(*uri::Uri::parse("/test"));
-        expect_eq(e.uri(), *uri::Uri::parse("hax://example.com/test"));
+        e.navigate(uri::Uri::parse("/test"));
+        expect_eq(e.uri(), uri::Uri::parse("hax://example.com/test"));
     });
 
     etest::test("scheme-relative uri", [] {
         engine::Engine e{std::make_unique<FakeProtocolHandler>(protocol::Response{.err = protocol::Error::Ok})};
 
-        e.navigate(*uri::Uri::parse("hax://example.com"));
-        expect_eq(e.uri(), *uri::Uri::parse("hax://example.com"));
+        e.navigate(uri::Uri::parse("hax://example.com"));
+        expect_eq(e.uri(), uri::Uri::parse("hax://example.com"));
 
-        e.navigate(*uri::Uri::parse("//example2.com/test"));
-        expect_eq(e.uri(), *uri::Uri::parse("hax://example2.com/test"));
+        e.navigate(uri::Uri::parse("//example2.com/test"));
+        expect_eq(e.uri(), uri::Uri::parse("hax://example2.com/test"));
     });
 
     return etest::run_all_tests();

--- a/protocol/http_test.cpp
+++ b/protocol/http_test.cpp
@@ -56,7 +56,7 @@ struct FakeSocket {
 };
 
 uri::Uri create_uri(std::string url = "http://example.com") {
-    return uri::Uri::parse(std::move(url)).value();
+    return uri::Uri::parse(std::move(url));
 }
 
 FakeSocket create_chunked_socket(std::string const &body) {

--- a/uri/uri.cpp
+++ b/uri/uri.cpp
@@ -7,6 +7,7 @@
 
 #include "util/string.h"
 
+#include <exception>
 #include <regex>
 #include <utility>
 
@@ -29,13 +30,13 @@ void normalize(Uri &uri) {
 
 } // namespace
 
-std::optional<Uri> Uri::parse(std::string uristr) {
+Uri Uri::parse(std::string uristr) {
     std::smatch match;
 
     // Regex taken from RFC 3986.
     std::regex uri_regex("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?");
     if (!std::regex_search(uristr, match, uri_regex)) {
-        return std::nullopt;
+        std::terminate();
     }
 
     Authority authority{};

--- a/uri/uri.h
+++ b/uri/uri.h
@@ -6,7 +6,6 @@
 #ifndef URI_URI_H_
 #define URI_URI_H_
 
-#include <optional>
 #include <string>
 
 namespace uri {
@@ -23,7 +22,7 @@ struct Authority {
 };
 
 struct Uri {
-    static std::optional<Uri> parse(std::string uri);
+    static Uri parse(std::string uri);
 
     std::string uri;
     std::string scheme;

--- a/uri/uri_fuzz_test.cpp
+++ b/uri/uri_fuzz_test.cpp
@@ -12,6 +12,6 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size);
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size) {
-    std::ignore = uri::Uri::parse(std::string{reinterpret_cast<char const *>(data), size}).value();
+    std::ignore = uri::Uri::parse(std::string{reinterpret_cast<char const *>(data), size});
     return 0;
 }

--- a/uri/uri_test.cpp
+++ b/uri/uri_test.cpp
@@ -13,7 +13,7 @@ using uri::Uri;
 
 int main() {
     etest::test("https: simple uri", [] {
-        auto uri = *Uri::parse("https://example.com");
+        auto uri = Uri::parse("https://example.com");
         Uri expected{
                 .uri = "https://example.com",
                 .scheme = "https",
@@ -25,7 +25,7 @@ int main() {
     });
 
     etest::test("https: short uri", [] {
-        auto uri = *Uri::parse("https://gr.ht");
+        auto uri = Uri::parse("https://gr.ht");
         Uri expected{
                 .uri = "https://gr.ht",
                 .scheme = "https",
@@ -37,8 +37,7 @@ int main() {
     });
 
     etest::test("https: user, pass, port, path, query", [] {
-        auto https_uri =
-                *Uri::parse("https://zero-one:muh_password@example-domain.net:8080/muh/long/path.html?foo=bar");
+        auto https_uri = Uri::parse("https://zero-one:muh_password@example-domain.net:8080/muh/long/path.html?foo=bar");
 
         expect(https_uri.scheme == "https");
         expect(https_uri.authority.user == "zero-one");
@@ -51,7 +50,7 @@ int main() {
     });
 
     etest::test("https: user, pass, path, query", [] {
-        auto https_uri = *Uri::parse("https://zero-one:muh_password@example-domain.net/muh/long/path.html?foo=bar");
+        auto https_uri = Uri::parse("https://zero-one:muh_password@example-domain.net/muh/long/path.html?foo=bar");
 
         expect(https_uri.scheme == "https");
         expect(https_uri.authority.user == "zero-one");
@@ -64,7 +63,7 @@ int main() {
     });
 
     etest::test("https: user, path, query", [] {
-        auto https_uri = *Uri::parse("https://zero-one@example-domain.net/muh/long/path.html?foo=bar");
+        auto https_uri = Uri::parse("https://zero-one@example-domain.net/muh/long/path.html?foo=bar");
 
         expect(https_uri.scheme == "https");
         expect(https_uri.authority.user == "zero-one");
@@ -77,7 +76,7 @@ int main() {
     });
 
     etest::test("https: path, query", [] {
-        auto https_uri = *Uri::parse("https://example-domain.net/muh/long/path.html?foo=bar");
+        auto https_uri = Uri::parse("https://example-domain.net/muh/long/path.html?foo=bar");
 
         expect(https_uri.scheme == "https");
         expect(https_uri.authority.user.empty());
@@ -90,7 +89,7 @@ int main() {
     });
 
     etest::test("https: path, fragment", [] {
-        auto https_uri = *Uri::parse("https://example-domain.net/muh/long/path.html#About");
+        auto https_uri = Uri::parse("https://example-domain.net/muh/long/path.html#About");
 
         expect(https_uri.scheme == "https");
         expect(https_uri.authority.user.empty());
@@ -103,7 +102,7 @@ int main() {
     });
 
     etest::test("mailto: path", [] {
-        auto mailto_uri = *Uri::parse("mailto:example@example.net");
+        auto mailto_uri = Uri::parse("mailto:example@example.net");
 
         expect(mailto_uri.scheme == "mailto");
         expect(mailto_uri.authority.user.empty());
@@ -116,7 +115,7 @@ int main() {
     });
 
     etest::test("tel: path", [] {
-        auto tel_uri = *Uri::parse("tel:+1-830-476-5664");
+        auto tel_uri = Uri::parse("tel:+1-830-476-5664");
 
         expect(tel_uri.scheme == "tel");
         expect(tel_uri.authority.user.empty());
@@ -129,17 +128,17 @@ int main() {
     });
 
     etest::test("relative, no host", [] {
-        auto uri = *Uri::parse("hello/there.html");
+        auto uri = Uri::parse("hello/there.html");
         expect_eq(uri, Uri{.uri = "hello/there.html", .path = "hello/there.html"});
     });
 
     etest::test("absolute, no host", [] {
-        auto uri = *Uri::parse("/hello/there.html");
+        auto uri = Uri::parse("/hello/there.html");
         expect_eq(uri, Uri{.uri = "/hello/there.html", .path = "/hello/there.html"});
     });
 
     etest::test("scheme-relative", [] {
-        auto uri = *Uri::parse("//example.com/hello/there.html");
+        auto uri = Uri::parse("//example.com/hello/there.html");
         expect_eq(uri,
                 Uri{.uri = "//example.com/hello/there.html",
                         .authority = {.host = "example.com"},
@@ -147,7 +146,7 @@ int main() {
     });
 
     etest::test("normalization, lowercasing scheme+host", [] {
-        auto actual = *Uri::parse("HTTPS://EXAMPLE.COM/");
+        auto actual = Uri::parse("HTTPS://EXAMPLE.COM/");
         Uri expected{
                 .uri = "HTTPS://EXAMPLE.COM/",
                 .scheme = "https",
@@ -157,12 +156,6 @@ int main() {
 
         expect_eq(actual, expected);
     });
-
-    // TODO(Zer0-One): Test for parsing failure.
-    // etest::test("parse failure", [] {
-    //     auto tel_uri = Uri::parse("");
-    //     expect(!tel_uri.has_value());
-    // });
 
     return etest::run_all_tests();
 }


### PR DESCRIPTION
The regex currently in use always matches the input, so we were never failing, but still required the call-site to handle a potential failure.