### PR TITLE
html2: Handle incorrectly opened comments in tokenizing

### DIFF
--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -1057,7 +1057,15 @@ void Tokenizer::run() {
                     state_ = State::Doctype;
                     continue;
                 }
-                std::terminate();
+
+                if (input_.substr(pos_, std::strlen("[CDATA[")) == "[CDATA["sv) {
+                    std::terminate();
+                }
+
+                emit(ParseError::IncorrectlyOpenedComment);
+                current_token_ = CommentToken{};
+                state_ = State::BogusComment;
+                continue;
 
             case State::CommentStart: {
                 auto c = consume_next_input_character();

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -1043,6 +1043,7 @@ void Tokenizer::run() {
                 continue;
             }
 
+            // https://html.spec.whatwg.org/multipage/parsing.html#markup-declaration-open-state
             case State::MarkupDeclarationOpen:
                 if (input_.substr(pos_, 2) == "--") {
                     pos_ += 2;
@@ -1056,7 +1057,7 @@ void Tokenizer::run() {
                     state_ = State::Doctype;
                     continue;
                 }
-                break;
+                std::terminate();
 
             case State::CommentStart: {
                 auto c = consume_next_input_character();

--- a/html2/tokenizer.h
+++ b/html2/tokenizer.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -110,6 +110,7 @@ enum class ParseError {
     EofInDoctype,
     EofInTag,
     IncorrectlyClosedComment,
+    IncorrectlyOpenedComment,
     InvalidCharacterSequenceAfterDoctypeName,
     InvalidFirstCharacterOfTagName,
     MissingDoctypeName,

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -488,6 +488,13 @@ int main() {
     etest::test("comment, simple", [] {
         auto tokens = run_tokenizer("<!-- Hello -->");
         expect_token(tokens, CommentToken{.data = " Hello "});
+        expect_token(tokens, EndOfFileToken{});
+    });
+
+    etest::test("comment, bogus open", [] {
+        auto tokens = run_tokenizer("<!Hello");
+        expect_error(tokens, ParseError::IncorrectlyOpenedComment);
+        expect_token(tokens, CommentToken{.data = "Hello"});
         expect_token(tokens, EndOfFileToken{});
     });
 


### PR DESCRIPTION
This is one of the first parts of the tokenizer I wrote, and I guess I didn't add `std::terminate()` where I skipped parts of the spec.