### PR TITLE
dom: Use a subset of xpath instead of an ad-hoc DSL for node-selection

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -37,8 +37,8 @@ auto constexpr kDefaultResolutionY = 480;
 // Magic number that felt right during testing.
 auto constexpr kMouseWheelScrollFactor = 10;
 
-std::optional<std::string_view> try_get_text_content(dom::Document const &doc, std::string_view path) {
-    auto nodes = dom::nodes_by_path(doc.html(), path);
+std::optional<std::string_view> try_get_text_content(dom::Document const &doc, std::string_view xpath) {
+    auto nodes = dom::nodes_by_xpath(doc.html(), xpath);
     if (nodes.empty() || nodes[0]->children.empty() || !std::holds_alternative<dom::Text>(nodes[0]->children[0])) {
         return std::nullopt;
     }
@@ -348,7 +348,7 @@ void App::on_navigation_failure(protocol::Error err) {
 
 void App::on_page_loaded() {
     page_loaded_ = true;
-    if (auto page_title = try_get_text_content(engine_.dom(), "html.head.title"sv)) {
+    if (auto page_title = try_get_text_content(engine_.dom(), "/html/head/title"sv)) {
         window_.setTitle(fmt::format("{} - {}", *page_title, browser_title_));
     } else {
         window_.setTitle(browser_title_);

--- a/dom/dom.h
+++ b/dom/dom.h
@@ -41,8 +41,8 @@ struct Document {
 };
 
 // reference_wrapper to ensure that the argument isn't a temporary since we return pointers into it.
-std::vector<Element const *> nodes_by_path(std::reference_wrapper<Node const>, std::string_view path);
-std::vector<Element const *> nodes_by_path(std::reference_wrapper<Element const>, std::string_view path);
+std::vector<Element const *> nodes_by_xpath(std::reference_wrapper<Node const>, std::string_view);
+std::vector<Element const *> nodes_by_xpath(std::reference_wrapper<Element const>, std::string_view);
 
 std::string to_string(Document const &node);
 

--- a/dom/dom_test.cpp
+++ b/dom/dom_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -32,7 +32,16 @@ int main() {
 
     etest::test("root not being an element shouldn't crash", [] {
         dom::Node dom = dom::Text{"hello"};
-        auto const nodes = nodes_by_path(dom, "anything");
+        auto const nodes = nodes_by_xpath(dom, "/anything");
+        expect(nodes.empty());
+    });
+
+    etest::test("unsupported xpaths don't return anything", [] {
+        dom::Node dom = dom::Element{"div"};
+        auto nodes = nodes_by_xpath(dom, "div");
+        expect(nodes.empty());
+
+        nodes = nodes_by_xpath(dom, "//div");
         expect(nodes.empty());
     });
 
@@ -48,7 +57,7 @@ int main() {
             }),
         });
 
-        auto const nodes = nodes_by_path(dom_root, "html.body.a");
+        auto const nodes = nodes_by_xpath(dom_root, "/html/body/a");
         expect(nodes.empty());
     });
 
@@ -60,7 +69,7 @@ int main() {
             }),
         });
 
-        auto const nodes = nodes_by_path(dom_root, "html");
+        auto const nodes = nodes_by_xpath(dom_root, "/html");
         require(nodes.size() == 1);
         expect(nodes[0]->name == "html");
     });
@@ -73,7 +82,7 @@ int main() {
             }),
         });
 
-        auto const nodes = nodes_by_path(dom_root, "html.body.p");
+        auto const nodes = nodes_by_xpath(dom_root, "/html/body/p");
         require(nodes.size() == 1);
         expect(nodes[0]->name == "p");
     });
@@ -87,7 +96,7 @@ int main() {
             }),
         });
 
-        auto const nodes = nodes_by_path(dom_root, "html.body.p");
+        auto const nodes = nodes_by_xpath(dom_root, "/html/body/p");
         require(nodes.size() == 2);
 
         auto const first = *nodes[0];
@@ -116,7 +125,7 @@ int main() {
             })
         });
 
-        auto const nodes = nodes_by_path(dom_root, "html.body.div.p");
+        auto const nodes = nodes_by_xpath(dom_root, "/html/body/div/p");
         require(nodes.size() == 2);
 
         auto const first = *nodes[0];
@@ -139,7 +148,7 @@ int main() {
             }),
         });
 
-        auto const nodes = nodes_by_path(dom_root, "html.body.p");
+        auto const nodes = nodes_by_xpath(dom_root, "/html/body/p");
         expect(nodes.size() == 1);
     });
 

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -21,8 +21,8 @@ using namespace std::literals;
 namespace engine {
 namespace {
 
-std::optional<std::string_view> try_get_text_content(dom::Document const &doc, std::string_view path) {
-    auto nodes = dom::nodes_by_path(doc.html(), path);
+std::optional<std::string_view> try_get_text_content(dom::Document const &doc, std::string_view xpath) {
+    auto nodes = dom::nodes_by_xpath(doc.html(), xpath);
     if (nodes.empty() || nodes[0]->children.empty() || !std::holds_alternative<dom::Text>(nodes[0]->children[0])) {
         return std::nullopt;
     }
@@ -73,14 +73,14 @@ void Engine::on_navigation_success() {
     dom_ = html::parse(response_.body);
     stylesheet_ = css::default_style();
 
-    if (auto style = try_get_text_content(dom_, "html.head.style"sv)) {
+    if (auto style = try_get_text_content(dom_, "/html/head/style"sv)) {
         auto new_rules = css::parse(*style);
         stylesheet_.reserve(stylesheet_.size() + new_rules.size());
         stylesheet_.insert(
                 end(stylesheet_), std::make_move_iterator(begin(new_rules)), std::make_move_iterator(end(new_rules)));
     }
 
-    auto head_links = dom::nodes_by_path(dom_.html(), "html.head.link");
+    auto head_links = dom::nodes_by_xpath(dom_.html(), "/html/head/link");
     std::erase_if(head_links, [](auto const *link) {
         return !link->attributes.contains("rel")
                 || (link->attributes.contains("rel") && link->attributes.at("rel") != "stylesheet")


### PR DESCRIPTION
This adapts our ad-hoc DSL implementation to instead support the abbreviated xpath child axis specifier.

I'll close the xpath issue with this as we're starting down that path instead of using our ad-hoc DSL, and we'll just add to the xpath support as we need it. E.g. I'll probably add support for `//` in the near future as I want to be able to collect all `<a>` tags and all `<img>` tags on a page for the tui and image rendering respectively.

Resolves #219 