### PR TITLE
Move handling of origin/scheme-relative uris into `//uri`

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -294,7 +294,7 @@ int App::run() {
 
 void App::navigate() {
     page_loaded_ = false;
-    auto uri = uri::Uri::parse(url_buf_);
+    auto uri = uri::Uri::parse(url_buf_, engine_.uri());
     browse_history_.push(uri);
     engine_.navigate(std::move(uri));
 

--- a/engine/engine_test.cpp
+++ b/engine/engine_test.cpp
@@ -75,25 +75,5 @@ int main() {
         expect(success);
     });
 
-    etest::test("origin-relative uri", [] {
-        engine::Engine e{std::make_unique<FakeProtocolHandler>(protocol::Response{.err = protocol::Error::Ok})};
-
-        e.navigate(uri::Uri::parse("hax://example.com"));
-        expect_eq(e.uri(), uri::Uri::parse("hax://example.com"));
-
-        e.navigate(uri::Uri::parse("/test"));
-        expect_eq(e.uri(), uri::Uri::parse("hax://example.com/test"));
-    });
-
-    etest::test("scheme-relative uri", [] {
-        engine::Engine e{std::make_unique<FakeProtocolHandler>(protocol::Response{.err = protocol::Error::Ok})};
-
-        e.navigate(uri::Uri::parse("hax://example.com"));
-        expect_eq(e.uri(), uri::Uri::parse("hax://example.com"));
-
-        e.navigate(uri::Uri::parse("//example2.com/test"));
-        expect_eq(e.uri(), uri::Uri::parse("hax://example2.com/test"));
-    });
-
     return etest::run_all_tests();
 }

--- a/uri/BUILD
+++ b/uri/BUILD
@@ -9,6 +9,7 @@ cc_library(
     deps = [
         "//util:string",
         "@ctre",
+        "@fmt",
     ],
 )
 

--- a/uri/uri.h
+++ b/uri/uri.h
@@ -6,6 +6,8 @@
 #ifndef URI_URI_H_
 #define URI_URI_H_
 
+#include <functional>
+#include <optional>
 #include <string>
 
 namespace uri {
@@ -22,7 +24,7 @@ struct Authority {
 };
 
 struct Uri {
-    static Uri parse(std::string uri);
+    static Uri parse(std::string uri, std::optional<std::reference_wrapper<Uri const>> base_uri = std::nullopt);
 
     std::string uri;
     std::string scheme;

--- a/uri/uri_test.cpp
+++ b/uri/uri_test.cpp
@@ -157,5 +157,17 @@ int main() {
         expect_eq(actual, expected);
     });
 
+    etest::test("origin-relative completion", [] {
+        auto const base = uri::Uri::parse("hax://example.com");
+        auto const completed = uri::Uri::parse("/test", base);
+        expect_eq(completed, uri::Uri::parse("hax://example.com/test"));
+    });
+
+    etest::test("scheme-relative uri", [] {
+        auto const base = uri::Uri::parse("hax://example.com");
+        auto const completed = uri::Uri::parse("//example2.com/test", base);
+        expect_eq(completed, uri::Uri::parse("hax://example2.com/test"));
+    });
+
     return etest::run_all_tests();
 }


### PR DESCRIPTION
Previously this was sort of handled in 2 different places in `//engine`, and would have had to be added to yet more places. This also gives us one place to add support for e.g. relative uris which was what I was originally planning on doing.

@mkiael Not sure what to call this member function. `Uri Uri::complete_uri(std::string) const` doesn't feel super intuitive. Any ideas? One thing I considered was adding a `std::optional<Uri> const &base` argument to `Uri::parse`.