### PR TITLE
meta: Enable clang-tidy's unchecked-optional-access check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,8 +4,6 @@
 #
 # -bugprone-narrowing-conversions: Very noisy for not much gain.
 #
-# -bugprone-unchecked-optional-access: Lots of false positives.
-#
 # -clang-analyzer-cplusplus.NewDeleteLeaks: Lots of false positives w/
 # -std=c++2b when calling std::make_shared in the JS AST.
 # js/ast_executor_test.cpp:176:5: error: Potential leak of memory pointed to by
@@ -56,7 +54,6 @@ Checks: >
   readability-qualified-auto,
   -bugprone-exception-escape,
   -bugprone-narrowing-conversions,
-  -bugprone-unchecked-optional-access,
   -clang-analyzer-cplusplus.NewDeleteLeaks,
   -clang-analyzer-optin.cplusplus.UninitializedObject,
   -clang-diagnostic-builtin-macro-redefined,

--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -165,6 +165,7 @@ std::optional<std::string> try_parse_font_family(Tokenizer &tokenizer) {
         if (!font_family.empty()) {
             font_family += ' ';
         }
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): False positive.
         font_family += *str;
         tokenizer.next();
     }
@@ -422,6 +423,7 @@ void Parser::expand_border_impl(
 
     // TODO(robinlinden): Duplicate color/style/width shouldn't be
     // tolerated, but we have no way of propagating that info right now.
+    // NOLINTBEGIN(bugprone-unchecked-optional-access): False positives.
     for (auto v = tokenizer.get(); v.has_value(); v = tokenizer.next().get()) {
         switch (guess_type(*v)) {
             case BorderPropertyType::Color:
@@ -435,6 +437,7 @@ void Parser::expand_border_impl(
                 break;
         }
     }
+    // NOLINTEND(bugprone-unchecked-optional-access)
 
     declarations.insert_or_assign(color_id, color.value_or("currentcolor"));
     declarations.insert_or_assign(style_id, style.value_or("none"));
@@ -455,6 +458,7 @@ void Parser::expand_background(std::map<PropertyId, std::string> &declarations, 
 
     Tokenizer tokenizer{value, ' '};
     if (tokenizer.size() == 1) {
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): False positive.
         declarations[PropertyId::BackgroundColor] = tokenizer.get().value();
     }
 }
@@ -464,6 +468,7 @@ void Parser::expand_border_radius_values(std::map<PropertyId, std::string> &decl
     std::string top_left, top_right, bottom_right, bottom_left;
     auto [horizontal, vertical] = util::split_once(value, "/");
     Tokenizer tokenizer(horizontal, ' ');
+    // NOLINTBEGIN(bugprone-unchecked-optional-access): False positives.
     switch (tokenizer.size()) {
         case 1:
             top_left = top_right = bottom_right = bottom_left = tokenizer.get().value();
@@ -524,6 +529,7 @@ void Parser::expand_border_radius_values(std::map<PropertyId, std::string> &decl
             }
         }
     }
+    // NOLINTEND(bugprone-unchecked-optional-access)
 
     declarations.insert_or_assign(PropertyId::BorderTopLeftRadius, top_left);
     declarations.insert_or_assign(PropertyId::BorderTopRightRadius, top_right);
@@ -541,6 +547,7 @@ void Parser::expand_text_decoration_values(std::map<PropertyId, std::string> &de
     }
 
     declarations.insert_or_assign(PropertyId::TextDecorationColor, "currentcolor");
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access): False positive.
     declarations.insert_or_assign(PropertyId::TextDecorationLine, tokenizer.get().value());
     declarations.insert_or_assign(PropertyId::TextDecorationStyle, "solid");
 }
@@ -549,6 +556,7 @@ void Parser::expand_edge_values(
         std::map<PropertyId, std::string> &declarations, std::string property, std::string_view value) const {
     std::string_view top = "", bottom = "", left = "", right = "";
     Tokenizer tokenizer(value, ' ');
+    // NOLINTBEGIN(bugprone-unchecked-optional-access): False positives.
     switch (tokenizer.size()) {
         case 1:
             top = bottom = left = right = tokenizer.get().value();
@@ -571,6 +579,7 @@ void Parser::expand_edge_values(
         default:
             break;
     }
+    // NOLINTEND(bugprone-unchecked-optional-access)
     std::string post_fix{""};
     if (property == "border-style") {
         // border-style is a bit special as we want border-top-style instead of border-style-top-style.
@@ -591,6 +600,7 @@ void Parser::expand_font(std::map<PropertyId, std::string> &declarations, std::s
     Tokenizer tokenizer(value, ' ');
     if (tokenizer.size() == 1) {
         // TODO(mkiael): Handle system properties correctly. Just forward it for now.
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): False positive.
         declarations.insert_or_assign(PropertyId::FontFamily, std::string{tokenizer.get().value()});
         return;
     }

--- a/engine/engine_test.cpp
+++ b/engine/engine_test.cpp
@@ -290,5 +290,15 @@ int main() {
                 == end(e.stylesheet()));
     });
 
+    etest::test("redirect not providing Location header", [] {
+        std::map<std::string, Response> responses;
+        responses["hax://example.com"s] = Response{
+                .err = Error::Ok,
+                .status_line = {.status_code = 301},
+        };
+        engine::Engine e{std::make_unique<FakeProtocolHandler>(std::move(responses))};
+        expect_eq(e.navigate(uri::Uri::parse("hax://example.com")), protocol::Error::InvalidResponse);
+    });
+
     return etest::run_all_tests();
 }

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -1596,6 +1596,10 @@ void Tokenizer::run() {
                 }
             }
 
+            // Only reachable via State::BeforeDoctypeName, and every branch
+            // there sets current_token_ to DoctypeToken and initalizes
+            // DoctypeToken::name to something not std::nullopt.
+            // NOLINTBEGIN(bugprone-unchecked-optional-access)
             case State::DoctypeName: {
                 auto c = consume_next_input_character();
                 if (!c) {
@@ -1630,6 +1634,7 @@ void Tokenizer::run() {
                         std::get<DoctypeToken>(current_token_).name->append(1, *c);
                         continue;
                 }
+                // NOLINTEND(bugprone-unchecked-optional-access)
             }
 
             case State::AfterDoctypeName: {
@@ -1751,6 +1756,10 @@ void Tokenizer::run() {
                 }
             }
 
+            // Reachable via State::AfterDoctypePublicKeyword and
+            // State::BeforeDoctypePublicIdentifier, both of which set
+            // DoctypeToken::public_identifier to an empty string.
+            // NOLINTBEGIN(bugprone-unchecked-optional-access)
             case State::DoctypePublicIdentifierDoubleQuoted: {
                 auto c = consume_next_input_character();
                 if (!c) {
@@ -1780,7 +1789,12 @@ void Tokenizer::run() {
                         continue;
                 }
             }
+            // NOLINTEND(bugprone-unchecked-optional-access)
 
+            // Reachable via State::AfterDoctypePublicKeyword and
+            // State::BeforeDoctypePublicIdentifier, both of which set
+            // DoctypeToken::public_identifier to an empty string.
+            // NOLINTBEGIN(bugprone-unchecked-optional-access)
             case State::DoctypePublicIdentifierSingleQuoted: {
                 auto c = consume_next_input_character();
                 if (!c) {
@@ -1809,6 +1823,7 @@ void Tokenizer::run() {
                         *std::get<DoctypeToken>(current_token_).public_identifier += *c;
                         continue;
                 }
+                // NOLINTEND(bugprone-unchecked-optional-access)
             }
 
             case State::AfterDoctypePublicIdentifier: {
@@ -1965,6 +1980,12 @@ void Tokenizer::run() {
                 }
             }
 
+            // Reachable via State::AfterDoctypePublicIdentifier,
+            // State::BetweenDoctypePublicAndSystemIdentifiers,
+            // State::AfterDoctypeSystemKeyword, and
+            // State::BeforeDoctypeSystemIdentifier, all of which set
+            // DoctypeToken::system_identifier to an empty string.
+            // NOLINTBEGIN(bugprone-unchecked-optional-access)
             case State::DoctypeSystemIdentifierDoubleQuoted: {
                 auto c = consume_next_input_character();
                 if (!c) {
@@ -1994,7 +2015,14 @@ void Tokenizer::run() {
                         continue;
                 }
             }
+            // NOLINTEND(bugprone-unchecked-optional-access)
 
+            // Reachable via State::AfterDoctypePublicIdentifier,
+            // State::BetweenDoctypePublicAndSystemIdentifiers,
+            // State::AfterDoctypeSystemKeyword, and
+            // State::BeforeDoctypeSystemIdentifier, all of which set
+            // DoctypeToken::system_identifier to an empty string.
+            // NOLINTBEGIN(bugprone-unchecked-optional-access)
             case State::DoctypeSystemIdentifierSingleQuoted: {
                 auto c = consume_next_input_character();
                 if (!c) {
@@ -2023,6 +2051,7 @@ void Tokenizer::run() {
                         *std::get<DoctypeToken>(current_token_).system_identifier += *c;
                         continue;
                 }
+                // NOLINTEND(bugprone-unchecked-optional-access)
             }
 
             case State::AfterDoctypeSystemIdentifier: {

--- a/js/ast_executor.h
+++ b/js/ast_executor.h
@@ -113,6 +113,7 @@ public:
         for (auto const &statement : v.body) {
             execute(statement);
             if (returning) {
+                // NOLINTNEXTLINE(bugprone-unchecked-optional-access): False positive.
                 return *std::exchange(returning, std::nullopt);
             }
         }

--- a/util/generator.h
+++ b/util/generator.h
@@ -61,7 +61,8 @@ public:
     bool has_next() const { return !handle_.done(); }
     T next() {
         assert(has_next());
-        auto v = std::move(*handle_.promise().maybe_value);
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): Usage error, will crash, this is fine.
+        auto v = std::move(handle_.promise().maybe_value.value());
         handle_.resume();
         return v;
     }
@@ -81,6 +82,7 @@ private:
             return *this;
         }
 
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): Usage error, will crash, this is fine.
         T &operator*() const { return handle.promise().maybe_value.value(); }
         T *operator->() const { return &**this; }
     };


### PR DESCRIPTION
A bunch of false positives in //css where the code could be rewritten to get rid of them, but the plan is to nuke that file altogether once //css2 is more complete, but other than that I think most warnings here were pretty reasonable.

Calling Generator::next() when the generator is done was updated to crash instead of doing whatever UB would happen to do at the time.