### PR TITLE
build: Rewamp how we handle warning flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,84 +22,6 @@ build:linux --features=layering_check
 
 build:linux --cxxopt='-std=c++20'
 build:linux --cxxopt='-fno-rtti'
-build:linux --copt='-Wall'
-build:linux --copt='-Wextra'
-build:linux --copt='-pedantic-errors'
-build:linux --copt='-Werror'
-build:linux --copt='-Wdouble-promotion'
-build:linux --copt='-Wformat=2'
-build:linux --copt='-Wmissing-declarations'
-build:linux --copt='-Wnull-dereference'
-build:linux --copt='-Wshadow'
-build:linux --copt='-Wsign-compare'
-build:linux --copt='-Wundef'
-build:linux --copt='-fno-common'
-build:linux --cxxopt='-Wnon-virtual-dtor'
-build:linux --cxxopt='-Woverloaded-virtual'
-build:linux --copt='-Wno-missing-field-initializers' # Common idiom for zeroing members.
-build:linux --per_file_copt='gfx:sfml_canvas@-Wno-implicit-fallthrough' # sfml leaks this into our code.
-build:linux --per_file_copt='net:socket@-Wno-nonnull' # asio leaks this into our code.
-build:linux --per_file_copt='net:socket@-Wno-shadow' # asio leaks this into our code.
-build:linux --per_file_copt='net:socket@-Wno-undef' # asio leaks this into our code.
-build:linux --per_file_copt='external/asio[:/]@-Wno-sign-compare'
-build:linux --per_file_copt='external/asio[:/]@-Wno-undef'
-build:linux --per_file_copt='external/boringssl[:/]@-Wno-cast-function-type'
-build:linux --per_file_copt='external/boringssl[:/]@-Wno-gnu-binary-literal'
-build:linux --per_file_copt='external/boringssl[:/]@-Wno-overlength-strings'
-build:linux --per_file_copt='external/boringssl[:/]@-Wno-pedantic'
-build:linux --per_file_copt='external/boringssl[:/]@-Wno-unused-parameter'
-build:linux --per_file_copt='external/com_google_absl[:/]@-Wno-double-promotion'
-build:linux --per_file_copt='external/com_google_absl[:/]@-Wno-format-nonliteral'
-build:linux --per_file_copt='external/com_google_absl[:/]@-Wno-gcc-compat'
-build:linux --per_file_copt='external/com_google_absl[:/]@-Wno-pedantic'
-build:linux --per_file_copt='external/freetype2[:/]@-Wno-cast-function-type'
-build:linux --per_file_copt='external/freetype2[:/]@-Wno-implicit-fallthrough'
-build:linux --per_file_copt='external/freetype2[:/]@-Wno-missing-declarations'
-build:linux --per_file_copt='external/freetype2[:/]@-Wno-sometimes-uninitialized'
-build:linux --per_file_copt='external/freetype2[:/]@-Wno-unused-but-set-variable'
-build:linux --per_file_copt='external/ftxui[:/]@-Wno-double-promotion'
-build:linux --per_file_copt='external/ftxui[:/]@-Wno-missing-declarations'
-build:linux --per_file_copt='external/glew[:/]@-Wno-strict-prototypes'
-build:linux --per_file_copt='external/glew[:/]@-Wno-undef'
-build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-empty-translation-unit'
-build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-format-nonliteral'
-build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-gnu-case-range'
-build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-gnu-designator'
-build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-pedantic'
-build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-shadow'
-build:linux --per_file_copt='external/honggfuzz[:/]@-Wno-undef'
-build:linux --per_file_copt='external/imgui-sfml[:/]@-Wno-double-promotion'
-build:linux --per_file_copt='external/imgui-sfml[:/]@-Wno-implicit-fallthrough'
-build:linux --per_file_copt='external/imgui-sfml[:/]@-Wno-missing-declarations'
-build:linux --per_file_copt='external/imgui-sfml[:/]@-Wno-switch'
-build:linux --per_file_copt='external/imgui[:/]@-Wno-deprecated-enum-enum-conversion'
-build:linux --per_file_copt='external/imgui[:/]@-Wno-double-promotion'
-build:linux --per_file_copt='external/libpng[:/]@-Wno-null-pointer-subtraction'
-build:linux --per_file_copt='external/libpng[:/]@-Wno-undef'
-build:linux --per_file_copt='external/libpng[:/]@-Wno-unused-but-set-variable'
-build:linux --per_file_copt='external/rules_fuzzing[:/]@-Wno-double-promotion'
-build:linux --per_file_copt='external/rules_fuzzing[:/]@-Wno-gcc-compat'
-build:linux --per_file_copt='external/rules_fuzzing[:/]@-Wno-pedantic'
-build:linux --per_file_copt='external/sfml[:/]@-Wno-double-promotion'
-build:linux --per_file_copt='external/sfml[:/]@-Wno-implicit-fallthrough'
-build:linux --per_file_copt='external/sfml[:/]@-Wno-missing-declarations'
-build:linux --per_file_copt='external/sfml[:/]@-Wno-shadow'
-build:linux --per_file_copt='external/sfml[:/]@-Wno-sign-compare'
-build:linux --per_file_copt='external/sfml[:/]@-Wno-undef'
-build:linux --per_file_copt='external/sfml[:/]@-Wno-unused-parameter'
-build:linux --per_file_copt='external/udev-zero[:/]@-Wno-format-nonliteral'
-build:linux --per_file_copt='external/udev-zero[:/]@-Wno-unused-parameter'
-build:linux --per_file_copt='external/xext[:/]@-Wno-missing-declarations'
-build:linux --per_file_copt='external/xext[:/]@-Wno-sign-compare'
-build:linux --per_file_copt='external/xext[:/]@-Wno-unused-parameter'
-build:linux --per_file_copt='external/xrandr[:/]@-Wno-type-limits'
-build:linux --per_file_copt='external/xrandr[:/]@-Wno-unused-parameter'
-build:linux --per_file_copt='external/xrender[:/]@-Wno-sign-compare'
-build:linux --per_file_copt='external/xrender[:/]@-Wno-unused-parameter'
-build:linux --per_file_copt='external/zlib[:/]@-Wno-format-nonliteral'
-build:linux --per_file_copt='external/zlib[:/]@-Wno-implicit-fallthrough'
-build:linux --per_file_copt='external/zlib[:/]@-Wno-missing-declarations'
-build:linux --per_file_copt='external/zlib[:/]@-Wno-strict-prototypes'
 
 # Force DWARF-4 format for debug symbols for compatibility with valgrind.
 # See: https://bugs.kde.org/show_bug.cgi?id=452758
