### PR TITLE
Enable more clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -45,6 +45,7 @@
 # harmful.
 Checks: >
   bugprone-*,
+  cppcoreguidelines-pro-type-cstyle-cast,
   cppcoreguidelines-pro-type-member-init,
   google-*,
   misc-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -45,6 +45,7 @@
 # harmful.
 Checks: >
   bugprone-*,
+  cppcoreguidelines-pro-type-member-init,
   google-*,
   misc-*,
   modernize-*,

--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -174,7 +174,7 @@ void App::set_scale(unsigned scale) {
 
 int App::run() {
     while (window_.isOpen()) {
-        sf::Event event;
+        sf::Event event{};
         while (window_.pollEvent(event)) {
             ImGui::SFML::ProcessEvent(event);
 

--- a/gfx/gfx_example.cpp
+++ b/gfx/gfx_example.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
 
     bool running = true;
     while (running) {
-        sf::Event event;
+        sf::Event event{};
         while (window.pollEvent(event)) {
             switch (event.type) {
                 case sf::Event::Closed:

--- a/img/img_example.cpp
+++ b/img/img_example.cpp
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
 
     bool running = true;
     while (running) {
-        sf::Event event;
+        sf::Event event{};
         while (window.pollEvent(event)) {
             switch (event.type) {
                 case sf::Event::Closed:

--- a/protocol/response.h
+++ b/protocol/response.h
@@ -25,7 +25,7 @@ enum class Error {
 
 struct StatusLine {
     std::string version;
-    int status_code;
+    int status_code{};
     std::string reason;
 
     [[nodiscard]] bool operator==(StatusLine const &) const = default;
@@ -52,7 +52,7 @@ private:
 };
 
 struct Response {
-    Error err;
+    Error err{};
     StatusLine status_line;
     Headers headers;
     std::string body;

--- a/util/uuid.h
+++ b/util/uuid.h
@@ -15,7 +15,7 @@
 
 namespace util {
 inline std::string new_uuid() {
-    std::array<unsigned char, 16> data;
+    std::array<unsigned char, 16> data{};
     std::stringstream uuid_string;
     uuid_string << std::setfill('0');
 


### PR DESCRIPTION
Initializing our things is essentially free and ensures we'll never have any UB from reading uninitialized types.
C casts try a bunch of different combinations of static_cast, const_cast, and reinterpret_cast, and we want 0 const_casts and our reinterpret_casts visible.

https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.html
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.html