### PR TITLE
style: Make border-style properties more strongly typed

### DIFF
--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -221,8 +221,6 @@ std::map<std::string_view, int> const kBorderWidthKeywords{
 };
 
 void calculate_border(LayoutBox &box, int const font_size) {
-    std::string_view default_style = "none";
-
     auto as_px = [&](std::string_view border_width_property) {
         if (kBorderWidthKeywords.contains(border_width_property)) {
             return kBorderWidthKeywords.at(border_width_property);
@@ -231,22 +229,22 @@ void calculate_border(LayoutBox &box, int const font_size) {
         return to_px(border_width_property, font_size);
     };
 
-    if (box.get_property<css::PropertyId::BorderLeftStyle>() != default_style) {
+    if (box.get_property<css::PropertyId::BorderLeftStyle>() != style::BorderStyle::None) {
         auto border_width = box.get_property<css::PropertyId::BorderLeftWidth>();
         box.dimensions.border.left = as_px(border_width);
     }
 
-    if (box.get_property<css::PropertyId::BorderRightStyle>() != default_style) {
+    if (box.get_property<css::PropertyId::BorderRightStyle>() != style::BorderStyle::None) {
         auto border_width = box.get_property<css::PropertyId::BorderRightWidth>();
         box.dimensions.border.right = as_px(border_width);
     }
 
-    if (box.get_property<css::PropertyId::BorderTopStyle>() != default_style) {
+    if (box.get_property<css::PropertyId::BorderTopStyle>() != style::BorderStyle::None) {
         auto border_width = box.get_property<css::PropertyId::BorderTopWidth>();
         box.dimensions.border.top = as_px(border_width);
     }
 
-    if (box.get_property<css::PropertyId::BorderBottomStyle>() != default_style) {
+    if (box.get_property<css::PropertyId::BorderBottomStyle>() != style::BorderStyle::None) {
         auto border_width = box.get_property<css::PropertyId::BorderBottomWidth>();
         box.dimensions.border.bottom = as_px(border_width);
     }

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -269,6 +269,35 @@ std::string_view StyledNode::get_raw_property(css::PropertyId property) const {
     return it->second;
 }
 
+BorderStyle StyledNode::get_border_style_property(css::PropertyId property) const {
+    auto raw = get_raw_property(property);
+
+    if (raw == "none") {
+        return BorderStyle::None;
+    } else if (raw == "hidden") {
+        return BorderStyle::Hidden;
+    } else if (raw == "dotted") {
+        return BorderStyle::Dotted;
+    } else if (raw == "dashed") {
+        return BorderStyle::Dashed;
+    } else if (raw == "solid") {
+        return BorderStyle::Solid;
+    } else if (raw == "double") {
+        return BorderStyle::Double;
+    } else if (raw == "groove") {
+        return BorderStyle::Groove;
+    } else if (raw == "ridge") {
+        return BorderStyle::Ridge;
+    } else if (raw == "inset") {
+        return BorderStyle::Inset;
+    } else if (raw == "outset") {
+        return BorderStyle::Outset;
+    }
+
+    spdlog::warn("Unhandled border-style value '{}'", raw);
+    return BorderStyle::None;
+}
+
 gfx::Color StyledNode::get_color_property(css::PropertyId property) const {
     auto color_text = get_raw_property(property);
 

--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -19,6 +19,19 @@
 
 namespace style {
 
+enum class BorderStyle {
+    None,
+    Hidden,
+    Dotted,
+    Dashed,
+    Solid,
+    Double,
+    Groove,
+    Ridge,
+    Inset,
+    Outset,
+};
+
 enum class DisplayValue {
     None,
     Inline,
@@ -50,6 +63,9 @@ struct StyledNode {
         } else if constexpr (T == css::PropertyId::BorderBottomColor || T == css::PropertyId::BorderLeftColor
                 || T == css::PropertyId::BorderRightColor || T == css::PropertyId::BorderTopColor) {
             return get_color_property(T);
+        } else if constexpr (T == css::PropertyId::BorderBottomStyle || T == css::PropertyId::BorderLeftStyle
+                || T == css::PropertyId::BorderRightStyle || T == css::PropertyId::BorderTopStyle) {
+            return get_border_style_property(T);
         } else if constexpr (T == css::PropertyId::Color) {
             return get_color_property(T);
         } else if constexpr (T == css::PropertyId::Display) {
@@ -69,6 +85,7 @@ struct StyledNode {
     }
 
 private:
+    BorderStyle get_border_style_property(css::PropertyId) const;
     gfx::Color get_color_property(css::PropertyId) const;
     DisplayValue get_display_property() const;
     FontStyle get_font_style_property() const;

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -256,6 +256,23 @@ int main() {
     etest::test("get_property, unhandled display value",
             [] { expect_property_eq<css::PropertyId::Display>("i cant believe this", style::DisplayValue::Block); });
 
+    etest::test("get_property, border-style", [] {
+        expect_property_eq<css::PropertyId::BorderBottomStyle>("none", style::BorderStyle::None);
+        expect_property_eq<css::PropertyId::BorderBottomStyle>("hidden", style::BorderStyle::Hidden);
+        expect_property_eq<css::PropertyId::BorderBottomStyle>("dotted", style::BorderStyle::Dotted);
+        expect_property_eq<css::PropertyId::BorderBottomStyle>("dashed", style::BorderStyle::Dashed);
+        expect_property_eq<css::PropertyId::BorderBottomStyle>("solid", style::BorderStyle::Solid);
+        expect_property_eq<css::PropertyId::BorderBottomStyle>("double", style::BorderStyle::Double);
+        expect_property_eq<css::PropertyId::BorderBottomStyle>("groove", style::BorderStyle::Groove);
+        expect_property_eq<css::PropertyId::BorderBottomStyle>("ridge", style::BorderStyle::Ridge);
+        expect_property_eq<css::PropertyId::BorderBottomStyle>("inset", style::BorderStyle::Inset);
+        expect_property_eq<css::PropertyId::BorderBottomStyle>("outset", style::BorderStyle::Outset);
+        expect_property_eq<css::PropertyId::BorderBottomStyle>("???", style::BorderStyle::None);
+
+        expect_property_eq<css::PropertyId::BorderLeftStyle>("ridge", style::BorderStyle::Ridge);
+        expect_property_eq<css::PropertyId::BorderRightStyle>("ridge", style::BorderStyle::Ridge);
+        expect_property_eq<css::PropertyId::BorderTopStyle>("ridge", style::BorderStyle::Ridge);
+    });
 
     return etest::run_all_tests();
 }

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -6,11 +6,28 @@
 
 #include "etest/etest.h"
 
+#include <string>
 #include <tuple>
+#include <utility>
 
 using namespace std::literals;
 using etest::expect;
 using etest::expect_eq;
+
+namespace {
+template<css::PropertyId IdT>
+void expect_property_eq(
+        std::string value, auto expected, etest::source_location const &loc = etest::source_location::current()) {
+    dom::Node dom_node = dom::Element{"dummy"s};
+    style::StyledNode styled_node{
+            .node = dom_node,
+            .properties = {{IdT, std::move(value)}},
+            .children = {},
+    };
+
+    etest::expect_eq(styled_node.get_property<IdT>(), expected, std::nullopt, loc);
+};
+} // namespace
 
 int main() {
     etest::test("get_property", [] {

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -11,7 +11,6 @@
 #include <utility>
 
 using namespace std::literals;
-using etest::expect;
 using etest::expect_eq;
 
 namespace {
@@ -30,16 +29,7 @@ void expect_property_eq(
 } // namespace
 
 int main() {
-    etest::test("get_property", [] {
-        dom::Node dom_node = dom::Element{"dummy"s};
-        style::StyledNode styled_node{
-                .node = dom_node,
-                .properties = {{css::PropertyId::Width, "15px"s}},
-                .children = {},
-        };
-
-        expect(styled_node.get_property<css::PropertyId::Width>() == "15px"sv);
-    });
+    etest::test("get_property", [] { expect_property_eq<css::PropertyId::Width>("15px", "15px"); });
 
     etest::test("property inheritance", [] {
         dom::Node dom_node = dom::Element{"dummy"s};
@@ -163,20 +153,14 @@ int main() {
     });
 
     etest::test("get_font_style_property", [] {
-        dom::Node dom_node = dom::Element{"dummy"s};
-        style::StyledNode styled_node{.node = dom_node, .properties = {{css::PropertyId::FontStyle, "oblique"s}}};
-
-        expect_eq(styled_node.get_property<css::PropertyId::FontStyle>(), style::FontStyle::Oblique);
+        expect_property_eq<css::PropertyId::FontStyle>("oblique", style::FontStyle::Oblique);
 
         // Unhandled properties don't break things.
-        styled_node.properties[0] = std::pair{css::PropertyId::FontStyle, "???"s};
-        expect_eq(styled_node.get_property<css::PropertyId::FontStyle>(), style::FontStyle::Normal);
+        expect_property_eq<css::PropertyId::FontStyle>("???", style::FontStyle::Normal);
     });
 
     etest::test("get_font_family_property", [] {
-        dom::Node dom_node = dom::Element{"dummy"s};
-        style::StyledNode styled_node{.node = dom_node, .properties = {{css::PropertyId::FontFamily, "abc, def"s}}};
-        expect_eq(styled_node.get_property<css::PropertyId::FontFamily>(), std::vector<std::string_view>{"abc", "def"});
+        expect_property_eq<css::PropertyId::FontFamily>("abc, def", std::vector<std::string_view>{"abc", "def"});
     });
 
     etest::test("get_font_size_property", [] {
@@ -269,16 +253,9 @@ int main() {
         expect_eq(styled_node.get_property<css::PropertyId::Display>(), style::DisplayValue::None);
     });
 
-    etest::test("get_property, unhandled display value", [] {
-        dom::Node dom_node = dom::Element{"dummy"s};
-        style::StyledNode styled_node{
-                .node = dom_node,
-                .properties = {{css::PropertyId::Display, "i cant believe this"s}},
-                .children = {},
-        };
+    etest::test("get_property, unhandled display value",
+            [] { expect_property_eq<css::PropertyId::Display>("i cant believe this", style::DisplayValue::Block); });
 
-        expect_eq(styled_node.get_property<css::PropertyId::Display>(), style::DisplayValue::Block);
-    });
 
     return etest::run_all_tests();
 }


### PR DESCRIPTION
I also added a cute little property-test helper to reduce the dom/style tree boilerplate we need in every test checking properties.