### PR TITLE
ci: Don't print progress when downloading the codecov uploader

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,7 +208,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - run: npm install --global prettier@2.8.7
+      - run: npm install --global prettier@2.8.8
       # Prettier thinks our fragment shaders are JS-something and complains
       # about syntax errors.
       - run: npx prettier --ignore-path .gitignore --write . '!**/*.frag'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,7 @@ jobs:
         run: lcov --summary bazel-out/_coverage/_coverage_report.dat
       - name: Upload
         run: |
-          wget --output-document=codecov https://github.com/codecov/uploader/releases/download/v0.5.0/codecov-linux
+          wget --no-verbose --output-document=codecov https://github.com/codecov/uploader/releases/download/v0.5.0/codecov-linux
           chmod +x codecov
           ./codecov -f bazel-out/_coverage/_coverage_report.dat
 


### PR DESCRIPTION
Having to scroll past 850 lines of wget progress before I can check why
an upload failed isn't nice.