@@ -107,56 +29,19 @@ build:linux --copt='-gdwarf-4'
 
 build:gcc10 --cxxopt='-fcoroutines'
 
-build:gcc12 --per_file_copt='external/freetype2[:/]@-Wno-dangling-pointer'
-build:gcc12 --per_file_copt='external/glew[:/]@-Wno-address'
-build:gcc12 --per_file_copt='external/libpng[:/]@-Wno-maybe-uninitialized'
-
-build:clang15 --per_file_copt='external/com_google_absl[:/]@-Wno-deprecated-builtins'
-build:clang15 --per_file_copt='external/ftxui[:/]@-Wno-deprecated-declarations'
-build:clang15 --per_file_copt='external/rules_fuzzing[:/]@-Wno-deprecated-builtins'
-build:clang15 --per_file_copt='external/xext[:/]@-Wno-invalid-utf8'
-build:clang15 --per_file_copt='external/zlib[:/]@-Wno-deprecated-non-prototype'
-
 build:windows --enable_runfiles
 build:windows --cxxopt='/std:c++20'
 build:windows --cxxopt='/GR-' # Disable rtti.
-build:windows --copt='/W4' # More warnings.
-build:windows --copt='/WX' # Treat warnings as errors.
 build:windows --copt='/permissive-' # Conform to the standard.
 build:windows --copt='/Zc:__cplusplus' # Report the real supported C++ version, not just C++98.
