### PR TITLE
css2: Add partial support for tokenizing strings

### DIFF
--- a/css2/tokenizer.h
+++ b/css2/tokenizer.h
@@ -21,11 +21,14 @@ enum class State {
     CommentStart,
     Comment,
     CommentEnd,
+    String,
     Whitespace,
 };
 
 enum class ParseError {
     EofInComment,
+    EofInString,
+    NewlineInString,
 };
 
 class Tokenizer {
@@ -39,6 +42,9 @@ private:
     std::string_view input_;
     std::size_t pos_{0};
     State state_{State::Main};
+    Token current_token_{};
+
+    char string_ending_{};
 
     std::function<void(Token &&)> on_emit_;
     std::function<void(ParseError)> on_error_;

--- a/css2/tokenizer_test.cpp
+++ b/css2/tokenizer_test.cpp
@@ -135,5 +135,33 @@ int main() {
         expect_token(output, DelimToken{'a'});
         expect_token(output, WhitespaceToken{});
     });
+
+    etest::test("single quoted string", [] {
+        auto output = run_tokenizer("\'this is a string\'");
+
+        expect_token(output, StringToken{"this is a string"});
+    });
+
+    etest::test("double quoted string", [] {
+        auto output = run_tokenizer("\"this is a string\"");
+
+        expect_token(output, StringToken{"this is a string"});
+    });
+
+    etest::test("eof in string", [] {
+        auto output = run_tokenizer("\"this is a");
+
+        expect_error(output, ParseError::EofInString);
+        expect_token(output, StringToken{"this is a"});
+    });
+
+    etest::test("newline in string", [] {
+        auto output = run_tokenizer("\"this is a\n");
+
+        expect_error(output, ParseError::NewlineInString);
+        expect_token(output, BadStringToken{});
+        expect_token(output, WhitespaceToken{});
+    });
+
     return etest::run_all_tests();
 }


### PR DESCRIPTION
Implementation is based on this chapter in the specification: https://www.w3.org/TR/css-syntax-3/#consume-string-token