### PR TITLE
html2: Fix the replacement character not being emitted in UTF-8

### DIFF
--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -93,6 +93,8 @@ constexpr bool is_unicode_noncharacter(int code_point) {
     }
 }
 
+std::string const kReplacementCharacter = util::unicode_to_utf8(0xFFFD);
+
 } // namespace
 
 void Tokenizer::set_state(State state) {
@@ -939,7 +941,7 @@ void Tokenizer::run() {
                         continue;
                     case '\0':
                         emit(ParseError::UnexpectedNullCharacter);
-                        current_attribute().value.append(util::unicode_to_utf8(0xFFFD));
+                        current_attribute().value += kReplacementCharacter;
                         continue;
                     case '"':
                     case '\'':
@@ -1023,7 +1025,7 @@ void Tokenizer::run() {
                         continue;
                     case '\0':
                         emit(ParseError::UnexpectedNullCharacter);
-                        std::get<CommentToken>(current_token_).data += util::unicode_to_utf8(0xFFFD);
+                        std::get<CommentToken>(current_token_).data += kReplacementCharacter;
                         continue;
                 }
 
@@ -1498,7 +1500,7 @@ void Tokenizer::run() {
                         continue;
                     case '\0':
                         emit(ParseError::UnexpectedNullCharacter);
-                        *std::get<DoctypeToken>(current_token_).public_identifier += util::unicode_to_utf8(0xFFFD);
+                        *std::get<DoctypeToken>(current_token_).public_identifier += kReplacementCharacter;
                         continue;
                     case '>':
                         emit(ParseError::AbruptDoctypePublicIdentifier);
@@ -1528,7 +1530,7 @@ void Tokenizer::run() {
                         continue;
                     case '\0':
                         emit(ParseError::UnexpectedNullCharacter);
-                        *std::get<DoctypeToken>(current_token_).public_identifier += util::unicode_to_utf8(0xFFFD);
+                        *std::get<DoctypeToken>(current_token_).public_identifier += kReplacementCharacter;
                         continue;
                     case '>':
                         emit(ParseError::AbruptDoctypePublicIdentifier);
@@ -1940,7 +1942,7 @@ bool Tokenizer::is_appropriate_end_tag_token(Token const &token) const {
 }
 
 void Tokenizer::emit_replacement_character() {
-    for (char c : util::unicode_to_utf8(0xFFFD)) {
+    for (char c : kReplacementCharacter) {
         emit(CharacterToken{c});
     }
 }

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -240,8 +240,8 @@ void Tokenizer::run() {
                         emit(std::move(current_token_));
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
-                        append_to_tag_name("\xFF\xFD");
+                        emit(ParseError::UnexpectedNullCharacter);
+                        append_to_tag_name(kReplacementCharacter);
                         continue;
                     default:
                         append_to_tag_name(*c);
@@ -790,8 +790,8 @@ void Tokenizer::run() {
                         state_ = State::BeforeAttributeValue;
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
-                        append_to_current_attribute_name("\xFF\xFD");
+                        emit(ParseError::UnexpectedNullCharacter);
+                        append_to_current_attribute_name(kReplacementCharacter);
                         continue;
                     case '"':
                     case '\'':
@@ -881,8 +881,8 @@ void Tokenizer::run() {
                         state_ = State::CharacterReference;
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
-                        current_attribute().value += "\xFF\xFD";
+                        emit(ParseError::UnexpectedNullCharacter);
+                        current_attribute().value += kReplacementCharacter;
                         continue;
                     default:
                         current_attribute().value += *c;
@@ -907,8 +907,8 @@ void Tokenizer::run() {
                         state_ = State::CharacterReference;
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
-                        current_attribute().value += "\xFF\xFD";
+                        emit(ParseError::UnexpectedNullCharacter);
+                        current_attribute().value += kReplacementCharacter;
                         continue;
                     default:
                         current_attribute().value += *c;
@@ -1113,8 +1113,8 @@ void Tokenizer::run() {
                         state_ = State::CommentEndDash;
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
-                        std::get<CommentToken>(current_token_).data.append("\xFF\xFD");
+                        emit(ParseError::UnexpectedNullCharacter);
+                        std::get<CommentToken>(current_token_).data += kReplacementCharacter;
                         continue;
                     default:
                         std::get<CommentToken>(current_token_).data.append(1, *c);
@@ -1312,9 +1312,9 @@ void Tokenizer::run() {
                     case ' ':
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
+                        emit(ParseError::UnexpectedNullCharacter);
                         current_token_ = DoctypeToken{.name = std::string{}};
-                        std::get<DoctypeToken>(current_token_).name->append("\xFF\xFD");
+                        *std::get<DoctypeToken>(current_token_).name += kReplacementCharacter;
                         state_ = State::DoctypeName;
                         continue;
                     case '>':
@@ -1358,8 +1358,8 @@ void Tokenizer::run() {
                         emit(std::move(current_token_));
                         continue;
                     case '\0':
-                        // This is an unexpected-null-character parse error.
-                        std::get<DoctypeToken>(current_token_).name->append("\xFF\xFD");
+                        emit(ParseError::UnexpectedNullCharacter);
+                        *std::get<DoctypeToken>(current_token_).name += kReplacementCharacter;
                         continue;
                     default:
                         std::get<DoctypeToken>(current_token_).name->append(1, *c);


### PR DESCRIPTION
Resolves #135 