### PR TITLE
engine: add security enforcement by default

### DIFF
--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -94,6 +94,12 @@ void Engine::on_navigation_success() {
         future_new_rules.push_back(std::async(std::launch::async, [=, this]() -> std::vector<css::Rule> {
             auto const &href = link->attributes.at("href");
             auto stylesheet_url = uri::Uri::parse(href, uri_);
+            if (stylesheet_url.err != uri::Error::Ok) {
+                spdlog::error("Error {} when attempting to fetch {}",
+                        static_cast<int>(stylesheet_url.err),
+                        stylesheet_url.uri);
+                return {};
+            }
 
             spdlog::info("Downloading stylesheet from {}", stylesheet_url.uri);
             auto style_data = protocol_handler_->handle(stylesheet_url);
@@ -104,6 +110,7 @@ void Engine::on_navigation_success() {
 
             if ((stylesheet_url.scheme == "http" || stylesheet_url.scheme == "https")
                     && style_data.status_line.status_code != 200) {
+                // TODO handle http 3XX series
                 spdlog::warn("Error {}: {} downloading {}",
                         style_data.status_line.status_code,
                         style_data.status_line.reason,

--- a/etest/etest.h
+++ b/etest/etest.h
@@ -19,8 +19,8 @@ namespace etest {
 
 template<typename T>
 concept Printable = requires(std::ostream &os, T t) {
-    { os << t } -> std::same_as<std::ostream &>;
-};
+                        { os << t } -> std::same_as<std::ostream &>;
+                    };
 
 struct RunOptions {
     bool run_disabled_tests{false};

--- a/uri/uri.h
+++ b/uri/uri.h
@@ -12,6 +12,12 @@
 
 namespace uri {
 
+enum class Error {
+    Ok,
+    Unparseable,
+    Security,
+};
+
 struct Authority {
     std::string user;
     std::string passwd;
@@ -24,8 +30,11 @@ struct Authority {
 };
 
 struct Uri {
-    static Uri parse(std::string uri, std::optional<std::reference_wrapper<Uri const>> base_uri = std::nullopt);
+    static Uri parse(std::string uri,
+            std::optional<std::reference_wrapper<Uri const>> base_uri = std::nullopt,
+            bool enforce_security = true);
 
+    Error err;
     std::string uri;
     std::string scheme;
     Authority authority;


### PR DESCRIPTION
Prevent requesting css files from a different scheme than the host.

This naive implementation does prevent https -> http downgrades, but
also prevents http -> upgrades... Eventually, someone should probably
fix that
