### PR TITLE
ci: Add a check for link liveness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,6 +193,12 @@ jobs:
       - run: shfmt -i 2 -w $(shfmt -f .)
       - run: git diff --exit-code
 
+  link-liveness:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: grep --recursive --no-filename --only-matching --exclude=WORKSPACE --exclude=*test.cpp --exclude=ci.yaml 'https://[^)(}{", ]*' | grep -v '^https://$' | xargs wget --spider
+
   gitlint:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
This might be a bit finicky for a bit; will probably require one or two updates in the future as we add different kinds of links in different places and discover that it doesn't match something correctly.

An alternative to this would be to add an explicit tag that I can match on which indicates that a check should be performed. e.g, "[live-check] https://example.com".