### PR TITLE
engine: Don't try to parse encoded responses as css

### DIFF
--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -111,6 +111,11 @@ void Engine::on_navigation_success() {
                 return {};
             }
 
+            if (auto encoding = style_data.headers.get("Content-Encoding")) {
+                spdlog::warn("Got unsupported encoding '{}', skipping stylesheet '{}'", *encoding, stylesheet_url.uri);
+                return {};
+            }
+
             return css::parse(style_data.body);
         }));
     }


### PR DESCRIPTION
This works around us crashing in CSS parsing on https://yahoo.com as we no longer pass one of their gzipped stylesheets to our ad-hoc parser. It should handle any kind of garbage we give to it, really, but we're switching to the spec-compliant css2 soon(tm), so I don't want to spend too much time on it.