### PR TITLE
gui: make windows semi-rtransparent in debug mode

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -191,6 +191,11 @@ int App::run() {
                         }
                         case sf::Keyboard::Key::F1: {
                             render_debug_ = !render_debug_;
+                            if (render_debug_) {
+                                ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.25f);
+                            } else {
+                                ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 1.0f);
+                            }
                             break;
                         }
                         case sf::Keyboard::Key::F2: {


### PR DESCRIPTION
When F1 is pressed, set the ImGui window alpha to 0.25f
