### PR TITLE
ci: Use the preinstalled LLVM 14 for the clang-cl job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,8 +151,6 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v3
-      # windows-2022 ships with llvm 13 which doesn't seem to work for us.
-      - run: choco install llvm -y --force --version 14.0.5
       - run: echo "build --config clang-cl" >.bazelrc.local
       - run: bazel test ...
       # TODO(robinlinden): This no longer runs in CI due to http://example.com


### PR DESCRIPTION
The preinstalled LLVM was upgraded from 13 to 14 a few months ago, so we don't have to update it ourselves anymore.

This should save us around 1.5 minutes per CI run which is nice since the clang-cl job is the one that takes the longest.