### PR TITLE
html: Stop comment tokens from falling through to the end of the parser

### DIFF
--- a/html/parser_states.cpp
+++ b/html/parser_states.cpp
@@ -59,6 +59,11 @@ std::optional<InsertionMode> Initial::process(Actions &a, html2::Token const &to
         return {};
     }
 
+    if (std::holds_alternative<html2::CommentToken>(token)) {
+        // TODO(robinlinden): Insert as last child.
+        return {};
+    }
+
     if (auto const *doctype = std::get_if<html2::DoctypeToken>(&token)) {
         if (doctype->name) {
             a.document().doctype = *doctype->name;
@@ -72,6 +77,11 @@ std::optional<InsertionMode> Initial::process(Actions &a, html2::Token const &to
 
 // https://html.spec.whatwg.org/multipage/parsing.html#the-before-html-insertion-mode
 std::optional<InsertionMode> BeforeHtml::process(Actions &a, html2::Token const &token) {
+    if (std::holds_alternative<html2::CommentToken>(token)) {
+        // TODO(robinlinden): Insert as last child.
+        return {};
+    }
+
     if (is_boring_whitespace(token)) {
         return {};
     }
@@ -96,6 +106,11 @@ std::optional<InsertionMode> BeforeHead::process(Actions &a, html2::Token const 
         return {};
     }
 
+    if (std::holds_alternative<html2::CommentToken>(token)) {
+        // TODO(robinlinden): Insert a comment.
+        return {};
+    }
+
     if (auto const *start = std::get_if<html2::StartTagToken>(&token)) {
         if (start->tag_name == "head") {
             a.insert_element_for(*start);
@@ -112,6 +127,11 @@ std::optional<InsertionMode> InHead::process(Actions &a, html2::Token const &tok
     if (is_boring_whitespace(token)) {
         // TODO(robinlinden): Should be inserting characters, but our last
         // parser didn't do that so it will require rewriting tests.
+        return {};
+    }
+
+    if (std::holds_alternative<html2::CommentToken>(token)) {
+        // TODO(robinlinden): Insert a comment.
         return {};
     }
 

--- a/html/parser_states.cpp
+++ b/html/parser_states.cpp
@@ -151,12 +151,9 @@ std::optional<InsertionMode> InHead::process(Actions &a, html2::Token const &tok
             return {};
         }
 
-        // These branches won't be the same once we've added support for rcdata in the tokenizer.
-        // NOLINTNEXTLINE(bugprone-branch-clone)
         if (name == "title") {
             a.insert_element_for(*start);
-            // TODO(robinlinden): Rcdata instead.
-            a.set_tokenizer_state(html2::State::Rawtext);
+            a.set_tokenizer_state(html2::State::Rcdata);
             a.store_original_insertion_mode(InHead{});
             return Text{};
         }

--- a/html/parser_states.h
+++ b/html/parser_states.h
@@ -48,7 +48,6 @@ struct AfterFrameset;
 struct AfterAfterBody;
 struct AfterAfterFrameset;
 
-// clang-format off
 using InsertionMode = std::variant<Initial,
         BeforeHtml,
         BeforeHead,
@@ -74,8 +73,7 @@ using InsertionMode = std::variant<Initial,
         AfterAfterBody,
         AfterAfterFrameset
 #endif
-    >;
-// clang-format on
+        >;
 
 struct InTable {};
 struct InTableText {};

--- a/html/parser_states_test.cpp
+++ b/html/parser_states_test.cpp
@@ -47,9 +47,20 @@ void initial_tests() {
         res = parse("\t\n\r <!DOCTYPE bad>", {});
         expect_eq(res.document.doctype, "bad");
     });
+
+    etest::test("Initial: comment", [] {
+        auto res = parse("<!-- hello --><!DOCTYPE html>", {});
+        expect_eq(res.document.doctype, "html");
+        expect_eq(res.document.html(), dom::Element{"html", {}, {dom::Element{"head"}}});
+    });
 }
 
 void before_html_tests() {
+    etest::test("BeforeHtml: comment", [] {
+        auto res = parse("<!DOCTYPE html><!-- hello --><html foo='bar'>", {});
+        expect_eq(res.document.html(), dom::Element{"html", {{"foo", "bar"}}, {dom::Element{"head"}}});
+    });
+
     etest::test("BeforeHtml: html tag", [] {
         auto res = parse("<html foo='bar'>", {});
         expect_eq(res.document.html(), dom::Element{"html", {{"foo", "bar"}}, {dom::Element{"head"}}});
@@ -62,6 +73,11 @@ void before_html_tests() {
 }
 
 void before_head_tests() {
+    etest::test("BeforeHead: comment", [] {
+        auto res = parse("<html><!-- comment --><head foo='bar'>", {});
+        expect_eq(res.document.html(), dom::Element{"html", {}, {dom::Element{"head", {{"foo", "bar"}}}}});
+    });
+
     etest::test("BeforeHead: head tag", [] {
         auto res = parse("<head foo='bar'>", {});
         expect_eq(res.document.html(), dom::Element{"html", {}, {dom::Element{"head", {{"foo", "bar"}}}}});
@@ -74,6 +90,11 @@ void before_head_tests() {
 }
 
 void in_head_tests() {
+    etest::test("InHead: comment", [] {
+        auto res = parse("<html><head><!-- comment --><meta>", {});
+        expect_eq(res.document.html(), dom::Element{"html", {}, {dom::Element{"head", {}, {dom::Element{"meta"}}}}});
+    });
+
     etest::test("InHead: base, basefont, bgsound, link", [] {
         auto res = parse("<base> <basefont> <bgsound> <link>", {});
 

--- a/html/parser_states_test.cpp
+++ b/html/parser_states_test.cpp
@@ -111,8 +111,8 @@ void in_head_tests() {
     });
 
     etest::test("InHead: title", [] {
-        auto res = parse("<title><body></title>", {});
-        auto title = dom::Element{"title", {}, {dom::Text{"<body>"}}};
+        auto res = parse("<title><body>&amp;</title>", {});
+        auto title = dom::Element{"title", {}, {dom::Text{"<body>&"}}};
         expect_eq(res.document.html(), dom::Element{"html", {}, {dom::Element{"head", {}, {std::move(title)}}}});
     });
 


### PR DESCRIPTION
Even if we don't yet insert them into the dom, this stops them from
falling through the entirety of the new tree constructor.