### PR TITLE
ci: Take the Bazel version into account when computing the cache key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.cache/bazel
-          key: ${{ matrix.name }}-${{ hashFiles('WORKSPACE', 'third_party/**') }}
+          key: ${{ matrix.name }}-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
           restore-keys: ${{ matrix.name }}-
       - name: Build
         run: bazel build //... ${{ matrix.bazel }}
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.cache/bazel
-          key: ${{ matrix.name }}-${{ hashFiles('WORKSPACE', 'third_party/**') }}
+          key: ${{ matrix.name }}-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
           restore-keys: ${{ matrix.name }}-
       - name: Install
         run: |


### PR DESCRIPTION
This is only needed in the Linux jobs, where we don't use --disk_cache and instead save the entire Bazel dir.