### PR TITLE
Add dependency on icu

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -100,6 +100,18 @@ http_archive(
 )
 
 http_archive(
+    name = "icu",  # Unicode-DFS-2016
+    build_file = "//third_party:icu.BUILD",
+    patch_cmds = [
+        "rm source/common/BUILD.bazel",
+        "rm source/stubdata/BUILD.bazel",
+    ],
+    sha256 = "a2d2d38217092a7ed56635e34467f92f976b370e20182ad325edea6681a71d68",
+    strip_prefix = "icu",
+    url = "https://github.com/unicode-org/icu/releases/download/release-72-1/icu4c-72_1-src.tgz",
+)
+
+http_archive(
     name = "imgui",  # MIT
     build_file = "//third_party:imgui.BUILD",
     sha256 = "3b665fadd5580b7ef494d5d8bb1c12b2ec53ee723034caf43332956381f5d631",

--- a/third_party/icu.BUILD
+++ b/third_party/icu.BUILD
@@ -1,0 +1,43 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "common",
+    srcs = glob([
+        "source/common/*.h",
+        "source/common/*.cpp",
+        "source/stubdata/*.h",
+        "source/stubdata/*.cpp",
+    ]),
+    hdrs = glob([
+        "source/common/unicode/*.h",
+    ]),
+    copts = select({
+        "@platforms//os:windows": [
+            "/GR",
+            "-utf-8",
+            "-I source/common/",
+            "-I source/common/unicode/",
+            "-I source/stubdata/",
+        ],
+        "//conditions:default": [
+            "-frtti",
+            "-I source/common/",
+            "-I source/common/unicode/",
+            "-I source/stubdata/",
+        ],
+    }) + select({
+        "@bazel_tools//tools/cpp:clang-cl": [
+            "-Wno-microsoft-include",
+        ],
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-ldl"],
+    }),
+    local_defines = [
+        "U_COMMON_IMPLEMENTATION",
+    ],
+    strip_include_prefix = "source/common/",
+    visibility = ["//visibility:public"],
+)

--- a/url/BUILD
+++ b/url/BUILD
@@ -10,6 +10,7 @@ cc_library(
     deps = [
         "//util:string",
         "//util:uuid",
+        "@icu//:common",
     ],
 )
 


### PR DESCRIPTION
icu will handle IDNA and misc unicode stuff that requires lugging around giant mapping tables that need to stay up-to-date with the unicode standard.