### PR TITLE
deps: Add tl::expected

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,6 +68,14 @@ http_archive(
 )
 
 http_archive(
+    name = "expected",  # CC0-1.0
+    build_file = "//third_party:expected.BUILD",
+    sha256 = "67b4216c80eae2959222a5da93bb58839ebef0ed37f3c402b930fa5b263244f9",
+    strip_prefix = "expected-3e304a4bdd00feef8d41f5b388c37bd9d6108025",
+    url = "https://github.com/tartanllama/expected/archive/3e304a4bdd00feef8d41f5b388c37bd9d6108025.tar.gz",
+)
+
+http_archive(
     name = "fmt",  # MIT
     build_file = "//third_party:fmt.BUILD",
     sha256 = "5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2",

--- a/third_party/expected.BUILD
+++ b/third_party/expected.BUILD
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "expected",
+    hdrs = ["include/tl/expected.hpp"],
+    includes = ["include/"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)

--- a/wasm/BUILD
+++ b/wasm/BUILD
@@ -13,6 +13,7 @@ cc_library(
     hdrs = glob(["*.h"]),
     copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
+    deps = ["@expected"],
 )
 
 [cc_test(

--- a/wasm/wasm.h
+++ b/wasm/wasm.h
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+#include <tl/expected.hpp>
+
 namespace wasm {
 
 // https://webassembly.github.io/spec/core/binary/modules.html#indices
@@ -119,10 +121,18 @@ struct CodeSection {
     [[nodiscard]] bool operator==(CodeSection const &) const = default;
 };
 
+enum class ParseError {
+    Unknown,
+    UnexpectedEof,
+    InvalidMagic,
+    UnsupportedVersion,
+    InvalidSectionId,
+};
+
 // https://webassembly.github.io/spec/core/bikeshed/#modules
 struct Module {
-    static std::optional<Module> parse_from(std::istream &&is) { return parse_from(is); }
-    static std::optional<Module> parse_from(std::istream &);
+    static tl::expected<Module, ParseError> parse_from(std::istream &&is) { return parse_from(is); }
+    static tl::expected<Module, ParseError> parse_from(std::istream &);
 
     std::vector<Section> sections{};
 

--- a/wasm/wasm_test.cpp
+++ b/wasm/wasm_test.cpp
@@ -343,12 +343,12 @@ void code_section_tests() {
 int main() {
     etest::test("invalid magic", [] {
         auto wasm_bytes = std::stringstream{"hello"};
-        expect_eq(wasm::Module::parse_from(wasm_bytes), std::nullopt);
+        expect_eq(wasm::Module::parse_from(wasm_bytes), tl::unexpected{wasm::ParseError::InvalidMagic});
     });
 
     etest::test("unsupported version", [] {
         auto wasm_bytes = std::stringstream{"\0asm\2\0\0\0"s};
-        expect_eq(wasm::Module::parse_from(wasm_bytes), std::nullopt);
+        expect_eq(wasm::Module::parse_from(wasm_bytes), tl::unexpected{wasm::ParseError::UnsupportedVersion});
     });
 
     // https://webassembly.github.io/spec/core/bikeshed/#modules
@@ -360,22 +360,22 @@ int main() {
 
     etest::test("invalid section id", [] {
         auto wasm_bytes = std::stringstream{"\0asm\1\0\0\0\x0d"s};
-        expect_eq(wasm::Module::parse_from(std::move(wasm_bytes)), std::nullopt);
+        expect_eq(wasm::Module::parse_from(std::move(wasm_bytes)), tl::unexpected{wasm::ParseError::InvalidSectionId});
     });
 
     etest::test("missing size", [] {
         auto wasm_bytes = std::stringstream{"\0asm\1\0\0\0\0"s};
-        expect_eq(wasm::Module::parse_from(std::move(wasm_bytes)), std::nullopt);
+        expect_eq(wasm::Module::parse_from(std::move(wasm_bytes)), tl::unexpected{wasm::ParseError::Unknown});
     });
 
     etest::test("missing content", [] {
         auto wasm_bytes = std::stringstream{"\0asm\1\0\0\0\0\4"s};
-        expect_eq(wasm::Module::parse_from(std::move(wasm_bytes)), std::nullopt);
+        expect_eq(wasm::Module::parse_from(std::move(wasm_bytes)), tl::unexpected{wasm::ParseError::UnexpectedEof});
     });
 
     etest::test("not enough content", [] {
         auto wasm_bytes = std::stringstream{"\0asm\1\0\0\0\0\4\0\0\0"s};
-        expect_eq(wasm::Module::parse_from(std::move(wasm_bytes)), std::nullopt);
+        expect_eq(wasm::Module::parse_from(std::move(wasm_bytes)), tl::unexpected{wasm::ParseError::UnexpectedEof});
     });
 
     etest::test("one valid section", [] {


### PR DESCRIPTION
We'll replace this with std::expected once our compilers have implemented more of C++23.