### PR TITLE
uri: Nuke leftovers from fuzz-platform cleanup

### DIFF
--- a/bzl/copts.bzl
+++ b/bzl/copts.bzl
@@ -44,6 +44,6 @@ HASTUR_COPTS = select({
 
 # C++ fuzzing requires a Clang compiler: https://github.com/bazelbuild/rules_fuzzing#prerequisites
 HASTUR_FUZZ_PLATFORMS = select({
-    ":is_clang": ["@platforms//os:linux"],
+    "//bzl:is_clang": ["@platforms//os:linux"],
     "//conditions:default": ["@platforms//:incompatible"],
 })

--- a/uri/BUILD
+++ b/uri/BUILD
@@ -26,11 +26,6 @@ cc_test(
     ],
 )
 
-config_setting(
-    name = "is_clang",
-    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang"},
-)
-
 cc_fuzz_test(
     name = "uri_fuzz_test",
     size = "small",


### PR DESCRIPTION
This was missed in 36471c4d5311db7fae836d0325fd1e3325905dd4.