### PR TITLE
css2: Simplify identification of ident sequence

### DIFF
--- a/css2/tokenizer.h
+++ b/css2/tokenizer.h
@@ -22,9 +22,7 @@ enum class State {
     Comment,
     CommentEnd,
     CommercialAt,
-    CommercialAtHyphenMinus,
     CommercialAtIdent,
-    HyphenMinus,
     IdentLike,
     String,
     Whitespace,
@@ -59,6 +57,8 @@ private:
     void emit(ParseError);
     void emit(Token &&);
     std::optional<char> consume_next_input_character();
+    std::optional<char> peek_input(int index) const;
+    bool inputs_starts_ident_sequence(char first_character) const;
     bool is_eof() const;
     void reconsume_in(State);
 };


### PR DESCRIPTION
This commits adds a function for identifying if a sequnce of character starts an ident sequence. Support for handling escaped characters is still missing.