### PR TITLE
deps: Update libpng

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -120,9 +120,9 @@ http_archive(
 http_archive(
     name = "libpng",  # Libpng
     build_file = "//third_party:libpng.BUILD",
-    sha256 = "d4160037fa5d09fa7cff555037f2a7f2fefc99ca01e21723b19bfcda33015234",
-    strip_prefix = "libpng-1.6.38",
-    url = "https://github.com/glennrp/libpng/archive/v1.6.38.tar.gz",
+    sha256 = "a00e9d2f2f664186e4202db9299397f851aea71b36a35e74910b8820e380d441",
+    strip_prefix = "libpng-1.6.39",
+    url = "https://github.com/glennrp/libpng/archive/v1.6.39.tar.gz",
 )
 
 http_archive(


### PR DESCRIPTION
https://github.com/glennrp/libpng/blob/61bfdb0cb02a6f3a62c929dbc9e832894c0a8df2/CHANGES#L6112-L6122
```
Version 1.6.39 [November 20, 2022]
  Changed the error handler of oversized chunks (i.e. larger than
    PNG_USER_CHUNK_MALLOC_MAX) from png_chunk_error to png_benign_error.
  Fixed a buffer overflow error in contrib/tools/pngfix.
  Fixed a memory leak (CVE-2019-6129) in contrib/tools/pngcp.
  Disabled the ARM Neon optimizations by default in the CMake file,
    following the default behavior of the configure script.
  Allowed configure.ac to work with the trunk version of autoconf.
  Removed the support for "install" targets from the legacy makefiles;
    removed the obsolete makefile.cegcc.
  Cleaned up the code and updated the internal documentation.
```