### PR TITLE
layout: Support fractional sizes in pixel calculation

### DIFF
--- a/layout/BUILD
+++ b/layout/BUILD
@@ -9,6 +9,7 @@ cc_library(
         "//geom",
         "//style",
         "//util:overloaded",
+        "@spdlog",
     ],
 )
 

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -87,6 +87,11 @@ std::map<std::string_view, float> const kFontSizeAbsoluteSizeKeywords{
 // * Not all measurements have to be in pixels.
 // * %, rem
 int to_px(std::string_view property, int const font_size) {
+    // Special case for 0 since it won't ever have a unit that needs to be handled.
+    if (property == "0") {
+        return 0;
+    }
+
     int res{};
     auto parse_result = std::from_chars(property.data(), property.data() + property.size(), res);
     if (parse_result.ec != std::errc{}) {

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -99,10 +99,19 @@ int to_px(std::string_view property, int const font_size) {
         return res;
     }
 
-    if (property.ends_with("em")) {
-        res *= font_size;
+    auto const parsed_length = std::distance(property.data(), parse_result.ptr);
+    auto const unit = property.substr(parsed_length);
+
+    if (unit == "px") {
+        return res;
     }
 
+    if (unit == "em") {
+        res *= font_size;
+        return res;
+    }
+
+    spdlog::warn("Bad property '{}' w/ unit '{}' in to_px", property, unit);
     return res;
 }
 

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -7,6 +7,8 @@
 
 #include "util/overloaded.h"
 
+#include <spdlog/spdlog.h>
+
 #include <algorithm>
 #include <cassert>
 #include <charconv>
@@ -86,7 +88,12 @@ std::map<std::string_view, float> const kFontSizeAbsoluteSizeKeywords{
 // * %, rem
 int to_px(std::string_view property, int const font_size) {
     int res{};
-    std::from_chars(property.data(), property.data() + property.size(), res);
+    auto parse_result = std::from_chars(property.data(), property.data() + property.size(), res);
+    if (parse_result.ec != std::errc{}) {
+        spdlog::warn("Unable to parse property '{}' in to_px", property);
+        return res;
+    }
+
     if (property.ends_with("em")) {
         res *= font_size;
     }

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -1042,6 +1042,23 @@ int main() {
         expect_eq(layout, expected_layout);
     });
 
+    etest::test("unhandled unit", [] {
+        dom::Node dom = dom::Element{.name{"html"}};
+        style::StyledNode style{
+                .node{dom},
+                .properties{{"display", "block"}, {"height", "0notarealunit"}},
+        };
+
+        layout::LayoutBox expected_layout{
+                .node = &style,
+                .type = LayoutType::Block,
+                .dimensions{{0, 0, 0, 0}},
+        };
+
+        auto layout = layout::create_layout(style, 0);
+        expect_eq(layout, expected_layout);
+    });
+
     etest::test("get_property", [] {
         dom::Node dom_root = dom::Element{.name{"html"}, .attributes{}, .children{}};
         auto style_root = style::StyledNode{.node = dom_root, .properties = {{"color", "green"}}, .children{}};

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -1025,6 +1025,23 @@ int main() {
         expect_eq(medium_layout_width * 3, xxxlarge_layout_width);
     });
 
+    etest::test("invalid size", [] {
+        dom::Node dom = dom::Element{.name{"html"}};
+        style::StyledNode style{
+                .node{dom},
+                .properties{{"display", "block"}, {"height", "no"}},
+        };
+
+        layout::LayoutBox expected_layout{
+                .node = &style,
+                .type = LayoutType::Block,
+                .dimensions{{0, 0, 0, 0}},
+        };
+
+        auto layout = layout::create_layout(style, 0);
+        expect_eq(layout, expected_layout);
+    });
+
     etest::test("get_property", [] {
         dom::Node dom_root = dom::Element{.name{"html"}, .attributes{}, .children{}};
         auto style_root = style::StyledNode{.node = dom_root, .properties = {{"color", "green"}}, .children{}};


### PR DESCRIPTION
The main things being that now we support fractional sizes, and warn on things we don't handle.