### PR TITLE
Dedup URLs for link liveness check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - run: grep --recursive --no-filename --only-matching --exclude=WORKSPACE --exclude=*test.cpp --exclude=ci.yaml 'https://[^)(}{", ]*' | grep -v '^https://$' | xargs wget --spider
+      - run: grep --recursive --no-filename --only-matching --exclude=WORKSPACE --exclude=*test.cpp --exclude=ci.yaml 'https://[^)(}{",# ]*' | grep -v '^https://$' | sort | uniq | xargs wget --spider
 
   gitlint:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This cuts down the number of checked URLs by almost half, since so many are the same page with different anchors.