### PR TITLE
all: Restrict the fuzz tests to only run when using clang

### DIFF
--- a/bzl/BUILD
+++ b/bzl/BUILD
@@ -5,6 +5,11 @@ filegroup(
 )
 
 config_setting(
+    name = "is_clang",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang"},
+)
+
+config_setting(
     name = "is_clang-cl",
     flag_values = {"@bazel_tools//tools/cpp:compiler": "clang-cl"},
 )

--- a/bzl/copts.bzl
+++ b/bzl/copts.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+# SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -40,4 +40,10 @@ HASTUR_COPTS = select({
     "//bzl:is_clang-cl": HASTUR_CLANG_CL_WARNING_FLAGS,
     "//bzl:is_msvc": HASTUR_MSVC_WARNING_FLAGS,
     "@platforms//os:linux": HASTUR_LINUX_WARNING_FLAGS,
+})
+
+# C++ fuzzing requires a Clang compiler: https://github.com/bazelbuild/rules_fuzzing#prerequisites
+HASTUR_FUZZ_PLATFORMS = select({
+    ":is_clang": ["@platforms//os:linux"],
+    "//conditions:default": ["@platforms//:incompatible"],
 })

--- a/css/BUILD
+++ b/css/BUILD
@@ -1,6 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
-load("//bzl:copts.bzl", "HASTUR_COPTS")
+load("//bzl:copts.bzl", "HASTUR_COPTS", "HASTUR_FUZZ_PLATFORMS")
 
 genrule(
     name = "default_css",
@@ -40,7 +40,7 @@ cc_fuzz_test(
     srcs = ["parser_fuzz_test.cpp"],
     copts = HASTUR_COPTS,
     tags = ["manual"],
-    target_compatible_with = ["@platforms//os:linux"],
+    target_compatible_with = HASTUR_FUZZ_PLATFORMS,
     deps = [":css"],
 )
 

--- a/html2/BUILD
+++ b/html2/BUILD
@@ -1,6 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
-load("//bzl:copts.bzl", "HASTUR_COPTS")
+load("//bzl:copts.bzl", "HASTUR_COPTS", "HASTUR_FUZZ_PLATFORMS")
 
 cc_library(
     name = "html2",
@@ -47,6 +47,6 @@ dependencies = {
     srcs = [src],
     copts = HASTUR_COPTS,
     tags = ["manual"],
-    target_compatible_with = ["@platforms//os:linux"],
+    target_compatible_with = HASTUR_FUZZ_PLATFORMS,
     deps = [":html2"],
 ) for src in glob(["*_fuzz_test.cpp"])]

--- a/uri/BUILD
+++ b/uri/BUILD
@@ -1,6 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
-load("//bzl:copts.bzl", "HASTUR_COPTS")
+load("//bzl:copts.bzl", "HASTUR_COPTS", "HASTUR_FUZZ_PLATFORMS")
 
 cc_library(
     name = "uri",
@@ -36,9 +36,6 @@ cc_fuzz_test(
     size = "small",
     srcs = ["uri_fuzz_test.cpp"],
     copts = HASTUR_COPTS,
-    target_compatible_with = select({
-        ":is_clang": ["@platforms//os:linux"],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
+    target_compatible_with = HASTUR_FUZZ_PLATFORMS,
     deps = [":uri"],
 )


### PR DESCRIPTION
No idea why it was set up this way when no other fuzz test was. Past me didn't document it either. :(