### PR TITLE
ci: Fix coverage job's cache key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,8 +94,8 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.cache/bazel
-          key: ${{ matrix.name }}-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
-          restore-keys: ${{ matrix.name }}-
+          key: coverage-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
+          restore-keys: coverage-
       - name: Install
         run: |
           sudo apt-get update


### PR DESCRIPTION
As it's not part of a matrix job, `${{ matrix.name }}` expanded to an empty string.