### PR TITLE
ci: Disable codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+# https://docs.codecov.com/docs/pull-request-comments#disable-comment
+comment: false


### PR DESCRIPTION
We get this same info from the codecov PR checks anyway, and we can still get to the detailed report by clicking either of codecov's checks.