### PR TITLE
ci: Update Buildifier and codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
         run: lcov --summary bazel-out/_coverage/_coverage_report.dat
       - name: Upload
         run: |
-          wget --output-document=codecov https://github.com/codecov/uploader/releases/download/v0.4.0/codecov-linux
+          wget --output-document=codecov https://github.com/codecov/uploader/releases/download/v0.4.1/codecov-linux
           chmod +x codecov
           ./codecov -f bazel-out/_coverage/_coverage_report.dat
 
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install
         run: |
-          wget --output-document=buildifier https://github.com/bazelbuild/buildtools/releases/download/6.0.1/buildifier-linux-amd64
+          wget --output-document=buildifier https://github.com/bazelbuild/buildtools/releases/download/6.1.0/buildifier-linux-amd64
           sudo chmod +x buildifier
       - name: Check
         run: ./buildifier --lint=warn --warnings=all -mode diff WORKSPACE $(find . -type f -iname "*.BUILD" -or -iname BUILD -or -iname "*.bzl")


### PR DESCRIPTION
https://github.com/bazelbuild/buildtools/releases/tag/6.1.0