-build:windows --per_file_copt='external/boringssl[:/]@/wd4100' # C4100: 'out_public_key': unreferenced formal parameter
-build:windows --per_file_copt='external/boringssl[:/]@/wd4127' # C4127: conditional expression is constant
-build:windows --per_file_copt='external/boringssl[:/]@/wd4244' # C4244: '=': conversion from 'unsigned int' to 'uint8_t', possible loss of data
-build:windows --per_file_copt='external/boringssl[:/]@/wd4267' # C4267: '=': conversion from 'size_t' to 'int', possible loss of data
-build:windows --per_file_copt='external/boringssl[:/]@/wd4706' # C4706: assignment within conditional expression
-build:windows --per_file_copt='external/freetype2[:/]@/wd4018' # C4018: '>': signed/unsigned mismatch
-build:windows --per_file_copt='external/freetype2[:/]@/wd4244' # C4244: '=': conversion from '__int64' to 'FT_Int', possible loss of data
-build:windows --per_file_copt='external/freetype2[:/]@/wd4267' # C4267: '=': conversion from 'size_t' to 'FT_ULong', possible loss of data
-build:windows --per_file_copt='external/freetype2[:/]@/wd4701' # C4701: potentially uninitialized local variable 'cbox' used
-build:windows --per_file_copt='external/ftxui[:/]@/wd4244' # C4244: '=': conversion from 'int' to 'uint8_t', possible loss of data
-build:windows --per_file_copt='external/ftxui[:/]@/wd4267' # C4267: '=': conversion from 'size_t' to 'int', possible loss of data
-build:windows --per_file_copt='external/imgui-sfml[:/]@/wd4244' # C4244: 'argument': conversion from 'const unsigned int' to 'float', possible loss of data
-build:windows --per_file_copt='external/sfml[:/]@/wd4100' # C4100: 'visible': unreferenced formal parameter
-build:windows --per_file_copt='external/sfml[:/]@/wd4244' # C4244: 'initializing': conversion from 'sf::Uint32' to 'sf::Uint8', possible loss of data
-build:windows --per_file_copt='external/sfml[:/]@/wd4456' # C4456: declaration of 'i' hides previous local declaration
-build:windows --per_file_copt='external/sfml[:/]@/wd4701' # C4701: potentially uninitialized local variable 'shape' used
-build:windows --per_file_copt='external/sfml[:/]@/wd4703' # C4703: potentially uninitialized local pointer variable 'shape' used
-build:windows --per_file_copt='external/zlib[:/]@/wd4127' # C4127: conditional expression is constant
-build:windows --per_file_copt='external/zlib[:/]@/wd4131' # C4131: 'adler32_z': uses old-style declarator
-build:windows --per_file_copt='external/zlib[:/]@/wd4244' # C4244: '+=': conversion from 'int' to 'ush', possible loss of data
 
 # Special build options
 # =========================================================
 
-# TODO(robinlinden): Our compilation flag management needs some cleanup for this
-# to be well-supported.
 # https://bazel.build/docs/windows#clang
 build:clang-cl --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
 build:clang-cl --extra_execution_platforms=//:x64_windows-clang-cl
 build:clang-cl --platforms=//:x64_windows-clang-cl
-build:clang-cl --copt='-Wno-error'
-build:clang-cl --copt='-Wno-missing-field-initializers'
-build:clang-cl --copt='-Wno-unused-command-line-argument'
 
 build:libc++ --cxxopt=-stdlib=libc++
 build:libc++ --cxxopt=-fexperimental-library

--- a/.bazelrc.local.example
+++ b/.bazelrc.local.example
@@ -2,7 +2,7 @@
 #
 # Copy this to .bazelrc.local and uncomment --config lines you want.
 #
-# Clang 14 on Linux and MSVC on Windows don't require any --config flags.
+# GCC-12 and Clang on Linux, and MSVC on Windows don't require any --config flags.
 
 # Choose a build type
 build -c dbg
@@ -10,9 +10,7 @@ build -c dbg
 
 # Choose a compiler
 ## Linux
-# build --config clang15
 # build --config gcc10
-# build --config gcc12
 ## Windows
 # build --config clang-cl
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
             os: ubuntu-22.04
             compiler: gcc
             version: 12
-            bazel: --config gcc12 --run_under="valgrind --leak-check=full --errors-for-leak-kinds=all --error-exitcode=1 --track-origins=yes --show-leak-kinds=all"
+            bazel: --run_under="valgrind --leak-check=full --errors-for-leak-kinds=all --error-exitcode=1 --track-origins=yes --show-leak-kinds=all"
             apt: g++-12 valgrind
 
           - name: clang-14-tsan
@@ -42,13 +42,12 @@ jobs:
             os: ubuntu-22.04
             compiler: clang
             version: 15
-            bazel: --config clang15
 
           - name: clang-15-libc++
             os: ubuntu-22.04
             compiler: clang
             version: 15
-            bazel: --config libc++ --config clang15
+            bazel: --config libc++
             apt: libc++abi-15-dev libc++-15-dev
 
     steps:

