### PR TITLE
Enforce more formatting bits in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,6 +182,14 @@ jobs:
       - run: npx prettier --ignore-path .gitignore --write . '!**/*.frag'
       - run: git diff --exit-code
 
+  shfmt:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: pip install shfmt-py==3.4.3.1
+      - run: shfmt -i 2 -w $(shfmt -f .)
+      - run: git diff --exit-code
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
           wget --output-document=buildifier https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-amd64
           sudo chmod +x buildifier
       - name: Check
-        run: ./buildifier --lint=warn --warnings=all -mode diff WORKSPACE $(find . -type f -iname "*.BUILD" -or -iname BUILD)
+        run: ./buildifier --lint=warn --warnings=all -mode diff WORKSPACE $(find . -type f -iname "*.BUILD" -or -iname BUILD -or -iname "*.bzl")
 
   prettier:
     runs-on: ubuntu-20.04

--- a/bzl/defs.bzl
+++ b/bzl/defs.bzl
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Starlark rules for creating xfail tests."""
+
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 
 def cc_xfail_test(


### PR DESCRIPTION
Both shell scripts and .bzl-files were introduced in 774c22cedd1fabbdad0992c4698a6695bf554e3e.