### PR TITLE
deps: Remove unused targets from dependencies

### DIFF
--- a/third_party/fmt.BUILD
+++ b/third_party/fmt.BUILD
@@ -11,11 +11,3 @@ cc_library(
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
 )
-
-cc_library(
-    name = "header_only",
-    hdrs = glob(["include/**/*.h"]),
-    defines = ["FMT_HEADER_ONLY=1"],
-    strip_include_prefix = "include",
-    visibility = ["//visibility:public"],
-)

--- a/third_party/spdlog.BUILD
+++ b/third_party/spdlog.BUILD
@@ -20,15 +20,3 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = ["@fmt"],
 )
-
-cc_library(
-    name = "header_only",
-    hdrs = glob(["include/**/*.h"]),
-    linkopts = select({
-        "@platforms//os:linux": ["-lpthread"],
-        "@platforms//os:windows": [],
-    }),
-    strip_include_prefix = "include",
-    visibility = ["//visibility:public"],
-    deps = ["@fmt"],
-)


### PR DESCRIPTION
No point in ever using the header-only targets now that we've set up the more proper ones.