### PR TITLE
css: Remove font shorthand from property id list

### DIFF
--- a/css/parser.h
+++ b/css/parser.h
@@ -285,7 +285,7 @@ private:
         Tokenizer tokenizer(value, ' ');
         if (tokenizer.size() == 1) {
             // TODO(mkiael): Handle system properties correctly. Just forward it for now.
-            declarations.insert_or_assign(PropertyId::Font, std::string{tokenizer.get().value()});
+            declarations.insert_or_assign(PropertyId::FontFamily, std::string{tokenizer.get().value()});
             return;
         }
 

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -104,14 +104,14 @@ int main() {
     });
 
     etest::test("parser: minified", [] {
-        auto rules = css::parse("body{width:50px;font:inherit}head,p{display:none}"sv);
+        auto rules = css::parse("body{width:50px;font-family:inherit}head,p{display:none}"sv);
         require(rules.size() == 2);
 
         auto first = rules[0];
         expect(first.selectors == std::vector{"body"s});
         expect(first.declarations.size() == 2);
         expect(first.declarations.at(css::PropertyId::Width) == "50px"s);
-        expect(first.declarations.at(css::PropertyId::Font) == "inherit"s);
+        expect(first.declarations.at(css::PropertyId::FontFamily) == "inherit"s);
 
         auto second = rules[1];
         expect(second.selectors == std::vector{"head"s, "p"s});
@@ -700,6 +700,15 @@ int main() {
         expect(get_and_erase(body.declarations, css::PropertyId::FontWeight) == "bold"s);
         expect(get_and_erase(body.declarations, css::PropertyId::LineHeight) == "80%"s);
         expect(check_initial_font_values(body.declarations));
+    });
+
+    etest::test("parser: font, single-argument", [] {
+        auto rules = css::parse("p { font: status-bar; }"sv);
+        require(rules.size() == 1);
+
+        auto p = rules[0];
+        expect_eq(p.declarations.size(), std::size_t{1});
+        expect_eq(get_and_erase(p.declarations, css::PropertyId::FontFamily), "status-bar"s);
     });
 
     etest::test("parser: shorthand font with ultra-exapnded font stretch", [] {

--- a/css/property_id.cpp
+++ b/css/property_id.cpp
@@ -44,7 +44,6 @@ std::map<std::string_view, PropertyId> const kKnownProperties{
         {"display"sv, PropertyId::Display},
         {"elevation"sv, PropertyId::Elevation},
         {"empty-cells"sv, PropertyId::EmptyCells},
-        {"font"sv, PropertyId::Font},
         {"font-family"sv, PropertyId::FontFamily},
         {"font-feature-settings"sv, PropertyId::FontFeatureSettings},
         {"font-kerning"sv, PropertyId::FontKerning},

--- a/css/property_id.h
+++ b/css/property_id.h
@@ -42,7 +42,6 @@ enum class PropertyId {
     Display,
     Elevation,
     EmptyCells,
-    Font,
     FontFamily,
     FontFeatureSettings,
     FontKerning,
@@ -119,7 +118,6 @@ constexpr bool is_inherited(PropertyId id) {
         case css::PropertyId::Direction:
         case css::PropertyId::Elevation:
         case css::PropertyId::EmptyCells:
-        case css::PropertyId::Font:
         case css::PropertyId::FontFamily:
         case css::PropertyId::FontSize:
         case css::PropertyId::FontStyle:


### PR DESCRIPTION
This was the only shorthand property in this list, and dumping any potential single-argument font property values into font-family feels okay for now.