### PR TITLE
ci: Decrease the job timeout from 6 hours to 30 minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ jobs:
   linux-ci:
     name: linux-${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -100,6 +101,7 @@ jobs:
 
   linux-gcc-12-coverage:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:
@@ -130,6 +132,7 @@ jobs:
 
   windows-msvc:
     runs-on: windows-2022
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash
@@ -151,6 +154,7 @@ jobs:
 
   windows-clang-cl:
     runs-on: windows-2022
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash
@@ -169,6 +173,7 @@ jobs:
 
   clang-format:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt-get update && sudo apt-get install --no-install-recommends clang-format-14
@@ -179,6 +184,7 @@ jobs:
 
   clang-tidy:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Set up the llvm repository
@@ -195,6 +201,7 @@ jobs:
 
   buildifier:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Install
@@ -206,6 +213,7 @@ jobs:
 
   prettier:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - run: npm install --global prettier@2.8.8
@@ -216,6 +224,7 @@ jobs:
 
   shfmt:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - run: pip install shfmt-py==3.4.3.1
@@ -224,12 +233,14 @@ jobs:
 
   link-liveness:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - run: grep --recursive --no-filename --only-matching --exclude=WORKSPACE --exclude=*test.cpp --exclude=ci.yaml 'https://[^)(}{",# ]*' | grep -v '^https://$' | sort | uniq | xargs wget --spider
 
   gitlint:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The longest time a job has taken so far was 18 minutes and 55 seconds, and that was clang-tidy. Let's kill things that hang after 30 minutes instead of 6 hours. We could definitely have a lower timeout on some of these things, but micromanaging timeouts doesn't seem worth the effort to get notified a few minutes earlier.

See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes