### PR TITLE
//wasm cleanup: Link to the real spec instead of a draft, be less silly when parsing value types.

### DIFF
--- a/wasm/leb128.h
+++ b/wasm/leb128.h
@@ -13,7 +13,7 @@
 
 namespace wasm {
 
-// https://webassembly.github.io/spec/core/bikeshed/#binary-int
+// https://webassembly.github.io/spec/core/binary/values.html#integers
 template<typename T>
 requires std::integral<T>
 struct Leb128 {

--- a/wasm/leb128_test.cpp
+++ b/wasm/leb128_test.cpp
@@ -72,7 +72,7 @@ int main() {
     });
 
     etest::test("trailing zeros", [] {
-        // From https://webassembly.github.io/spec/core/bikeshed/#binary-int
+        // From https://webassembly.github.io/spec/core/binary/values.html#integers
 
         // The side conditions N>7 in the productions for non-terminal bytes of
         // the u and s encodings restrict the encoding's length. However,
@@ -91,7 +91,7 @@ int main() {
     });
 
     etest::test("unused bits in terminal byte", [] {
-        // From https://webassembly.github.io/spec/core/bikeshed/#binary-int
+        // From https://webassembly.github.io/spec/core/binary/values.html#integers
 
         // The side conditions on the value n of terminal bytes further enforce
         // that any unused bits in these bytes must be 0 for positive values and

--- a/wasm/wasm.cpp
+++ b/wasm/wasm.cpp
@@ -38,6 +38,7 @@ std::optional<std::uint32_t> parse(std::istream &is) {
     return Leb128<std::uint32_t>::decode_from(is);
 }
 
+// https://webassembly.github.io/spec/core/binary/types.html
 template<>
 std::optional<ValueType> parse(std::istream &is) {
     std::uint8_t byte{};
@@ -45,17 +46,21 @@ std::optional<ValueType> parse(std::istream &is) {
         return std::nullopt;
     }
 
-    // Cute hack to make sure that the byte we read is one of the valid enum values.
-    auto type = static_cast<ValueType>(byte);
-    switch (type) {
-        case ValueType::Int32:
-        case ValueType::Int64:
-        case ValueType::Float32:
-        case ValueType::Float64:
-        case ValueType::Vector128:
-        case ValueType::FunctionReference:
-        case ValueType::ExternReference:
-            return type;
+    switch (byte) {
+        case 0x7f:
+            return ValueType::Int32;
+        case 0x7e:
+            return ValueType::Int64;
+        case 0x7d:
+            return ValueType::Float32;
+        case 0x7c:
+            return ValueType::Float64;
+        case 0x7b:
+            return ValueType::Vector128;
+        case 0x70:
+            return ValueType::FunctionReference;
+        case 0x6f:
+            return ValueType::ExternReference;
         default:
             return std::nullopt;
     }

--- a/wasm/wasm.cpp
+++ b/wasm/wasm.cpp
@@ -85,10 +85,10 @@ std::optional<FunctionType> parse(std::istream &is) {
     };
 }
 
-// https://webassembly.github.io/spec/core/bikeshed/#export-section
+// https://webassembly.github.io/spec/core/binary/modules.html#binary-exportsec
 template<>
 std::optional<Export> parse(std::istream &is) {
-    // https://webassembly.github.io/spec/core/bikeshed/#binary-utf8
+    // https://webassembly.github.io/spec/core/binary/values.html#names
     auto name_length = Leb128<std::uint32_t>::decode_from(is);
     if (!name_length) {
         return std::nullopt;
@@ -171,7 +171,7 @@ std::optional<CodeEntry> parse(std::istream &is) {
     };
 }
 
-// https://webassembly.github.io/spec/core/bikeshed/#binary-vec
+// https://webassembly.github.io/spec/core/binary/conventions.html#vectors
 template<typename T>
 std::optional<std::vector<T>> parse_vector(std::istream &is) {
     auto item_count = Leb128<std::uint32_t>::decode_from(is);
@@ -212,14 +212,14 @@ std::optional<std::string> get_section_data(std::vector<Section> const &sections
 tl::expected<Module, ParseError> Module::parse_from(std::istream &is) {
     std::string buf;
 
-    // https://webassembly.github.io/spec/core/bikeshed/#binary-magic
+    // https://webassembly.github.io/spec/core/binary/modules.html#binary-magic
     buf.resize(kMagicSize);
     is.read(buf.data(), buf.size());
     if (!is || buf != "\0asm"sv) {
         return tl::unexpected{ParseError::InvalidMagic};
     }
 
-    // https://webassembly.github.io/spec/core/bikeshed/#binary-version
+    // https://webassembly.github.io/spec/core/binary/modules.html#binary-version
     buf.resize(kVersionSize);
     is.read(buf.data(), buf.size());
     if (!is || buf != "\1\0\0\0"sv) {
@@ -228,7 +228,7 @@ tl::expected<Module, ParseError> Module::parse_from(std::istream &is) {
 
     Module module;
 
-    // https://webassembly.github.io/spec/core/bikeshed/#sections
+    // https://webassembly.github.io/spec/core/binary/modules.html#sections
     while (true) {
         std::uint8_t id{};
         is.read(reinterpret_cast<char *>(&id), sizeof(id));

--- a/wasm/wasm.h
+++ b/wasm/wasm.h
@@ -18,7 +18,7 @@ namespace wasm {
 // https://webassembly.github.io/spec/core/binary/modules.html#indices
 using TypeIdx = std::uint32_t;
 
-// https://webassembly.github.io/spec/core/bikeshed/#sections
+// https://webassembly.github.io/spec/core/binary/modules.html#sections
 enum class SectionId {
     Custom = 0,
     Type = 1,
@@ -83,7 +83,7 @@ struct FunctionSection {
     [[nodiscard]] bool operator==(FunctionSection const &) const = default;
 };
 
-// https://webassembly.github.io/spec/core/bikeshed/#binary-export
+// https://webassembly.github.io/spec/core/binary/modules.html#binary-export
 struct Export {
     enum class Type { Function = 0, Table = 1, Memory = 2, Global = 3 };
 
@@ -94,7 +94,7 @@ struct Export {
     [[nodiscard]] bool operator==(Export const &) const = default;
 };
 
-// https://webassembly.github.io/spec/core/bikeshed/#export-section
+// https://webassembly.github.io/spec/core/binary/modules.html#binary-exportsec
 struct ExportSection {
     std::vector<Export> exports{};
 
@@ -129,7 +129,7 @@ enum class ParseError {
     InvalidSectionId,
 };
 
-// https://webassembly.github.io/spec/core/bikeshed/#modules
+// https://webassembly.github.io/spec/core/syntax/modules.html
 struct Module {
     static tl::expected<Module, ParseError> parse_from(std::istream &&is) { return parse_from(is); }
     static tl::expected<Module, ParseError> parse_from(std::istream &);

--- a/wasm/wasm.h
+++ b/wasm/wasm.h
@@ -42,20 +42,20 @@ struct Section {
     [[nodiscard]] bool operator==(Section const &) const = default;
 };
 
-// https://webassembly.github.io/spec/core/binary/types.html#types
+// https://webassembly.github.io/spec/core/syntax/types.html
 enum class ValueType : std::uint8_t {
-    // https://webassembly.github.io/spec/core/binary/types.html#number-types
-    Int32 = 0x7f,
-    Int64 = 0x7e,
-    Float32 = 0x7d,
-    Float64 = 0x7c,
+    // Number types.
+    Int32,
+    Int64,
+    Float32,
+    Float64,
 
-    // https://webassembly.github.io/spec/core/binary/types.html#vector-types
-    Vector128 = 0x7b,
+    // Vector types.
+    Vector128,
 
-    // https://webassembly.github.io/spec/core/binary/types.html#reference-types
-    FunctionReference = 0x70,
-    ExternReference = 0x6f,
+    // Reference types.
+    FunctionReference,
+    ExternReference,
 };
 
 // https://webassembly.github.io/spec/core/binary/types.html#result-types

--- a/wasm/wasm_test.cpp
+++ b/wasm/wasm_test.cpp
@@ -214,11 +214,11 @@ void type_section_tests() {
     });
 
     etest::test("type section, two types", [] {
-        auto const i32_byte = static_cast<std::uint8_t>(wasm::ValueType::Int32);
-        auto const f64_byte = static_cast<std::uint8_t>(wasm::ValueType::Float64);
+        constexpr std::uint8_t kInt32Byte = 0x7f;
+        constexpr std::uint8_t kFloat64Byte = 0x7c;
         auto module = wasm::Module{.sections{wasm::Section{
                 .id = wasm::SectionId::Type,
-                .content{2, 0x60, 0, 1, i32_byte, 0x60, 2, i32_byte, i32_byte, 1, f64_byte},
+                .content{2, 0x60, 0, 1, kInt32Byte, 0x60, 2, kInt32Byte, kInt32Byte, 1, kFloat64Byte},
         }}};
 
         expect_eq(module.type_section(),
@@ -228,6 +228,30 @@ void type_section_tests() {
                                 wasm::FunctionType{
                                         .parameters{wasm::ValueType::Int32, wasm::ValueType::Int32},
                                         .results{wasm::ValueType::Float64},
+                                },
+                        },
+                });
+    });
+
+    etest::test("type section, all types", [] {
+        auto module = wasm::Module{.sections{wasm::Section{
+                .id = wasm::SectionId::Type,
+                .content{1, 0x60, 7, 0x7f, 0x7e, 0x7d, 0x7c, 0x7b, 0x70, 0x6f, 0},
+        }}};
+
+        expect_eq(module.type_section(),
+                wasm::TypeSection{
+                        .types{
+                                wasm::FunctionType{
+                                        .parameters{
+                                                wasm::ValueType::Int32,
+                                                wasm::ValueType::Int64,
+                                                wasm::ValueType::Float32,
+                                                wasm::ValueType::Float64,
+                                                wasm::ValueType::Vector128,
+                                                wasm::ValueType::FunctionReference,
+                                                wasm::ValueType::ExternReference,
+                                        },
                                 },
                         },
                 });

--- a/wasm/wasm_test.cpp
+++ b/wasm/wasm_test.cpp
@@ -351,7 +351,7 @@ int main() {
         expect_eq(wasm::Module::parse_from(wasm_bytes), tl::unexpected{wasm::ParseError::UnsupportedVersion});
     });
 
-    // https://webassembly.github.io/spec/core/bikeshed/#modules
+    // https://webassembly.github.io/spec/core/syntax/modules.html
     // Each of the vectors – and thus the entire module – may be empty
     etest::test("empty module", [] {
         auto wasm_bytes = std::stringstream{"\0asm\1\0\0\0"s};


### PR DESCRIPTION
The previous way of parsing value types worked, but it felt sort of gross, so here's a more "proper" implementation. I changed my mind about the hack being cute. :( It kept me up at night.