### PR TITLE
ci: Migrate to the new codecov uploader

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,10 @@ jobs:
       - name: Summary
         run: lcov --summary bazel-out/_coverage/_coverage_report.dat
       - name: Upload
-        run: bash <(curl -s https://codecov.io/bash) -f bazel-out/_coverage/_coverage_report.dat
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -f bazel-out/_coverage/_coverage_report.dat
 
   windows-msvc:
     runs-on: windows-2022


### PR DESCRIPTION
The bash codecov uploader was apparently deprecated and appears to now have stopped working.

See: https://github.com/codecov/codecov-bash, https://github.com/codecov/uploader

Error when using the old uploader:
```
bash <(curl -s https://codecov.io/bash) -f bazel-out/_coverage/_coverage_report.dat
/dev/fd/63: line 1: no: command not found
```
which makes sense, because that url now points to a page with the content:
```
no healthy upstream
```