### PR TITLE
Add plumbing for, and hook up rendering of text decoration lines

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -155,3 +155,16 @@ h6 {
   margin-top: 2.33em;
   margin-bottom: 2.33em;
 }
+
+/* Phrasing content */
+/* https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3 */
+ins,
+u {
+  text-decoration: underline;
+}
+
+del,
+s,
+strike {
+  text-decoration: line-through;
+}

--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -342,6 +342,8 @@ void Parser::add_declaration(
         expand_font(declarations, value);
     } else if (name == "border-radius") {
         expand_border_radius_values(declarations, value);
+    } else if (name == "text-decoration") {
+        expand_text_decoration_values(declarations, value);
     } else if (is_in_array<border_shorthand_properties>(name)) {
         expand_border(name, declarations, value);
     } else {
@@ -521,6 +523,20 @@ void Parser::expand_border_radius_values(std::map<PropertyId, std::string> &decl
     declarations.insert_or_assign(PropertyId::BorderTopRightRadius, top_right);
     declarations.insert_or_assign(PropertyId::BorderBottomRightRadius, bottom_right);
     declarations.insert_or_assign(PropertyId::BorderBottomLeftRadius, bottom_left);
+}
+
+// https://w3c.github.io/csswg-drafts/css-text-decor/#text-decoration-property
+void Parser::expand_text_decoration_values(std::map<PropertyId, std::string> &declarations, std::string_view value) {
+    Tokenizer tokenizer{value, ' '};
+    // TODO(robinlinden): CSS level 3 text-decorations.
+    if (tokenizer.size() != 1) {
+        spdlog::warn("Unsupported text-decoration value: '{}'", value);
+        return;
+    }
+
+    declarations.insert_or_assign(PropertyId::TextDecorationColor, "currentcolor");
+    declarations.insert_or_assign(PropertyId::TextDecorationLine, tokenizer.get().value());
+    declarations.insert_or_assign(PropertyId::TextDecorationStyle, "solid");
 }
 
 void Parser::expand_edge_values(

--- a/css/parser.h
+++ b/css/parser.h
@@ -49,6 +49,8 @@ private:
     // https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius
     static void expand_border_radius_values(std::map<PropertyId, std::string> &declarations, std::string_view value);
 
+    static void expand_text_decoration_values(std::map<PropertyId, std::string> &declarations, std::string_view value);
+
     void expand_edge_values(
             std::map<PropertyId, std::string> &declarations, std::string property, std::string_view value) const;
 

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -82,9 +82,31 @@ ValueT get_and_erase(
     return value;
 }
 
+void text_decoration_tests() {
+    etest::test("parser: text-decoration, 1 value", [] {
+        auto rules = css::parse("p { text-decoration: underline; }");
+        auto const &p = rules.at(0);
+        expect_eq(p.declarations,
+                std::map<css::PropertyId, std::string>{
+                        {css::PropertyId::TextDecorationColor, "currentcolor"},
+                        {css::PropertyId::TextDecorationLine, "underline"},
+                        {css::PropertyId::TextDecorationStyle, "solid"},
+                });
+    });
+
+    // This will fail once we support CSS Level 3 text-decorations.
+    etest::test("parser: text-decoration, 2 values", [] {
+        auto rules = css::parse("p { text-decoration: underline dotted; }");
+        auto const &p = rules.at(0);
+        expect_eq(p.declarations, std::map<css::PropertyId, std::string>{});
+    });
+}
+
 } // namespace
 
 int main() {
+    text_decoration_tests();
+
     etest::test("parser: simple rule", [] {
         auto rules = css::parse("body { width: 50px; }"sv);
         require(rules.size() == 1);

--- a/css/property_id.cpp
+++ b/css/property_id.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -98,6 +98,9 @@ std::map<std::string_view, PropertyId> const kKnownProperties{
         {"speech-rate"sv, PropertyId::SpeechRate},
         {"stress"sv, PropertyId::Stress},
         {"text-align"sv, PropertyId::TextAlign},
+        {"text-decoration-color"sv, PropertyId::TextDecorationColor},
+        {"text-decoration-line"sv, PropertyId::TextDecorationLine},
+        {"text-decoration-style"sv, PropertyId::TextDecorationStyle},
         {"text-indent"sv, PropertyId::TextIndent},
         {"text-transform"sv, PropertyId::TextTransform},
         {"visibility"sv, PropertyId::Visibility},

--- a/css/property_id.h
+++ b/css/property_id.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -96,6 +96,9 @@ enum class PropertyId {
     SpeechRate,
     Stress,
     TextAlign,
+    TextDecorationColor,
+    TextDecorationLine,
+    TextDecorationStyle,
     TextIndent,
     TextTransform,
     Visibility,

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -258,6 +258,13 @@ std::string_view StyledNode::get_raw_property(css::PropertyId property) const {
     auto it = std::ranges::find_if(
             rbegin(properties), rend(properties), [=](auto const &p) { return p.first == property; });
 
+    // TODO(robinlinden): Having a special case for dom::Text here doesn't feel good.
+    // You can't set properties on text nodes in HTML (even though we do in
+    // tests), so let's grab this from the parent node.
+    if (it == rend(properties) && std::holds_alternative<dom::Text>(node) && parent != nullptr) {
+        return parent->get_raw_property(property);
+    }
+
     if (it == rend(properties) || it->second == "unset") {
         // https://developer.mozilla.org/en-US/docs/Web/CSS/unset
         if (is_inherited(property) && parent != nullptr) {

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -42,6 +42,11 @@ std::map<css::PropertyId, std::string_view> const kInitialValues{
         // https://developer.mozilla.org/en-US/docs/Web/CSS/font-style#formal_definition
         {css::PropertyId::FontStyle, "normal"sv},
 
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration
+        {css::PropertyId::TextDecorationColor, "currentcolor"sv},
+        {css::PropertyId::TextDecorationLine, "none"sv},
+        {css::PropertyId::TextDecorationStyle, "solid"sv},
+
         // https://developer.mozilla.org/en-US/docs/Web/CSS/border-color#formal_definition
         {css::PropertyId::BorderBottomColor, "currentcolor"sv},
         {css::PropertyId::BorderLeftColor, "currentcolor"sv},

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -351,6 +351,38 @@ FontStyle StyledNode::get_font_style_property() const {
     return FontStyle::Normal;
 }
 
+std::vector<TextDecorationLine> StyledNode::get_text_decoration_line_property() const {
+    auto into = [](std::string_view v) -> std::optional<TextDecorationLine> {
+        if (v == "none") {
+            return TextDecorationLine::None;
+        } else if (v == "underline") {
+            return TextDecorationLine::Underline;
+        } else if (v == "overline") {
+            return TextDecorationLine::Overline;
+        } else if (v == "line-through") {
+            return TextDecorationLine::LineThrough;
+        } else if (v == "blink") {
+            return TextDecorationLine::Blink;
+        }
+
+        spdlog::warn("Unhandled text-decoration-line value '{}'", v);
+        return std::nullopt;
+    };
+
+    std::vector<TextDecorationLine> lines;
+
+    auto parts = util::split(get_raw_property(css::PropertyId::TextDecorationLine), " ");
+    for (auto const &part : parts) {
+        if (auto line = into(part)) {
+            lines.push_back(*line);
+        } else {
+            return {};
+        }
+    }
+
+    return lines;
+}
+
 static int const kDefaultFontSize{10};
 // https://w3c.github.io/csswg-drafts/css-fonts-4/#absolute-size-mapping
 constexpr int kMediumFontSize = kDefaultFontSize;

--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -44,6 +44,14 @@ enum class FontStyle {
     Oblique,
 };
 
+enum class TextDecorationLine {
+    None,
+    Underline,
+    Overline,
+    LineThrough,
+    Blink,
+};
+
 struct StyledNode {
     dom::Node const &node;
     std::vector<std::pair<css::PropertyId, std::string>> properties;
@@ -79,6 +87,8 @@ struct StyledNode {
             return get_font_size_property();
         } else if constexpr (T == css::PropertyId::FontStyle) {
             return get_font_style_property();
+        } else if constexpr (T == css::PropertyId::TextDecorationLine) {
+            return get_text_decoration_line_property();
         } else {
             return get_raw_property(T);
         }
@@ -90,6 +100,7 @@ private:
     DisplayValue get_display_property() const;
     FontStyle get_font_style_property() const;
     int get_font_size_property() const;
+    std::vector<TextDecorationLine> get_text_decoration_line_property() const;
 };
 
 [[nodiscard]] inline bool operator==(style::StyledNode const &a, style::StyledNode const &b) noexcept {

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 using namespace std::literals;
+using etest::expect;
 using etest::expect_eq;
 
 namespace {
@@ -295,6 +296,17 @@ int main() {
         expect_property_eq<css::PropertyId::TextDecorationLine>("underline blink", std::vector{Underline, Blink});
 
         expect_property_eq<css::PropertyId::TextDecorationLine>("unhandled!", std::vector<style::TextDecorationLine>{});
+    });
+
+    etest::test("get_property, non-inherited property for a text node", [] {
+        dom::Node dom = dom::Element{"hello"};
+        dom::Node text = dom::Text{"world"};
+        style::StyledNode styled_node{.node = dom, .properties = {{css::PropertyId::TextDecorationLine, "blink"s}}};
+        auto const &child = styled_node.children.emplace_back(style::StyledNode{.node = text, .parent = &styled_node});
+
+        expect(!css::is_inherited(css::PropertyId::TextDecorationLine));
+        expect_eq(child.get_property<css::PropertyId::TextDecorationLine>(),
+                std::vector{style::TextDecorationLine::Blink});
     });
 
     return etest::run_all_tests();

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -285,5 +285,17 @@ int main() {
         expect_property_eq<css::PropertyId::Color>("rgba(1 2)", kErrorColor);
     });
 
+    etest::test("get_property, text-decoration-line", [] {
+        using enum style::TextDecorationLine;
+        expect_property_eq<css::PropertyId::TextDecorationLine>("none", std::vector{None});
+        expect_property_eq<css::PropertyId::TextDecorationLine>("underline", std::vector{Underline});
+        expect_property_eq<css::PropertyId::TextDecorationLine>("overline", std::vector{Overline});
+        expect_property_eq<css::PropertyId::TextDecorationLine>("line-through", std::vector{LineThrough});
+        expect_property_eq<css::PropertyId::TextDecorationLine>("blink", std::vector{Blink});
+        expect_property_eq<css::PropertyId::TextDecorationLine>("underline blink", std::vector{Underline, Blink});
+
+        expect_property_eq<css::PropertyId::TextDecorationLine>("unhandled!", std::vector<style::TextDecorationLine>{});
+    });
+
     return etest::run_all_tests();
 }


### PR DESCRIPTION
After this, we support <ins>underlined</ins> and ~strikethrough~ text.