### PR TITLE
render: Add support for rgb(1, 2, 3) colors

### DIFF
--- a/render/render.cpp
+++ b/render/render.cpp
@@ -247,16 +247,23 @@ std::optional<gfx::Color> try_from_hex_chars(std::string_view hex_chars) {
     return std::nullopt;
 }
 
-// TODO(robinlinden): rgba, space-separated values, alpha.
+// TODO(robinlinden): space-separated values, alpha.
 // https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb
 // https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgba
 std::optional<gfx::Color> try_from_rgba(std::string_view text) {
-    if (!text.starts_with("rgb(") || !text.ends_with(')')) {
+    if (text.starts_with("rgb(")) {
+        text.remove_prefix(std::strlen("rgb("));
+    } else if (text.starts_with("rgba(")) {
+        text.remove_prefix(std::strlen("rgba("));
+    } else {
         return std::nullopt;
     }
 
-    text.remove_prefix(std::strlen("rgb("));
+    if (!text.ends_with(')')) {
+        return std::nullopt;
+    }
     text.remove_suffix(std::strlen(")"));
+
     auto rgba = util::split(text, ",");
     if (rgba.size() != 3) {
         return std::nullopt;

--- a/render/render_test.cpp
+++ b/render/render_test.cpp
@@ -248,6 +248,18 @@ int main() {
         render::render_layout(painter, layout);
         expect_eq(saver.take_commands(), CanvasCommands{std::move(cmd)});
 
+        // rgb, rgba should be an alias of rgb
+        styled.properties = {{css::PropertyId::BackgroundColor, "rgba(100, 200, 255)"}};
+        cmd = gfx::DrawRectCmd{.rect{0, 0, 20, 20}, .color{gfx::Color{100, 200, 255}}};
+        render::render_layout(painter, layout);
+        expect_eq(saver.take_commands(), CanvasCommands{std::move(cmd)});
+
+        // rgb, missing closing paren
+        styled.properties = {{css::PropertyId::BackgroundColor, "rgb(1, 2, 3"}};
+        cmd = gfx::DrawRectCmd{.rect{0, 0, 20, 20}, .color{kInvalidColor}};
+        render::render_layout(painter, layout);
+        expect_eq(saver.take_commands(), CanvasCommands{std::move(cmd)});
+
         // rgb, value out of range
         styled.properties = {{css::PropertyId::BackgroundColor, "rgb(-1, 2, 3)"}};
         render::render_layout(painter, layout);


### PR DESCRIPTION
I'll add support for providing alpha once I've messed around a bit with our std::from_chars-shim we need for parsing floats using from_chars in GCC 10.