### PR TITLE
uri: Fix path-relative completion when the base path doesn't end in /

### DIFF
--- a/uri/uri.cpp
+++ b/uri/uri.cpp
@@ -36,7 +36,12 @@ void complete_from_base_if_needed(Uri &uri, Uri const &base) {
         uri = Uri::parse(fmt::format("{}://{}{}", base.scheme, base.authority.host, uri.uri));
     } else if (uri.scheme.empty() && uri.authority.host.empty() && !uri.path.empty()) {
         // https://url.spec.whatwg.org/#path-relative-url-string
-        uri = Uri::parse(fmt::format("{}/{}", base.uri, uri.uri));
+        if (base.path == "/") {
+            uri = Uri::parse(fmt::format("{}/{}", base.uri, uri.uri));
+        } else {
+            auto end_of_last_path_segment = base.uri.find_last_of('/');
+            uri = Uri::parse(fmt::format("{}/{}", base.uri.substr(0, end_of_last_path_segment), uri.uri));
+        }
     } else if (uri.scheme.empty() && !uri.authority.host.empty() && uri.uri.starts_with("//")) {
         // Scheme-relative.
         uri = Uri::parse(fmt::format("{}:{}", base.scheme, uri.uri));

--- a/uri/uri_test.cpp
+++ b/uri/uri_test.cpp
@@ -174,8 +174,14 @@ int main() {
         auto completed = uri::Uri::parse("test", base);
         expect_eq(completed, uri::Uri::parse("hax://example.com/test"));
 
-        completed = uri::Uri::parse("hello", completed);
-        expect_eq(completed, uri::Uri::parse("hax://example.com/test/hello"));
+        completed = uri::Uri::parse("hello/", completed);
+        expect_eq(completed, uri::Uri::parse("hax://example.com/hello/"));
+
+        completed = uri::Uri::parse("test", completed);
+        expect_eq(completed, uri::Uri::parse("hax://example.com/hello/test"));
+
+        completed = uri::Uri::parse("goodbye", completed);
+        expect_eq(completed, uri::Uri::parse("hax://example.com/hello/goodbye"));
     });
 
     return etest::run_all_tests();


### PR DESCRIPTION
Previously, when completing e.g. "bar" with the base "example.com/foo.html", you would end up with the completed uri "example.com/foo.html/bar".