--- a/browser/BUILD
+++ b/browser/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 alias(
     name = "browser",
@@ -8,6 +9,7 @@ alias(
 cc_binary(
     name = "tui",
     srcs = ["tui.cpp"],
+    copts = HASTUR_COPTS,
     linkopts = select({
         "@platforms//os:linux": ["-lpthread"],
         "@platforms//os:windows": [],
@@ -25,6 +27,7 @@ cc_binary(
 cc_binary(
     name = "gui",
     srcs = ["gui.cpp"] + glob(["gui/*"]),
+    copts = HASTUR_COPTS,
     deps = [
         "//css",
         "//dom",

--- a/bzl/BUILD
+++ b/bzl/BUILD
@@ -3,3 +3,13 @@ filegroup(
     srcs = ["run_xfail_test"],
     visibility = ["//visibility:public"],
 )
+
+config_setting(
+    name = "is_clang-cl",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang-cl"},
+)
+
+config_setting(
+    name = "is_msvc",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "msvc-cl"},
+)

--- a/bzl/copts.bzl
+++ b/bzl/copts.bzl
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Common copts for Hastur targets."""
+
+HASTUR_LINUX_WARNING_FLAGS = [
+    "-Wall",
+    "-Wextra",
+    "-pedantic-errors",
+    "-Werror",
+    "-Wdouble-promotion",
+    "-Wformat=2",
+    "-Wmissing-declarations",
+    "-Wnull-dereference",
+    "-Wshadow",
+    "-Wsign-compare",
+    "-Wundef",
+    "-fno-common",
+    "-Wnon-virtual-dtor",
+    "-Woverloaded-virtual",
+    # Common idiom for zeroing members.
+    "-Wno-missing-field-initializers",
+]
+
+HASTUR_MSVC_WARNING_FLAGS = [
+    # More warnings.
+    "/W4",
+    # Treat warnings as errors.
+    "/WX",
+]
+
+HASTUR_CLANG_CL_WARNING_FLAGS = [
+    "-Wno-error",
+    "-Wno-missing-field-initializers",
+    "-Wno-unused-command-line-argument",
+]
+
+HASTUR_COPTS = select({
+    "//bzl:is_clang-cl": HASTUR_CLANG_CL_WARNING_FLAGS,
+    "//bzl:is_msvc": HASTUR_MSVC_WARNING_FLAGS,
+    "@platforms//os:linux": HASTUR_LINUX_WARNING_FLAGS,
+})

--- a/css/BUILD
+++ b/css/BUILD
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 genrule(
     name = "default_css",
@@ -24,6 +25,7 @@ cc_library(
         "property_id.h",
         "rule.h",
     ],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//util:base_parser",
@@ -36,6 +38,7 @@ cc_test(
     name = "css_parser_test",
     size = "small",
     srcs = ["parser_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":css",
         "//etest",
@@ -46,6 +49,7 @@ cc_test(
 cc_fuzz_test(
     name = "css_parser_fuzz_test",
     srcs = ["parser_fuzz_test.cpp"],
+    copts = HASTUR_COPTS,
     tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [":css"],
@@ -55,6 +59,7 @@ cc_test(
     name = "css_rule_test",
     size = "small",
     srcs = ["rule_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":css",
         "//etest",
@@ -65,6 +70,7 @@ cc_test(
     name = "property_id_test",
     size = "small",
     srcs = ["property_id_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":css",
         "//etest",

--- a/css2/BUILD
+++ b/css2/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "css2",
@@ -7,6 +8,7 @@ cc_library(
         exclude = ["*_test.cpp"],
     ),
     hdrs = glob(["*.h"]),
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//util:overloaded",
@@ -18,6 +20,7 @@ cc_library(
     name = src[:-4],
     size = "small",
     srcs = [src],
+    copts = HASTUR_COPTS,
     deps = [
         ":css2",
         "//etest",

--- a/dom/BUILD
+++ b/dom/BUILD
@@ -1,9 +1,11 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "dom",
     srcs = ["dom.cpp"],
     hdrs = ["dom.h"],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//util:overloaded",
@@ -14,6 +16,7 @@ cc_test(
     name = "dom_test",
     size = "small",
     srcs = ["dom_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":dom",
         "//etest",

--- a/dom2/BUILD
+++ b/dom2/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "dom2",
@@ -7,6 +8,7 @@ cc_library(
         exclude = ["*_test.cpp"],
     ),
     hdrs = glob(["*.h"]),
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
 )
 
@@ -14,6 +16,7 @@ cc_library(
     name = src[:-4],
     size = "small",
     srcs = [src],
+    copts = HASTUR_COPTS,
     deps = [
         ":dom2",
         "//etest",

--- a/engine/BUILD
+++ b/engine/BUILD
@@ -1,9 +1,11 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "engine",
     srcs = ["engine.cpp"],
     hdrs = ["engine.h"],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//css",
@@ -21,6 +23,7 @@ cc_test(
     name = "engine_test",
     size = "small",
     srcs = ["engine_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":engine",
         "//etest",

--- a/etest/BUILD
+++ b/etest/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 load("//bzl:defs.bzl", "cc_xfail_test")
 
 cc_library(
@@ -8,6 +9,7 @@ cc_library(
         "cxx_compat.h",
         "etest.h",
     ],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
 )
 
@@ -15,6 +17,7 @@ cc_library(
     name = src[:-4],
     size = "small",
     srcs = [src],
+    copts = HASTUR_COPTS,
     deps = [":etest"],
 ) for src in glob(
     include = ["*_test.cpp"],
@@ -25,5 +28,6 @@ cc_library(
     name = src[:-4],
     size = "small",
     srcs = [src],
+    copts = HASTUR_COPTS,
     deps = [":etest"],
 ) for src in glob(["*_failure_test.cpp"])]

--- a/geom/BUILD
+++ b/geom/BUILD
@@ -1,8 +1,10 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "geom",
     hdrs = ["geom.h"],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
 )
 
@@ -10,6 +12,7 @@ cc_test(
     name = "geom_test",
     size = "small",
     srcs = ["geom_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":geom",
         "//etest",

--- a/gfx/BUILD
+++ b/gfx/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "gfx",
@@ -9,6 +10,7 @@ cc_library(
         "icanvas.h",
         "painter.h",
     ],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = ["//geom"],
 )
@@ -17,6 +19,7 @@ cc_library(
     name = "opengl",
     srcs = ["opengl_canvas.cpp"],
     hdrs = ["opengl_canvas.h"],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         ":gfx",
@@ -46,6 +49,13 @@ cc_library(
         ":rect_fragment_shader",
     ],
     hdrs = ["sfml_canvas.h"],
+    copts = HASTUR_COPTS + select({
+        "@platforms//os:linux": [
+            # sfml leaks this into our code.
+            "-Wno-implicit-fallthrough",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":gfx",
@@ -59,6 +69,7 @@ cc_library(
     name = src[:-4],
     size = "small",
     srcs = [src],
+    copts = HASTUR_COPTS,
     deps = [
         ":gfx",
         "//etest",
@@ -68,6 +79,7 @@ cc_library(
 cc_binary(
     name = "gfx_example",
     srcs = ["gfx_example.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":gfx",
         ":opengl",

--- a/html/BUILD
+++ b/html/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "html",
@@ -10,6 +11,7 @@ cc_library(
         "parse.h",
         "parser.h",
     ],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//dom",
@@ -23,6 +25,7 @@ cc_test(
     name = "html_test",
     size = "small",
     srcs = ["parser_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":html",
         "//etest",

--- a/html2/BUILD
+++ b/html2/BUILD
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "html2",
@@ -8,6 +9,7 @@ cc_library(
         exclude = ["*_test.cpp"],
     ),
     hdrs = glob(["*.h"]),
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//dom2",
@@ -25,6 +27,7 @@ dependencies = {
     name = src[:-4],
     size = "small",
     srcs = [src],
+    copts = HASTUR_COPTS,
     deps = dependencies.get(
         src[:-9],
         [],
@@ -42,6 +45,7 @@ dependencies = {
     name = src[:-4],
     size = "small",
     srcs = [src],
+    copts = HASTUR_COPTS,
     tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [":html2"],

--- a/img/BUILD
+++ b/img/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "img",
@@ -7,6 +8,7 @@ cc_library(
         exclude = ["*_test.cpp"],
     ),
     hdrs = glob(["*.h"]),
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "@libpng",
@@ -32,6 +34,7 @@ extra_srcs = {
         src[:-9],
         [],
     ),
+    copts = HASTUR_COPTS,
     deps = [
         ":img",
         "//etest",

--- a/js/BUILD
+++ b/js/BUILD
@@ -1,8 +1,10 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "js",
     hdrs = glob(["*.h"]),
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
 )
 
@@ -10,6 +12,7 @@ cc_library(
     name = src[:-4],
     size = "small",
     srcs = [src],
+    copts = HASTUR_COPTS,
     deps = [
         ":js",
         "//etest",

--- a/layout/BUILD
+++ b/layout/BUILD
@@ -1,9 +1,11 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "layout",
     srcs = ["layout.cpp"],
     hdrs = glob(["*.h"]),
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//geom",

--- a/net/BUILD
+++ b/net/BUILD
@@ -7,10 +7,8 @@ cc_library(
     hdrs = ["socket.h"],
     copts = HASTUR_COPTS + select({
         "@platforms//os:linux": [
-            # asio leaks these into our code.
-            "-Wno-nonnull",
+            # asio leaks this into our code.
             "-Wno-shadow",
-            "-Wno-undef",
         ],
         "//conditions:default": [],
     }),

--- a/net/BUILD
+++ b/net/BUILD
@@ -1,9 +1,19 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "net",
     srcs = ["socket.cpp"],
     hdrs = ["socket.h"],
+    copts = HASTUR_COPTS + select({
+        "@platforms//os:linux": [
+            # asio leaks these into our code.
+            "-Wno-nonnull",
+            "-Wno-shadow",
+            "-Wno-undef",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = ["@asio"],
 )

--- a/os/BUILD
+++ b/os/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "os",
@@ -7,6 +8,7 @@ cc_library(
         "@platforms//os:windows": ["windows.cpp"],
     }),
     hdrs = ["os.h"],
+    copts = HASTUR_COPTS,
     linkopts = select({
         "@platforms//os:linux": [],
         "@platforms//os:windows": [
@@ -28,6 +30,7 @@ cc_test(
     name = "os_test",
     size = "small",
     srcs = ["os_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":os",
         "//etest",
@@ -38,6 +41,7 @@ cc_test(
     name = "linux_test",
     size = "small",
     srcs = ["linux_test.cpp"],
+    copts = HASTUR_COPTS,
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
         ":os",

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "protocol",
@@ -7,6 +8,7 @@ cc_library(
         exclude = ["*_test.cpp"],
     ),
     hdrs = glob(["*.h"]),
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//net",
@@ -20,6 +22,7 @@ cc_library(
     name = src[:-4],
     size = "small",
     srcs = [src],
+    copts = HASTUR_COPTS,
     deps = [
         ":protocol",
         "//etest",

--- a/render/BUILD
+++ b/render/BUILD
@@ -1,9 +1,11 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "render",
     srcs = ["render.cpp"],
     hdrs = ["render.h"],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//dom",
@@ -18,6 +20,7 @@ cc_test(
     name = "render_test",
     size = "small",
     srcs = ["render_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":render",
         "//dom",

--- a/style/BUILD
+++ b/style/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "style",
@@ -10,6 +11,7 @@ cc_library(
         "style.h",
         "styled_node.h",
     ],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//css",
@@ -23,6 +25,7 @@ cc_test(
     name = "style_test",
     size = "small",
     srcs = ["style_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":style",
         "//css",
@@ -35,6 +38,7 @@ cc_test(
     name = "styled_node_test",
     size = "small",
     srcs = ["styled_node_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":style",
         "//etest",

--- a/tui/BUILD
+++ b/tui/BUILD
@@ -1,9 +1,11 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "tui",
     srcs = ["tui.cpp"],
     hdrs = ["tui.h"],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//layout",

--- a/uri/BUILD
+++ b/uri/BUILD
@@ -1,10 +1,12 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "uri",
     srcs = ["uri.cpp"],
     hdrs = ["uri.h"],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//util:string",
@@ -17,6 +19,7 @@ cc_test(
     name = "uri_test",
     size = "small",
     srcs = ["uri_test.cpp"],
+    copts = HASTUR_COPTS,
     deps = [
         ":uri",
         "//etest",
@@ -32,6 +35,7 @@ cc_fuzz_test(
     name = "uri_fuzz_test",
     size = "small",
     srcs = ["uri_fuzz_test.cpp"],
+    copts = HASTUR_COPTS,
     target_compatible_with = select({
         ":is_clang": ["@platforms//os:linux"],
         "//conditions:default": ["@platforms//:incompatible"],

--- a/util/BUILD
+++ b/util/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 dependencies = {
     "base_parser": [":string"],
@@ -7,6 +8,7 @@ dependencies = {
 [cc_library(
     name = hdr[:-2],
     hdrs = [hdr],
+    copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = dependencies.get(
         hdr[:-2],
@@ -18,6 +20,7 @@ dependencies = {
     name = src[:-4],
     size = "small",
     srcs = [src],
+    copts = HASTUR_COPTS,
     deps = [
         ":%s" % src[:-9],
         "//etest",


### PR DESCRIPTION
This should make updating 3rd-party deps a bit more convenient at the expense of knowing less about the quality of the libraries we pull in.