### PR TITLE
util: Get rid of third-party dependencies

### DIFF
--- a/util/BUILD
+++ b/util/BUILD
@@ -3,7 +3,6 @@ load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 dependencies = {
     "base_parser": [":string"],
-    "string": ["@fmt"],
     "uuid": ["@fmt"],
 }
 

--- a/util/BUILD
+++ b/util/BUILD
@@ -3,7 +3,6 @@ load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 dependencies = {
     "base_parser": [":string"],
-    "uuid": ["@fmt"],
 }
 
 [cc_library(

--- a/util/string.h
+++ b/util/string.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021 Mikael Larsson <c.mikael.larsson@gmail.com>
 // SPDX-FileCopyrightText: 2022-2023 David Zero <zero-one@zer0-one.net>
 //
@@ -7,13 +7,13 @@
 #ifndef UTIL_STRING_H_
 #define UTIL_STRING_H_
 
-#include <fmt/core.h>
-
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <ios>
 #include <iterator>
 #include <span>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -144,7 +144,7 @@ inline std::string ipv4_serialize(std::uint32_t addr) {
 // To-Do(zero-one): specify constexpr when we drop gcc-11 support
 // https://url.spec.whatwg.org/#concept-ipv6-serializer
 inline std::string ipv6_serialize(std::span<std::uint16_t, 8> addr) {
-    std::string out = "";
+    std::stringstream out;
 
     std::size_t compress = 0;
 
@@ -176,9 +176,9 @@ inline std::string ipv6_serialize(std::span<std::uint16_t, 8> addr) {
 
         if (longest_run > 1 && compress == i) {
             if (i == 0) {
-                out += "::";
+                out << "::";
             } else {
-                out += ":";
+                out << ":";
             }
 
             ignore0 = true;
@@ -186,14 +186,14 @@ inline std::string ipv6_serialize(std::span<std::uint16_t, 8> addr) {
             continue;
         }
 
-        out += fmt::format("{:x}", addr[i]);
+        out << std::hex << addr[i];
 
         if (i != 7) {
-            out += ":";
+            out << ":";
         }
     }
 
-    return out;
+    return std::move(out).str();
 }
 
 } // namespace util

--- a/util/uuid.h
+++ b/util/uuid.h
@@ -1,18 +1,22 @@
 // SPDX-FileCopyrightText: 2023 David Zero <zero-one@zer0-one.net>
+// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #ifndef UTIL_UUID_H_
 #define UTIL_UUID_H_
 
+#include <iomanip>
+#include <ios>
 #include <random>
-
-#include <fmt/core.h>
+#include <sstream>
+#include <utility>
 
 namespace util {
 inline std::string new_uuid() {
     unsigned char data[16];
-    std::string uuid_string;
+    std::stringstream uuid_string;
+    uuid_string << std::setfill('0');
 
     std::random_device rando;
 
@@ -30,13 +34,13 @@ inline std::string new_uuid() {
 
     for (size_t i = 0; i < 16; i++) {
         if (i == 4 || i == 6 || i == 8 || i == 10) {
-            uuid_string += '-';
+            uuid_string << '-';
         }
 
-        uuid_string += fmt::format("{:02x}", data[i]);
+        uuid_string << std::setw(2) << std::hex << +data[i];
     }
 
-    return uuid_string;
+    return std::move(uuid_string).str();
 }
 
 } // namespace util


### PR DESCRIPTION
This is desirable (but not a hard requirement, for future reference) as the libs under util (especially `//util:string`) are depended on ~everywhere.

We'll switch to std::format and constexpr everything once the compilers we target are a bit more modern, but in neither of these libraries did switching to std::stringstream really decrease readability, so that's nice.