### PR TITLE
layout: Add API to get the text a layout box is responsible for

### DIFF
--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -178,8 +178,8 @@ void calculate_position(LayoutBox &box, geom::Rect const &parent) {
 
 void calculate_height(LayoutBox &box, int const font_size, int const root_font_size) {
     assert(box.node != nullptr);
-    if (auto const *text = std::get_if<dom::Text>(&box.node->node)) {
-        int lines = static_cast<int>(std::ranges::count(text->text, '\n')) + 1;
+    if (auto text = box.text()) {
+        int lines = static_cast<int>(std::ranges::count(*text, '\n')) + 1;
         box.dimensions.content.height = lines * font_size;
     }
 
@@ -255,9 +255,9 @@ void layout(LayoutBox &box, geom::Rect const &bounds, int const root_font_size) 
             calculate_padding(box, font_size, root_font_size);
             calculate_border(box, font_size, root_font_size);
 
-            if (auto const *text_node = std::get_if<dom::Text>(&box.node->node)) {
+            if (auto text = box.text()) {
                 // TODO(robinlinden): Measure the text for real.
-                box.dimensions.content.width = static_cast<int>(text_node->text.size()) * font_size / 2;
+                box.dimensions.content.width = static_cast<int>(text->size()) * font_size / 2;
             }
 
             if (box.node->parent) {
@@ -368,6 +368,18 @@ int get_root_font_size(style::StyledNode const &node) {
 }
 
 } // namespace
+
+std::optional<std::string_view> LayoutBox::text() const {
+    if (node == nullptr) {
+        return std::nullopt;
+    }
+
+    if (auto const *text = std::get_if<dom::Text>(&node->node)) {
+        return text->text;
+    }
+
+    return std::nullopt;
+}
 
 std::pair<int, int> LayoutBox::get_border_radius_property(css::PropertyId id) const {
     auto raw = node->get_raw_property(id);

--- a/layout/layout.h
+++ b/layout/layout.h
@@ -34,6 +34,8 @@ struct LayoutBox {
     std::vector<LayoutBox> children;
     [[nodiscard]] bool operator==(LayoutBox const &) const = default;
 
+    std::optional<std::string_view> text() const;
+
     template<css::PropertyId T>
     auto get_property() const {
         // Calling get_property on an anonymous block (the only type that

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -1190,5 +1190,19 @@ int main() {
         expect_eq(layout.children.at(0).dimensions.border_box().width, 32);
     });
 
+    etest::test("layout box text accessor", [] {
+        dom::Node dom = dom::Text{"hello"s};
+        style::StyledNode style{.node = dom};
+        layout::LayoutBox layout{.node = &style};
+
+        expect_eq(layout.text(), "hello");
+
+        dom = dom::Element{.name = "asdf"};
+        expect_eq(layout.text(), std::nullopt);
+
+        layout.node = nullptr;
+        expect_eq(layout.text(), std::nullopt);
+    });
+
     return etest::run_all_tests();
 }

--- a/render/BUILD
+++ b/render/BUILD
@@ -9,7 +9,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//css",
-        "//dom",
         "//gfx",
         "//layout",
         "//util:from_chars",

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -6,7 +6,6 @@
 #include "render/render.h"
 
 #include "css/property_id.h"
-#include "dom/dom.h"
 #include "gfx/color.h"
 #include "util/from_chars.h"
 #include "util/string.h"
@@ -28,10 +27,6 @@ namespace {
 
 bool has_any_border(geom::EdgeSize const &border) {
     return border != geom::EdgeSize{};
-}
-
-dom::Text const *try_get_text(layout::LayoutBox const &layout) {
-    return std::get_if<dom::Text>(&layout.node->node);
 }
 
 constexpr bool is_fully_transparent(gfx::Color const &c) {
@@ -69,7 +64,7 @@ gfx::FontStyle to_gfx(std::vector<style::TextDecorationLine> const &decorations)
     return style;
 }
 
-void render_text(gfx::ICanvas &painter, layout::LayoutBox const &layout, dom::Text const &text) {
+void render_text(gfx::ICanvas &painter, layout::LayoutBox const &layout, std::string_view text) {
     auto font_families = layout.get_property<css::PropertyId::FontFamily>();
     auto fonts = [&font_families] {
         std::vector<gfx::Font> fs;
@@ -81,7 +76,7 @@ void render_text(gfx::ICanvas &painter, layout::LayoutBox const &layout, dom::Te
     auto color = layout.get_property<css::PropertyId::Color>();
     auto text_decoration_line = to_gfx(layout.get_property<css::PropertyId::TextDecorationLine>());
     style |= text_decoration_line;
-    painter.draw_text(layout.dimensions.content.position(), text.text, fonts, font_size, style, color);
+    painter.draw_text(layout.dimensions.content.position(), text, fonts, font_size, style, color);
 }
 
 void render_element(gfx::ICanvas &painter, layout::LayoutBox const &layout) {
@@ -116,7 +111,7 @@ void render_element(gfx::ICanvas &painter, layout::LayoutBox const &layout) {
 }
 
 void do_render(gfx::ICanvas &painter, layout::LayoutBox const &layout) {
-    if (auto const *text = try_get_text(layout)) {
+    if (auto text = layout.text()) {
         render_text(painter, layout, *text);
     } else {
         render_element(painter, layout);


### PR DESCRIPTION
This is to enable things like whitespace collapsing, pre-formatting, text-transforms, and text wrapping.