### PR TITLE
all: Simplify substr-calls that get the rest of the string

### DIFF
--- a/css/parser.h
+++ b/css/parser.h
@@ -131,7 +131,7 @@ private:
                 pos = loc + 1;
             }
             if (pos < str.size()) {
-                tokens.push_back(str.substr(pos, str.size() - pos));
+                tokens.push_back(str.substr(pos));
             }
             token_iter = cbegin(tokens);
         }
@@ -343,7 +343,7 @@ private:
             std::string_view str = *token;
             if (std::size_t loc = str.find('/'); loc != std::string_view::npos) {
                 std::string_view font_size = str.substr(0, loc);
-                std::string_view line_height = str.substr(loc + 1, str.size() - loc);
+                std::string_view line_height = str.substr(loc + 1);
                 return std::pair(std::move(font_size), std::move(line_height));
             } else if (is_absolute_size(str) || is_relative_size(str) || is_length_or_percentage(str)) {
                 return std::pair(std::move(str), std::nullopt);

--- a/protocol/http.cpp
+++ b/protocol/http.cpp
@@ -65,7 +65,7 @@ std::optional<StatusLine> Http::parse_status_line(std::string_view status_line) 
     return StatusLine{
             std::string{status_line.substr(0, sep1)},
             status_code,
-            std::string{status_line.substr(sep2 + 1, status_line.size())},
+            std::string{status_line.substr(sep2 + 1)},
     };
 }
 

--- a/uri/uri.cpp
+++ b/uri/uri.cpp
@@ -55,12 +55,12 @@ Uri Uri::parse(std::string uristr, std::optional<std::reference_wrapper<Uri cons
     if (auto userinfo_end = hostport.find_first_of('@'); userinfo_end != std::string::npos) {
         // Userinfo present.
         std::string userinfo = hostport.substr(0, userinfo_end);
-        hostport = hostport.substr(userinfo_end + 1, hostport.size() - userinfo_end);
+        hostport = hostport.substr(userinfo_end + 1);
 
         if (auto user_end = userinfo.find_first_of(':'); user_end != std::string::npos) {
             // Password present.
             authority.user = userinfo.substr(0, user_end);
-            authority.passwd = userinfo.substr(user_end + 1, userinfo.size() - user_end);
+            authority.passwd = userinfo.substr(user_end + 1);
         } else {
             // Password not present.
             authority.user = std::move(userinfo);
@@ -70,7 +70,7 @@ Uri Uri::parse(std::string uristr, std::optional<std::reference_wrapper<Uri cons
     if (auto host_end = hostport.find_first_of(':'); host_end != std::string::npos) {
         // Port present.
         authority.host = hostport.substr(0, host_end);
-        authority.port = hostport.substr(host_end + 1, hostport.size() - host_end);
+        authority.port = hostport.substr(host_end + 1);
     } else {
         // Port not present.
         authority.host = std::move(hostport);

--- a/util/string.h
+++ b/util/string.h
@@ -76,7 +76,7 @@ inline std::vector<std::string_view> split(std::string_view str, std::string_vie
 
 inline std::pair<std::string_view, std::string_view> split_once(std::string_view str, std::string_view sep) {
     if (auto p = str.find(sep); p != str.npos) {
-        return {str.substr(0, p), str.substr(p + sep.size(), str.size() - p - sep.size())};
+        return {str.substr(0, p), str.substr(p + sep.size())};
     }
     return {str, ""};
 }


### PR DESCRIPTION
There's no need to calculate the size of the string after the index as the default is to get everything after the index.

Leaving the size out when you want "the rest" makes the intent a bit clearer.