### PR TITLE
Drop support for gcc 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
           echo "<html><body><h1>Example</h1><p>This is an example page.</p></body></html>" >example.html
           bazel run browser:tui file://$(pwd)/example.html ${{ matrix.bazel }}
 
-  linux-gcc-11-coverage:
+  linux-gcc-12-coverage:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -112,11 +112,12 @@ jobs:
       - name: Install
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends libgl-dev lcov gcc-11 g++-11
+          sudo apt-get install --no-install-recommends libgl-dev lcov gcc-12 g++-12
       - name: Setup
         run: |
-          echo "CC=gcc-11" >> $GITHUB_ENV
-          echo "CXX=g++-11" >> $GITHUB_ENV
+          echo "CC=gcc-12" >> $GITHUB_ENV
+          echo "CXX=g++-12" >> $GITHUB_ENV
+          echo "GCOV=gcov-12" >> $GITHUB_ENV
       - name: Coverage
         run: bazel coverage ...
       - name: Summary

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### Compiler
 
-Right now GCC 11, Clang 14, and MSVC are tested against. The project makes use
+Right now GCC 12, Clang 14, and MSVC are tested against. The project makes use
 of C++23 features, so a reasonably recent compiler is required.
 
 #### Build system

--- a/gfx/canvas_command_saver.h
+++ b/gfx/canvas_command_saver.h
@@ -136,7 +136,7 @@ public:
         canvas_.draw_rect(cmd.rect, cmd.color, cmd.borders, cmd.corners);
     }
 
-    void operator()(DrawTextWithFontOptionsCmd const &cmd) {
+    constexpr void operator()(DrawTextWithFontOptionsCmd const &cmd) {
         std::vector<gfx::Font> fonts;
         std::ranges::transform(
                 cmd.font_options, std::back_inserter(fonts), [](auto const &font) { return gfx::Font{font}; });
@@ -151,7 +151,7 @@ private:
     ICanvas &canvas_;
 };
 
-inline void replay_commands(ICanvas &canvas, std::vector<CanvasCommand> const &commands) {
+constexpr void replay_commands(ICanvas &canvas, std::vector<CanvasCommand> const &commands) {
     CanvasCommandVisitor visitor{canvas};
     for (auto const &command : commands) {
         std::visit(visitor, command);

--- a/util/string.h
+++ b/util/string.h
@@ -73,7 +73,7 @@ constexpr char lowercased(char c) {
     return c + ('a' - 'A');
 }
 
-[[nodiscard]] inline std::string lowercased(std::string s) {
+[[nodiscard]] constexpr std::string lowercased(std::string s) {
     std::ranges::for_each(s, [](char &c) { c = lowercased(c); });
     return s;
 }
@@ -82,7 +82,7 @@ constexpr bool no_case_compare(std::string_view a, std::string_view b) {
     return std::ranges::equal(a, b, [](auto c1, auto c2) { return lowercased(c1) == lowercased(c2); });
 }
 
-inline std::vector<std::string_view> split(std::string_view str, std::string_view sep) {
+constexpr std::vector<std::string_view> split(std::string_view str, std::string_view sep) {
     std::vector<std::string_view> result{};
     for (auto p = str.find(sep); p != str.npos; p = str.find(sep)) {
         result.push_back(str.substr(0, p));
@@ -124,9 +124,8 @@ constexpr std::string_view trim(std::string_view s) {
     return s;
 }
 
-// To-Do(zero-one): specify constexpr when we drop gcc-11 support
 // https://url.spec.whatwg.org/#concept-ipv4-serializer
-inline std::string ipv4_serialize(std::uint32_t addr) {
+constexpr std::string ipv4_serialize(std::uint32_t addr) {
     std::string out = "";
     std::uint32_t n = addr;
 
@@ -143,7 +142,6 @@ inline std::string ipv4_serialize(std::uint32_t addr) {
     return out;
 }
 
-// To-Do(zero-one): specify constexpr when we drop gcc-11 support
 // https://url.spec.whatwg.org/#concept-ipv6-serializer
 inline std::string ipv6_serialize(std::span<std::uint16_t, 8> addr) {
     std::stringstream out;

--- a/util/unicode.h
+++ b/util/unicode.h
@@ -34,7 +34,7 @@ constexpr int unicode_utf8_byte_count(std::uint32_t code_point) {
     return 0;
 }
 
-inline std::string unicode_to_utf8(std::uint32_t code_point) {
+constexpr std::string unicode_to_utf8(std::uint32_t code_point) {
     switch (unicode_utf8_byte_count(code_point)) {
         case 1:
             return {static_cast<char>(code_point & 0x7F)};


### PR DESCRIPTION
I finally found that there was a segv hidden in one of the logs when trying to generate the code coverage with gcc 12:
```
bazel-out/k8-fastbuild/testlogs/_coverage/wasm/wasm_test/test/bazel-out/k8-fastbuild/bin/wasm/_objs/wasm/wasm.pic.gcno:version 'B21*', prefer 'B13*'
external/bazel_tools/tools/test/collect_cc_coverage.sh: line 115:    31 Segmentation fault      "${GCOV}" -i $COVERAGE_GCOV_OPTIONS -o "$(dirname ${gcda})" "${gcda}"
```

Seems like Bazel isn't setting GCOV to the version corresponding to the current compiler version in all cases, so I worked around that by setting it to gcov-12 myself.