### PR TITLE
html2: Support tokenizing doctype system identifiers

### DIFF
--- a/html2/tokenizer.h
+++ b/html2/tokenizer.h
@@ -103,6 +103,7 @@ enum class State {
 enum class ParseError {
     AbruptClosingOfEmptyComment,
     AbruptDoctypePublicIdentifier,
+    AbruptDoctypeSystemIdentifier,
     AbsenceOfDigitsInNumericCharacterReference,
     ControlCharacterReference,
     EofInComment,
@@ -118,6 +119,7 @@ enum class ParseError {
     MissingWhitespaceAfterDoctypePublicKeyword,
     MissingWhitespaceBetweenDoctypePublicAndSystemIdentifiers,
     NestedComment,
+    UnexpectedCharacterAfterDoctypeSystemIdentifier,
     UnexpectedCharacterInUnquotedAttributeValue,
     UnexpectedNullCharacter,
 };


### PR DESCRIPTION
With this change, we can now load msn.com without crashing.

Resolves #207 