### PR TITLE
ci: Fix clang-ubsan job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,6 @@ jobs:
             compiler: clang
             version: 15
             bazel: --config ubsan
-            apt: libclang-rt-15-dev
 
           - name: clang-15
             os: ubuntu-22.04


### PR DESCRIPTION
libclang-rt-15-dev appears to be broken in llvm's repo:

    dpkg: error processing archive /tmp/apt-dpkg-install-PnMfIE/6-libclang-rt-15-dev_1%3a15.0.7~++20230412114143+8dfdcc7b7bf6-1~exp1~20230412114152.114_amd64.deb (--unpack):
    trying to overwrite '/usr/lib/llvm-15/lib/clang/15.0.7/README.txt', which is also in package libclang-common-15-dev 1:15.0.7-0ubuntu0.22.04.1

Seems like libclang-rt-*-dev is no longer needed for linking against ubsan though, so let's drop it.