### PR TITLE
css: Use the keyframes crash workaround for all unhandled at-rules

### DIFF
--- a/css/BUILD
+++ b/css/BUILD
@@ -26,6 +26,7 @@ cc_library(
     deps = [
         "//util:base_parser",
         "@fmt",
+        "@spdlog",
     ],
 )
 

--- a/css/parser.h
+++ b/css/parser.h
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <optional>
 #include <string_view>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -44,17 +45,17 @@ public:
                 skip_whitespace_and_comments();
             }
 
-            // https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes
-            // Not saved or anything yet, but stops us from crashing when encountering it.
-            if (starts_with("@keyframes ")) {
-                advance(std::strlen("@keyframes "));
+            // Make sure we don't crash if we hit a currently unsupported at-rule.
+            // @font-face works fine with the normal parsing-logic.
+            if (starts_with("@") && !starts_with("@font-face")) {
+                std::ignore = consume_while([](char c) { return c != ' ' && c != '{' && c != '('; });
                 skip_whitespace_and_comments();
-                [[maybe_unused]] auto keyframes_name = consume_while([](char c) { return c != '{'; });
+                std::ignore = consume_while([](char c) { return c != '{'; });
                 consume_char(); // {
                 skip_whitespace_and_comments();
 
                 while (peek() != '}') {
-                    [[maybe_unused]] auto rule = parse_rule();
+                    std::ignore = parse_rule();
                     skip_whitespace_and_comments();
                 }
 

--- a/css/parser.h
+++ b/css/parser.h
@@ -11,6 +11,7 @@
 #include "util/base_parser.h"
 
 #include <fmt/format.h>
+#include <spdlog/spdlog.h>
 
 #include <array>
 #include <charconv>
@@ -48,7 +49,9 @@ public:
             // Make sure we don't crash if we hit a currently unsupported at-rule.
             // @font-face works fine with the normal parsing-logic.
             if (starts_with("@") && !starts_with("@font-face")) {
-                std::ignore = consume_while([](char c) { return c != ' ' && c != '{' && c != '('; });
+                auto kind = consume_while([](char c) { return c != ' ' && c != '{' && c != '('; });
+                spdlog::warn("Encountered unhandled {} at-rule", kind);
+
                 skip_whitespace_and_comments();
                 std::ignore = consume_while([](char c) { return c != '{'; });
                 consume_char(); // {

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -680,5 +680,26 @@ int main() {
         expect(rules.empty());
     });
 
+    etest::test("parser: @font-face", [] {
+        // This isn't correct, but it doesn't crash.
+        auto css = R"(
+            @font-face {
+                font-family: "Open Sans";
+                src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
+                     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
+            })"sv;
+
+        auto rules = css::parse(css);
+        expect_eq(rules.size(), std::size_t{1});
+        expect_eq(rules[0].selectors, std::vector{"@font-face"s});
+        expect_eq(rules[0].declarations.size(), std::size_t{2});
+        expect_eq(rules[0].declarations.at("font-family"), R"("Open Sans")");
+        auto const &src = rules[0].declarations.at("src");
+        auto woff2 = src.find(R"(url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"))");
+        expect(woff2 != std::string::npos);
+        auto woff = src.find(R"(url("/fonts/OpenSans-Regular-webfont.woff") format("woff")");
+        expect(woff != std::string::npos);
+    });
+
     return etest::run_all_tests();
 }


### PR DESCRIPTION
With this change we can load github.com again.