### PR TITLE
ci: Update to clang-tidy-15, fix leftover unchecked optional access warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,13 +181,17 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get update && sudo apt-get install --no-install-recommends clang-tidy-14
-      - run: echo "CC=clang-14" >>$GITHUB_ENV && echo "CXX=clang++-14" >>$GITHUB_ENV
+      - name: Set up the llvm repository
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
+      - run: sudo apt-get update && sudo apt-get install --no-install-recommends clang-tidy-15
+      - run: echo "CC=clang-15" >>$GITHUB_ENV && echo "CXX=clang++-15" >>$GITHUB_ENV
       # Make sure all generated files are around so clang-tidy doesn't get
       # confused by missing headers.
       - run: bazel build `bazel query 'kind("genrule", "...")'`
       - run: bazel run refresh_compile_commands
-      - run: run-clang-tidy-14 -quiet `find . -name "*.cpp"`
+      - run: run-clang-tidy-15 -quiet `find . -name "*.cpp"`
 
   buildifier:
     runs-on: ubuntu-22.04

--- a/gfx/gfx_example.cpp
+++ b/gfx/gfx_example.cpp
@@ -14,6 +14,8 @@
 
 using namespace std::literals;
 
+constexpr auto kHotPink = gfx::Color::from_rgb(0xff'69'b4);
+
 int main(int argc, char **argv) {
     sf::RenderWindow window{sf::VideoMode{800, 600}, "gfx"};
     window.setVerticalSyncEnabled(true);
@@ -75,7 +77,7 @@ int main(int argc, char **argv) {
                 {24},
                 gfx::FontStyle::Italic | gfx::FontStyle::Bold | gfx::FontStyle::Underlined
                         | gfx::FontStyle::Strikethrough,
-                gfx::Color::from_css_name("hotpink").value());
+                kHotPink);
 
         window.display();
     }

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -935,6 +935,8 @@ void Tokenizer::run() {
                 if (c == '/') {
                     temporary_buffer_ = "";
                     state_ = State::ScriptDataDoubleEscapeEnd;
+                    // False-positive when using clang-tidy-15.
+                    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
                     emit(CharacterToken{*c});
                     continue;
                 }

--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -1564,8 +1564,7 @@ void Tokenizer::run() {
                 }
 
                 if (util::is_upper_alpha(*c)) {
-                    current_token_ = DoctypeToken{.name = std::string{}};
-                    std::get<DoctypeToken>(current_token_).name->append(1, util::lowercased(*c));
+                    current_token_ = DoctypeToken{.name = std::string{util::lowercased(*c)}};
                     state_ = State::DoctypeName;
                     continue;
                 }
@@ -1578,8 +1577,7 @@ void Tokenizer::run() {
                         continue;
                     case '\0':
                         emit(ParseError::UnexpectedNullCharacter);
-                        current_token_ = DoctypeToken{.name = std::string{}};
-                        *std::get<DoctypeToken>(current_token_).name += kReplacementCharacter;
+                        current_token_ = DoctypeToken{.name = std::string{kReplacementCharacter}};
                         state_ = State::DoctypeName;
                         continue;
                     case '>':
@@ -1589,8 +1587,7 @@ void Tokenizer::run() {
                         emit(std::move(current_token_));
                         continue;
                     default:
-                        current_token_ = DoctypeToken{.name = std::string{}};
-                        std::get<DoctypeToken>(current_token_).name->append(1, *c);
+                        current_token_ = DoctypeToken{.name = std::string{*c}};
                         state_ = State::DoctypeName;
                         continue;
                 }


### PR DESCRIPTION
clang-tidy-15 is needed for the bugprone-unchecked-optional-access check.

This also fixes a few warnings I missed in my last PR. I had them fixed locally and dropped them because I thought clang-tidy could work it out, and it passed CI, so... whoops.