### PR TITLE
Nuke range-v3 dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -118,13 +118,6 @@ http_archive(
 )
 
 http_archive(
-    name = "range-v3",  # BSL-1.0
-    sha256 = "015adb2300a98edfceaf0725beec3337f542af4915cec4d0b89fa0886f4ba9cb",
-    strip_prefix = "range-v3-0.12.0",
-    url = "https://github.com/ericniebler/range-v3/archive/0.12.0.tar.gz",
-)
-
-http_archive(
     name = "sfml",  # Zlib
     build_file = "//third_party:sfml.BUILD",
     # Work around SFML check for enough bytes for a given UTF-8 character crashing

--- a/dom/BUILD
+++ b/dom/BUILD
@@ -7,7 +7,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//util:overloaded",
-        "@range-v3",
     ],
 )
 

--- a/dom/dom.cpp
+++ b/dom/dom.cpp
@@ -1,14 +1,10 @@
-// SPDX-FileCopyrightText: 2021 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "dom/dom.h"
 
 #include "util/overloaded.h"
-
-#include <range/v3/action/push_back.hpp>
-#include <range/v3/view/remove_if.hpp>
-#include <range/v3/view/transform.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -71,10 +67,11 @@ std::vector<Element const *> nodes_by_path(std::reference_wrapper<Element const>
             }
 
             if (path.starts_with(node->name + ".")) {
-                auto view = node->children
-                        | ranges::views::transform([](Node const &n) { return std::get_if<Element>(&n); })
-                        | ranges::views::remove_if([](Element const *n) { return n == nullptr; });
-                next_search |= ranges::actions::push_back(view);
+                for (auto const &child : node->children) {
+                    if (auto const *element = std::get_if<Element>(&child)) {
+                        next_search.push_back(element);
+                    }
+                }
             }
         }
 

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -13,7 +13,6 @@ cc_library(
         "//uri",
         "//util:string",
         "@fmt",
-        "@range-v3",
     ],
 )
 

--- a/protocol/response.cpp
+++ b/protocol/response.cpp
@@ -7,8 +7,7 @@
 
 #include "util/string.h"
 
-#include <range/v3/algorithm/lexicographical_compare.hpp>
-
+#include <algorithm>
 #include <sstream>
 #include <utility>
 
@@ -38,8 +37,9 @@ std::size_t Headers::size() const {
 }
 
 bool Headers::CaseInsensitiveLess::operator()(std::string_view s1, std::string_view s2) const {
-    return ranges::lexicographical_compare(
-            s1, s2, [](char c1, char c2) { return util::lowercased(c1) < util::lowercased(c2); });
+    return std::lexicographical_compare(begin(s1), end(s1), begin(s2), end(s2), [](char c1, char c2) {
+        return util::lowercased(c1) < util::lowercased(c2);
+    });
 }
 
 } // namespace protocol

--- a/render/BUILD
+++ b/render/BUILD
@@ -10,7 +10,6 @@ cc_library(
         "//gfx",
         "//layout",
         "//util:string",
-        "@range-v3",
         "@spdlog",
     ],
 )

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -9,9 +9,9 @@
 #include "gfx/color.h"
 #include "util/string.h"
 
-#include <range/v3/algorithm/lexicographical_compare.hpp>
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
 #include <charconv>
 #include <cstdint>
 #include <map>
@@ -29,8 +29,9 @@ constexpr gfx::Color kDefaultColor{0x0, 0x0, 0x0};
 struct CaseInsensitiveLess {
     using is_transparent = void;
     bool operator()(std::string_view s1, std::string_view s2) const {
-        return ranges::lexicographical_compare(
-                s1, s2, [](char c1, char c2) { return util::lowercased(c1) < util::lowercased(c2); });
+        return std::lexicographical_compare(begin(s1), end(s1), begin(s2), end(s2), [](char c1, char c2) {
+            return util::lowercased(c1) < util::lowercased(c2);
+        });
     }
 };
 

--- a/util/BUILD
+++ b/util/BUILD
@@ -1,17 +1,9 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
-dependencies = {
-    "string": ["@range-v3"],
-}
-
 [cc_library(
     name = hdr[:-2],
     hdrs = [hdr],
     visibility = ["//visibility:public"],
-    deps = dependencies.get(
-        hdr[:-2],
-        [],
-    ),
 ) for hdr in glob(["*.h"])]
 
 [cc_test(

--- a/util/string.h
+++ b/util/string.h
@@ -6,8 +6,6 @@
 #ifndef UTIL_STRING_H_
 #define UTIL_STRING_H_
 
-#include <range/v3/algorithm/equal.hpp>
-
 #include <algorithm>
 #include <array>
 #include <iterator>
@@ -63,7 +61,8 @@ constexpr char lowercased(char c) {
 }
 
 constexpr bool no_case_compare(std::string_view a, std::string_view b) {
-    return ranges::equal(a, b, [](auto c1, auto c2) { return lowercased(c1) == lowercased(c2); });
+    return std::equal(
+            begin(a), end(a), begin(b), end(b), [](auto c1, auto c2) { return lowercased(c1) == lowercased(c2); });
 }
 
 inline std::vector<std::string_view> split(std::string_view str, std::string_view sep) {


### PR DESCRIPTION
In a way this is a bit sad since std::ranges is a lot nicer than what we do right now, but it's also a dependency, and hopefully Clang 16 will finish their range implementation. Even updating to Clang 15 would allow us to use std::ranges for almost all <algorithm> things we do right now.