### PR TITLE
doc: Fix broken CSS spec links

### DIFF
--- a/css/media_query.h
+++ b/css/media_query.h
@@ -44,7 +44,7 @@ public:
     Query query{};
     [[nodiscard]] bool operator==(MediaQuery const &) const = default;
 
-    // https://w3c.github.io/csswg-drafts/mediaqueries/#mq-syntax
+    // https://drafts.csswg.org/mediaqueries/#mq-syntax
     static constexpr std::optional<MediaQuery> parse(std::string_view s) {
         // We only handle media-in-parens right now.
         if (!(s.starts_with('(') && s.ends_with(')'))) {

--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -537,7 +537,7 @@ void Parser::expand_border_radius_values(std::map<PropertyId, std::string> &decl
     declarations.insert_or_assign(PropertyId::BorderBottomLeftRadius, bottom_left);
 }
 
-// https://w3c.github.io/csswg-drafts/css-text-decor/#text-decoration-property
+// https://drafts.csswg.org/css-text-decor/#text-decoration-property
 void Parser::expand_text_decoration_values(std::map<PropertyId, std::string> &declarations, std::string_view value) {
     Tokenizer tokenizer{value, ' '};
     // TODO(robinlinden): CSS level 3 text-decorations.

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -210,7 +210,7 @@ void calculate_padding(LayoutBox &box, int const font_size, int const root_font_
     box.dimensions.padding.bottom = to_px(padding_bottom, font_size, root_font_size);
 }
 
-// https://w3c.github.io/csswg-drafts/css-backgrounds/#the-border-width
+// https://drafts.csswg.org/css-backgrounds/#the-border-width
 std::map<std::string_view, int> const kBorderWidthKeywords{
         {"thin", 3},
         {"medium", 5},

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -1035,7 +1035,7 @@ int main() {
         expect(medium_layout_width > 0);
 
         // font-size: xxx-large should be 3x font-size: medium.
-        // https://w3c.github.io/csswg-drafts/css-fonts-4/#absolute-size-mapping
+        // https://drafts.csswg.org/css-fonts-4/#absolute-size-mapping
         expect_eq(medium_layout_width * 3, xxxlarge_layout_width);
     });
 

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -396,7 +396,7 @@ std::vector<TextDecorationLine> StyledNode::get_text_decoration_line_property() 
 }
 
 static int const kDefaultFontSize{10};
-// https://w3c.github.io/csswg-drafts/css-fonts-4/#absolute-size-mapping
+// https://drafts.csswg.org/css-fonts-4/#absolute-size-mapping
 constexpr int kMediumFontSize = kDefaultFontSize;
 std::map<std::string_view, float> const kFontSizeAbsoluteSizeKeywords{
         {"xx-small", 3 / 5.f},


### PR DESCRIPTION
See: https://github.com/w3c/csswg-drafts/issues/8798