### PR TITLE
css: Fix selectors w/ spaces being split

### DIFF
--- a/css/BUILD
+++ b/css/BUILD
@@ -29,6 +29,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//util:base_parser",
+        "//util:string",
         "@fmt",
         "@spdlog",
     ],

--- a/css/parser.h
+++ b/css/parser.h
@@ -10,6 +10,7 @@
 #include "css/rule.h"
 
 #include "util/base_parser.h"
+#include "util/string.h"
 
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
@@ -178,8 +179,8 @@ private:
     css::Rule parse_rule() {
         Rule rule{};
         while (peek() != '{') {
-            auto selector = consume_while([](char c) { return c != ' ' && c != ',' && c != '{'; });
-            rule.selectors.push_back(std::string{selector});
+            auto selector = consume_while([](char c) { return c != ',' && c != '{'; });
+            rule.selectors.push_back(std::string{util::trim(selector)});
             skip_if_neq('{'); // ' ' or ','
             skip_whitespace_and_comments();
         }

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -94,6 +94,15 @@ int main() {
         expect(body.declarations.at(css::PropertyId::Width) == "50px"s);
     });
 
+    etest::test("selector with spaces", [] {
+        auto rules = css::parse("p a { color: green; }");
+        expect_eq(rules,
+                std::vector<css::Rule>{{
+                        .selectors{{"p a"}},
+                        .declarations{{css::PropertyId::Color, "green"}},
+                }});
+    });
+
     etest::test("parser: minified", [] {
         auto rules = css::parse("body{width:50px;font:inherit}head,p{display:none}"sv);
         require(rules.size() == 2);
@@ -197,8 +206,8 @@ int main() {
 
     etest::test("parser: comments almost everywhere", [] {
         // body { width: 50px; } p { padding: 8em 4em; } with comments added everywhere currently supported.
-        auto rules = css::parse(R"(/**/body /**/{/**/width:50px;/**/}/*
-                */p /**/{/**/padding:/**/8em 4em;/**//**/}/**/)"sv);
+        auto rules = css::parse(R"(/**/body {/**/width:50px;/**/}/*
+                */p {/**/padding:/**/8em 4em;/**//**/}/**/)"sv);
         // TODO(robinlinden): Support comments in more places.
         // auto rules = css::parse(R"(/**/body/**/{/**/width/**/:/**/50px/**/;/**/}/*
         //         */p/**/{/**/padding/**/:/**/8em/**/4em/**/;/**//**/}/**/)"sv);


### PR DESCRIPTION
This commit breaks cases with comments like like

    p /**/ { color: green; }

that previously worked because `p /**/` was processed as two separate selectors with `/**/` being skipped by `skip_whitespace_and_comments`.