### PR TITLE
dom: Move dom::Element factory we don't want to less accessible places

### DIFF
--- a/dom/dom.h
+++ b/dom/dom.h
@@ -9,7 +9,6 @@
 #include <map>
 #include <string>
 #include <string_view>
-#include <utility>
 #include <variant>
 #include <vector>
 
@@ -40,10 +39,6 @@ struct Document {
     Element &html() { return std::get<Element>(html_node); }
     [[nodiscard]] bool operator==(Document const &) const = default;
 };
-
-inline Node create_element_node(std::string_view name, AttrMap attrs, std::vector<Node> children) {
-    return Element{std::string{name}, std::move(attrs), std::move(children)};
-}
 
 // reference_wrapper to ensure that the argument isn't a temporary since we return pointers into it.
 std::vector<Element const *> nodes_by_path(std::reference_wrapper<Node const>, std::string_view path);

--- a/dom/dom_test.cpp
+++ b/dom/dom_test.cpp
@@ -7,12 +7,20 @@
 #include "etest/etest.h"
 
 #include <string_view>
+#include <utility>
 
 using namespace std::literals;
 
 using etest::expect;
 using etest::expect_eq;
 using etest::require;
+
+namespace {
+// TODO(robinlinden): Remove.
+dom::Node create_element_node(std::string_view name, dom::AttrMap attrs, std::vector<dom::Node> children) {
+    return dom::Element{std::string{name}, std::move(attrs), std::move(children)};
+}
+} // namespace
 
 int main() {
     etest::test("to_string", [] {
@@ -33,10 +41,10 @@ int main() {
     // clang-format off
 
     etest::test("no matches", [] {
-        auto const dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("head", {}, {}),
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto const dom_root = create_element_node("html", {}, {
+            create_element_node("head", {}, {}),
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -45,10 +53,10 @@ int main() {
     });
 
     etest::test("root match", [] {
-        auto const dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("head", {}, {}),
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto const dom_root = create_element_node("html", {}, {
+            create_element_node("head", {}, {}),
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -58,10 +66,10 @@ int main() {
     });
 
     etest::test("path with one element node", [] {
-        auto const dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("head", {}, {}),
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto const dom_root = create_element_node("html", {}, {
+            create_element_node("head", {}, {}),
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -71,11 +79,11 @@ int main() {
     });
 
     etest::test("path with multiple element nodes", [] {
-        auto const dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("head", {}, {}),
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
-                dom::create_element_node("p", {{"display", "none"}}, {}),
+        auto const dom_root = create_element_node("html", {}, {
+            create_element_node("head", {}, {}),
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
+                create_element_node("p", {{"display", "none"}}, {}),
             }),
         });
 
@@ -93,17 +101,17 @@ int main() {
     });
 
     etest::test("matching nodes in different branches", [] {
-        auto const dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("head", {}, {}),
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("div", {}, {
-                    dom::create_element_node("p", {{"display", "none"}}, {}),
+        auto const dom_root = create_element_node("html", {}, {
+            create_element_node("head", {}, {}),
+            create_element_node("body", {}, {
+                create_element_node("div", {}, {
+                    create_element_node("p", {{"display", "none"}}, {}),
                 }),
-                dom::create_element_node("span", {}, {
-                    dom::create_element_node("p", {{"display", "inline"}}, {}),
+                create_element_node("span", {}, {
+                    create_element_node("p", {{"display", "inline"}}, {}),
                 }),
-                dom::create_element_node("div", {}, {
-                    dom::create_element_node("p", {{"display", "block"}}, {}),
+                create_element_node("div", {}, {
+                    create_element_node("p", {{"display", "block"}}, {}),
                 })
             })
         });
@@ -123,11 +131,11 @@ int main() {
     });
 
     etest::test("non-element node in search path", [] {
-        auto const dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("head", {}, {}),
+        auto const dom_root = create_element_node("html", {}, {
+            create_element_node("head", {}, {}),
             dom::Text{"I don't belong here. :("},
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -7,6 +7,9 @@
 
 #include "etest/etest.h"
 
+#include <string_view>
+#include <utility>
+
 using namespace std::literals;
 using etest::expect;
 using etest::expect_eq;
@@ -15,6 +18,7 @@ using etest::require_eq;
 using layout::LayoutType;
 
 namespace {
+
 // Until we have a nicer tree-creation abstraction for the tests, this needs to
 // be called if a test relies on property inheritance.
 void set_up_parent_ptrs(style::StyledNode &parent) {
@@ -23,6 +27,12 @@ void set_up_parent_ptrs(style::StyledNode &parent) {
         set_up_parent_ptrs(child);
     }
 }
+
+// TODO(robinlinden): Remove.
+dom::Node create_element_node(std::string_view name, dom::AttrMap attrs, std::vector<dom::Node> children) {
+    return dom::Element{std::string{name}, std::move(attrs), std::move(children)};
+}
+
 } // namespace
 
 // TODO(robinlinden): clang-format doesn't get along well with how I structured
@@ -32,10 +42,10 @@ void set_up_parent_ptrs(style::StyledNode &parent) {
 
 int main() {
     etest::test("simple tree", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("head", {}, {}),
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("head", {}, {}),
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -68,10 +78,10 @@ int main() {
     });
 
     etest::test("layouting removes display:none nodes", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("head", {}, {}),
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("head", {}, {}),
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -104,10 +114,10 @@ int main() {
     });
 
     etest::test("inline nodes get wrapped in anonymous blocks", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("head", {}, {}),
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("head", {}, {}),
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -143,7 +153,7 @@ int main() {
 
     // clang-format on
     etest::test("inline in inline don't get wrapped in anon-blocks", [] {
-        auto dom_root = dom::create_element_node("span", {}, {dom::create_element_node("span", {}, {})});
+        auto dom_root = create_element_node("span", {}, {create_element_node("span", {}, {})});
 
         auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
@@ -165,8 +175,8 @@ int main() {
     // clang-format off
 
     etest::test("text", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
                 dom::Text{"hello"},
                 dom::Text{"goodbye"},
             }),
@@ -204,9 +214,9 @@ int main() {
     });
 
     etest::test("simple width", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -236,9 +246,9 @@ int main() {
     });
 
     etest::test("min-width", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -268,9 +278,9 @@ int main() {
     });
 
     etest::test("max-width", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -300,9 +310,9 @@ int main() {
     });
 
     etest::test("less simple width", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -332,9 +342,9 @@ int main() {
     });
 
     etest::test("auto width expands to fill parent", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -364,9 +374,9 @@ int main() {
     });
 
     etest::test("height doesn't affect children", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -396,10 +406,10 @@ int main() {
     });
 
     etest::test("height affects siblings and parents", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -431,10 +441,10 @@ int main() {
     });
 
     etest::test("min-height is respected", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -466,10 +476,10 @@ int main() {
     });
 
     etest::test("max-height is respected", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -501,10 +511,10 @@ int main() {
     });
 
     etest::test("padding is taken into account", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -545,10 +555,10 @@ int main() {
     });
 
     etest::test("border is taken into account", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -593,9 +603,9 @@ int main() {
     });
 
     etest::test("border is not added if border style is none", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -634,10 +644,10 @@ int main() {
     });
 
     etest::test("margin is taken into account", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -677,9 +687,9 @@ int main() {
     });
 
     etest::test("auto margin is handled", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -716,9 +726,9 @@ int main() {
     });
 
     etest::test("auto left margin and fixed right margin is handled", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -755,9 +765,9 @@ int main() {
     });
 
     etest::test("fixed left margin and auto right margin is handled", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
             }),
         });
 
@@ -794,7 +804,7 @@ int main() {
     });
 
     etest::test("em sizes depend on the font-size", [] {
-        auto dom_root = dom::create_element_node("html", {}, {});
+        auto dom_root = create_element_node("html", {}, {});
         {
             auto style_root = style::StyledNode{
                 .node = dom_root,
@@ -840,7 +850,7 @@ int main() {
     });
 
     etest::test("px sizes don't depend on the font-size", [] {
-        auto dom_root = dom::create_element_node("html", {}, {});
+        auto dom_root = create_element_node("html", {}, {});
         {
             auto style_root = style::StyledNode{
                 .node = dom_root,
@@ -912,10 +922,10 @@ int main() {
     });
 
     etest::test("to_string", [] {
-        auto dom_root = dom::create_element_node("html", {}, {
-            dom::create_element_node("body", {}, {
-                dom::create_element_node("p", {}, {}),
-                dom::create_element_node("p", {}, {}),
+        auto dom_root = create_element_node("html", {}, {
+            create_element_node("body", {}, {
+                create_element_node("p", {}, {}),
+                create_element_node("p", {}, {}),
             }),
         });
 


### PR DESCRIPTION
We don't want anyone to use this, and we've cleaned it out from everywhere but the dom- and layout tests, so move the helper into the two files where it's used.