### PR TITLE
Switch back to std::regex for uri-parsing

### DIFF
--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -18,8 +18,6 @@ cc_library(
     ],
 )
 
-# file_handler_test needs some special treatment right now due to e.g.
-# incompatibility w/ clang-cl.
 [cc_test(
     name = src[:-4],
     size = "small",
@@ -28,28 +26,7 @@ cc_library(
     deps = [
         ":protocol",
         "//etest",
-    ],
-) for src in glob(
-    include = ["*_test.cpp"],
-    exclude = ["file_handler_test.cpp"],
-)]
-
-# TODO(robinlinden): Get file_handler_test working with clang-cl. Right now it
-# crashes due to a stack overflow when matching the regex in uri-parsing. This
-# will go away once the spec-compliant url-parser is ready.
-cc_test(
-    name = "file_handler_test",
-    size = "small",
-    srcs = ["file_handler_test.cpp"],
-    copts = HASTUR_COPTS,
-    target_compatible_with = select({
-        "//bzl:is_clang-cl": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    deps = [
-        ":protocol",
-        "//etest",
         "//uri",
         "@fmt",
     ],
-)
+) for src in glob(["*_test.cpp"])]

--- a/uri/BUILD
+++ b/uri/BUILD
@@ -10,7 +10,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//util:string",
-        "@ctre",
         "@fmt",
     ],
 )


### PR DESCRIPTION
ctre was causing stack overflows (in protocol/file_handler_test.cpp when using clang-cl).
See:
```
https://github.com/hanickadot/compile-time-regular-expressions/issues/30
https://github.com/hanickadot/compile-time-regular-expressions/issues/209
https://github.com/hanickadot/compile-time-regular-expressions/issues/252
```

I had a quick look at resolving it by removing a few unnecessary capture groups and things like that in our uri-parsing regex (even though it's straight from the RFC, so not ideal), but I was unable to have it both parsing uris correctly and not cause stack overflows when using clang-cl.