### PR TITLE
engine: Add a test that fetches stylesheets in parallel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -61,6 +61,7 @@ build:asan --action_env=LSAN_OPTIONS=report_objects=1
 
 build:tsan --strip=never
 build:tsan --features=tsan
+build:tsan --action_env=TSAN_OPTIONS=halt_on_error=1
 
 build:ubsan --strip=never
 build:ubsan --features=ubsan


### PR DESCRIPTION
This exercises the multithreading in //engine so tsan can detect any
potential errors.