### PR TITLE
url: Add url library

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -4,4 +4,4 @@ ignore=body-is-missing
 # TODO(robinlinden): Better way of documenting and setting this up.
 # Each commit must start with the main area it affects.
 [title-match-regex]
-regex=^(browser|bzl|css|css2|dom|dom2|engine|etest|geom|gfx|html|html2|img|js|layout|net|os|protocol|render|style|tui|uri|util|all|build|ci|deps|doc|meta)(/.*|\+.*)?:
+regex=^(browser|bzl|css|css2|dom|dom2|engine|etest|geom|gfx|html|html2|img|js|layout|net|os|protocol|render|style|tui|uri|url|util|all|build|ci|deps|doc|meta)(/.*|\+.*)?:

--- a/url/BUILD
+++ b/url/BUILD
@@ -1,0 +1,25 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
+
+cc_library(
+    name = "url",
+    srcs = ["url.cpp"],
+    hdrs = ["url.h"],
+    copts = HASTUR_COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//net",
+        "//util:uuid",
+    ],
+)
+
+cc_test(
+    name = "url_test",
+    size = "small",
+    srcs = ["url_test.cpp"],
+    copts = HASTUR_COPTS,
+    deps = [
+        ":url",
+        "//etest",
+    ],
+)

--- a/url/url.cpp
+++ b/url/url.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2023 David Zero <zero-one@zer0-one.net>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "url/url.h"
+
+#include "net/ip.h"
+#include "util/uuid.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <variant>
+
+namespace url {
+
+// https://w3c.github.io/FileAPI/#unicodeBlobURL
+std::string blob_url_create(Origin const &origin) {
+    std::string result = "blob:";
+    std::string serialized = "";
+
+    // https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin
+    if (origin.opaque) {
+        serialized = "null";
+    } else {
+        serialized = origin.scheme + "://";
+
+        switch (origin.host.type) {
+            case HostType::DnsDomain:
+            case HostType::Opaque:
+            case HostType::Empty:
+                serialized += std::get<std::string>(origin.host.data);
+                break;
+            case HostType::Ip4Addr:
+                serialized += net::ipv4_serialize(std::get<std::uint32_t>(origin.host.data));
+                break;
+            case HostType::Ip6Addr:
+                std::array<std::uint16_t, 8> v6 = std::get<std::array<std::uint16_t, 8>>(origin.host.data);
+                serialized += "[" + net::ipv6_serialize(v6) + "]";
+        }
+
+        if (origin.port.has_value()) {
+            serialized += ":" + std::to_string(origin.port.value());
+        }
+    }
+
+    result += serialized;
+    result += "/";
+    result += util::new_uuid();
+
+    return result;
+}
+
+} // namespace url

--- a/url/url.h
+++ b/url/url.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2023 David Zero <zero-one@zer0-one.net>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef URL_URL_H_
+#define URL_URL_H_
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+
+namespace url {
+
+enum class HostType { DnsDomain, Ip4Addr, Ip6Addr, Opaque, Empty };
+
+struct Host {
+    HostType type;
+
+    std::variant<std::string, std::uint32_t, std::array<std::uint16_t, 8>> data;
+};
+
+struct Origin {
+    std::string scheme;
+    Host host;
+    std::optional<std::uint16_t> port;
+    std::optional<std::string> domain;
+    // Need this placeholder until I figure out what "opaqueness" means for an origin in this context
+    bool opaque;
+};
+
+/**
+ * Generates a new Blob URL for the given origin
+ */
+std::string blob_url_create(Origin const &origin);
+
+} // namespace url
+
+#endif

--- a/url/url_test.cpp
+++ b/url/url_test.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2023 David Zero <zero-one@zer0-one.net>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "url/url.h"
+
+#include "etest/etest.h"
+
+#include <array>
+#include <cstdint>
+#include <iostream>
+#include <regex>
+
+using etest::expect;
+using etest::expect_eq;
+
+int main() {
+    etest::test("blob URL generation", [] {
+        std::string REGEX_UUID = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+
+        url::Host h = {url::HostType::DnsDomain, "example.com"};
+        url::Origin o = {"https", h, std::uint16_t{8080}, std::nullopt, false};
+
+        std::string blob = url::blob_url_create(o);
+        std::cout << "Generated Blob URL: " << blob << std::endl;
+
+        etest::expect(std::regex_match(blob, std::regex("blob:https://example.com:8080/" + REGEX_UUID)));
+
+        h = url::Host{url::HostType::Ip4Addr, std::uint32_t{134744072}};
+        o = {"https", h, std::uint16_t{8080}, std::nullopt, false};
+
+        blob = url::blob_url_create(o);
+        std::cout << "Generated Blob URL: " << blob << std::endl;
+
+        etest::expect(std::regex_match(blob, std::regex("blob:https://8.8.8.8:8080/" + REGEX_UUID)));
+
+        std::array<uint16_t, 8> v6 = {0x2001, 0xdb8, 0x85a3, 0, 0, 0x8a2e, 0x370, 0x7334};
+        h = url::Host{url::HostType::Ip6Addr, v6};
+        o = {"https", h, std::uint16_t{8080}, std::nullopt, false};
+
+        blob = url::blob_url_create(o);
+        std::cout << "Generated Blob URL: " << blob;
+
+        etest::expect(std::regex_match(
+                blob, std::regex("blob:https://\\[2001:db8:85a3::8a2e:370:7334\\]:8080/" + REGEX_UUID)));
+    });
+
+    return etest::run_all_tests();
+}


### PR DESCRIPTION
Adds a blob generation function for generating blob URLs according to
the W3C File API spec: https://w3c.github.io/FileAPI/#blob-url-entry

I will follow this PR up with another one that moves the IP serialization functions to util/string.h .