### PR TITLE
ci: Use the Bazel disk cache in the Windows jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,11 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/bazel
+          key: windows_msvc-${{ hashFiles('WORKSPACE', 'third_party/**') }}
+      - run: echo "build --disk_cache ~/.cache/bazel" >.bazelrc.local
       - name: Build
         run: bazel build ... -c dbg
       - name: Test
@@ -145,7 +150,12 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/bazel
+          key: windows_clang_cl-${{ hashFiles('WORKSPACE', 'third_party/**') }}
       - run: echo "build --config clang-cl" >.bazelrc.local
+      - run: echo "build --disk_cache ~/.cache/bazel" >>.bazelrc.local
       - run: bazel test ...
       # TODO(robinlinden): This no longer runs in CI due to http://example.com
       # being inaccessible.


### PR DESCRIPTION
While not perfect, this does improve the CI run time a lot.

Before:
![before](https://user-images.githubusercontent.com/8304462/196010395-88bba234-1bdf-413a-830e-d37dc395b680.png)


After:
![after](https://user-images.githubusercontent.com/8304462/196010386-ea2c350e-14a3-4ff2-9eb5-0708af2cc4c3.png)


Resolves #185