### PR TITLE
build: Don't print info about cached passed test runs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,7 @@
 build --enable_platform_specific_config
 coverage --combined_report=lcov
 test --test_output=errors
+test --test_summary=terse
 test --test_verbose_timeout_warnings
 
 # Bazel deprecations


### PR DESCRIPTION
You can restore the old behaviour by passing --test_summary=short on the command line or adding "test --test_summary=short" to .bazelrc.local.

After:
```
$ bazel test ...
INFO: Invocation ID: ac0d6f92-9904-420c-b414-03a3f56432b6
INFO: Analyzed 111 targets (0 packages loaded, 0 targets configured).
INFO: Found 51 targets and 60 test targets...
INFO: Elapsed time: 0.455s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

Executed 0 out of 60 tests: 58 tests pass and 2 were skipped.
```

Before:
```
$ bazel test ...
INFO: Invocation ID: bfaf239b-761f-4bcc-abb1-6eb2f799dd72
INFO: Analyzed 111 targets (0 packages loaded, 0 targets configured).
INFO: Found 51 targets and 60 test targets...
INFO: Elapsed time: 0.614s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//css:parser_test                                               (cached) PASSED in 0.1s
//css:property_id_test                                          (cached) PASSED in 0.1s
//css:rule_test                                                 (cached) PASSED in 0.1s
//css2:token_test                                               (cached) PASSED in 0.1s
//css2:tokenizer_test                                           (cached) PASSED in 0.1s
//dom:dom_test                                                  (cached) PASSED in 0.1s
//dom2:attr_test                                                (cached) PASSED in 0.2s
//dom2:cdata_section_test                                       (cached) PASSED in 0.2s
//dom2:character_data_test                                      (cached) PASSED in 0.2s
//dom2:comment_test                                             (cached) PASSED in 0.1s
//dom2:document_fragment_test                                   (cached) PASSED in 0.1s
//dom2:document_test                                            (cached) PASSED in 0.2s
//dom2:document_type_test                                       (cached) PASSED in 0.2s
//dom2:element_test                                             (cached) PASSED in 0.1s
//dom2:node_test                                                (cached) PASSED in 0.1s
//dom2:processing_instruction_test                              (cached) PASSED in 0.2s
//dom2:text_test                                                (cached) PASSED in 0.2s
//engine:engine_test                                            (cached) PASSED in 0.1s
//etest:disabled_test_test                                      (cached) PASSED in 0.1s
//etest:expect_eq_failure_test                                  (cached) PASSED in 0.4s
//etest:expect_failure_test                                     (cached) PASSED in 0.5s
//etest:require_eq_failure_test                                 (cached) PASSED in 0.3s
//etest:require_failure_test                                    (cached) PASSED in 0.3s
//etest:success_test                                            (cached) PASSED in 0.3s
//geom:geom_test                                                (cached) PASSED in 0.1s
//gfx:canvas_command_saver_test                                 (cached) PASSED in 0.1s
//gfx:color_test                                                (cached) PASSED in 0.1s
//html:html_test                                                (cached) PASSED in 0.1s
//html2:character_reference_test                                (cached) PASSED in 0.1s
//html2:token_test                                              (cached) PASSED in 0.2s
//html2:tokenizer_test                                          (cached) PASSED in 0.1s
//html2:tree_constructor_test                                   (cached) PASSED in 0.2s
//img:png_test                                                  (cached) PASSED in 0.1s
//js:ast_executor_test                                          (cached) PASSED in 0.1s
//js:ast_test                                                   (cached) PASSED in 0.2s
//js:reader_test                                                (cached) PASSED in 0.1s
//layout:box_model_test                                         (cached) PASSED in 0.1s
//layout:layout_test                                            (cached) PASSED in 0.1s
//os:os_test                                                    (cached) PASSED in 0.2s
//protocol:file_handler_test                                    (cached) PASSED in 0.1s
//protocol:http_test                                            (cached) PASSED in 0.1s
//protocol:multi_protocol_handler_test                          (cached) PASSED in 0.1s
//protocol:response_test                                        (cached) PASSED in 0.1s
//render:render_test                                            (cached) PASSED in 0.1s
//style:style_test                                              (cached) PASSED in 0.1s
//style:styled_node_test                                        (cached) PASSED in 0.1s
//uri:uri_test                                                  (cached) PASSED in 0.2s
//url:url_test                                                  (cached) PASSED in 0.1s
//util:base_parser_test                                         (cached) PASSED in 0.1s
//util:from_chars_test                                          (cached) PASSED in 0.2s
//util:generator_test                                           (cached) PASSED in 0.2s
//util:history_test                                             (cached) PASSED in 0.1s
//util:overloaded_test                                          (cached) PASSED in 0.2s
//util:string_test                                              (cached) PASSED in 0.2s
//util:unicode_test                                             (cached) PASSED in 0.1s
//util:uuid_test                                                (cached) PASSED in 0.2s
@freetype2//:bbox_test                                          (cached) PASSED in 0.9s
@libpng//:pngtest                                               (cached) PASSED in 0.2s
//os:linux_test                                                         SKIPPED
//uri:uri_fuzz_test                                                     SKIPPED

Executed 0 out of 60 tests: 58 tests pass and 2 were skipped.
```