### PR TITLE
browser/gui: Stop re-rendering the GUI when nothing's happening

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -127,7 +127,6 @@ App::App(std::string browser_title, std::string start_page_hint, bool load_start
     : browser_title_{std::move(browser_title)}, window_{sf::VideoMode(kDefaultResolutionX, kDefaultResolutionY),
                                                         browser_title_},
       url_buf_{std::move(start_page_hint)} {
-    window_.setFramerateLimit(60);
     window_.setMouseCursor(cursor_);
     if (!ImGui::SFML::Init(window_)) {
         spdlog::critical("imgui-sfml initialization failed");

--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -176,6 +176,10 @@ int App::run() {
     while (window_.isOpen()) {
         sf::Event event{};
         while (window_.pollEvent(event)) {
+            // ImGui needs a few iterations to do what it wants to do. This was
+            // pretty much picked at random after I still occasionally got
+            // unexpected results when giving it 2 iterations.
+            process_iterations_ = 5;
             ImGui::SFML::ProcessEvent(event);
 
             switch (event.type) {
@@ -301,6 +305,13 @@ int App::run() {
                     break;
             }
         }
+
+        if (process_iterations_ == 0) {
+            // The sleep duration was picked at random.
+            std::this_thread::sleep_for(std::chrono::milliseconds{5});
+            continue;
+        }
+        process_iterations_ -= 1;
 
         run_overlay();
         run_nav_widget();

--- a/browser/gui/app.h
+++ b/browser/gui/app.h
@@ -66,6 +66,9 @@ private:
 
     unsigned scale_{1};
 
+    // ImGui needs a few iterations to settle.
+    int process_iterations_{10};
+
     util::History<uri::Uri> browse_history_;
 
     void on_navigation_failure(protocol::Error);


### PR DESCRIPTION
I would have liked this to be a bool we'd flip when we get an event in
the SFML event loop, but ImGui needs to run for a few iterations every
time it does things.

This reduces idle CPU usage to 0, "busy" CPU usage by a lot, and makes the GUI a lot smoother on displays that can do more than 60 fps.

Resolves #230 