### PR TITLE
ci: Increase the test timeout when running under valgrind

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,7 @@ jobs:
             os: ubuntu-22.04
             compiler: gcc
             version: 12
-            # We exclude @freetype2//:bbox_test as that can take >1 minute to run under valgrind in CI.
-            bazel: --run_under="valgrind --leak-check=full --errors-for-leak-kinds=all --error-exitcode=1 --track-origins=yes --show-leak-kinds=all" -- -@freetype2//:bbox_test
+            bazel: --test_timeout=120 --run_under="valgrind --leak-check=full --errors-for-leak-kinds=all --error-exitcode=1 --track-origins=yes --show-leak-kinds=all"
             apt: g++-12 valgrind
 
           - name: clang-14-tsan


### PR DESCRIPTION
This allows us to run everything under valgrind again.