### PR TITLE
ci: Allow code coverage to fluctuate a bit

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,12 @@
 # https://docs.codecov.com/docs/pull-request-comments#disable-comment
 comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        # Allow coverage to fluctuate a bit. This is mostly to work around gcc
+        # not always reporting e.g. functions' closing braces or lambda variable
+        # declarations as covered, leading to "indirect changes" that really
+        # aren't changes at all.
+        threshold: 1%


### PR DESCRIPTION
This isn't really great, but after we migrated from gcc 10 to gcc 11 for code coverage, gcc has been a bit confused about if e.g. functions' closing braces or even lambda variable declarations are covered when it's literally impossible to not hit them if you call the function.

![lambda declaration not covered](https://user-images.githubusercontent.com/8304462/227775725-c94aa0c3-578a-4116-8740-db6855652d87.png)

![closing brace not covered](https://user-images.githubusercontent.com/8304462/227775737-98b03528-f914-4509-b0b1-248b60abac09.png)
