### PR TITLE
net: Fix ssl handshake failure when SNI is required

### DIFF
--- a/net/BUILD
+++ b/net/BUILD
@@ -16,5 +16,8 @@ cc_library(
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
-    deps = ["@asio"],
+    deps = [
+        "@asio",
+        "@boringssl//:ssl",
+    ],
 )

--- a/net/socket.cpp
+++ b/net/socket.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2021 Mikael Larsson <c.mikael.larsson@gmail.com>
+// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -93,10 +94,12 @@ std::string Socket::read_bytes(std::size_t bytes) {
 }
 
 struct SecureSocket::Impl : public BaseSocketImpl {
+    // TODO(robinlinden): Better error propagation.
     bool connect(std::string_view host, std::string_view service) {
         if (BaseSocketImpl::connect(resolver, socket.next_layer(), host, service)) {
-            socket.handshake(asio::ssl::stream_base::handshake_type::client);
-            return true;
+            asio::error_code ec;
+            socket.handshake(asio::ssl::stream_base::handshake_type::client, ec);
+            return !ec;
         }
         return false;
     }


### PR DESCRIPTION
After this, we're able to connect to and load e.g. https://www.ietf.org/

I had a brief look at esni and ech, but esni isn't a thing in boringssl, and ech is still in-progress. We'll probably be able to get ech working if we put some time into it since it's available behind a flag in Chromium, but that's future work.

SNI: https://www.cloudflare.com/learning/ssl/what-is-sni/
ESNI: https://www.cloudflare.com/learning/ssl/what-is-encrypted-sni/
ECH: https://blog.cloudflare.com/encrypted-client-hello/