### PR TITLE
engine: Improve Content-Encoding handling

### DIFF
--- a/archive/BUILD
+++ b/archive/BUILD
@@ -1,9 +1,14 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
     name = "archive",
-    srcs = glob(["*.cpp"]),
+    srcs = glob(
+        include = ["*.cpp"],
+        exclude = [
+            "*_test.cpp",
+        ],
+    ),
     hdrs = glob(["*.h"]),
     copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
@@ -12,3 +17,14 @@ cc_library(
         "@zlib",
     ],
 )
+
+[cc_test(
+    name = src[:-4],
+    size = "small",
+    srcs = [src],
+    copts = HASTUR_COPTS,
+    deps = [
+        ":archive",
+        "//etest",
+    ],
+) for src in glob(["*_test.cpp"])]

--- a/archive/zlib.h
+++ b/archive/zlib.h
@@ -17,7 +17,13 @@ struct ZlibError {
     int code{};
 };
 
-tl::expected<std::string, ZlibError> zlib_decode(std::string_view);
+enum class ZlibMode {
+    Zlib,
+    Gzip,
+    GzipAndZlib,
+};
+
+tl::expected<std::string, ZlibError> zlib_decode(std::string_view, ZlibMode);
 
 } // namespace archive
 

--- a/archive/zlib_test.cpp
+++ b/archive/zlib_test.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "archive/zlib.h"
+
+#include "etest/etest.h"
+
+#include <string_view>
+
+using namespace archive;
+using namespace etest;
+using namespace std::literals;
+
+namespace {
+
+constexpr auto expected = "p { font-size: 123em; }\n"sv;
+
+// p { font-size: 123em; }, gzipped.
+constexpr auto gzipped_css =
+        "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\x2b\x50\xa8\x56\x48\xcb\xcf\x2b\xd1\x2d\xce\xac\x4a\xb5\x52\x30\x34\x32\x4e\xcd\xb5\x56\xa8\xe5\x02\x00\x0c\x97\x72\x35\x18\x00\x00\x00"sv;
+
+// p { font-size: 123em; }, zlibbed.
+constexpr auto zlibbed_css =
+        "\x78\x5e\x2b\x50\xa8\x56\x48\xcb\xcf\x2b\xd1\x2d\xce\xac\x4a\xb5\x52\x30\x34\x32\x4e\xcd\xb5\x56\xa8\xe5\x02\x00\x63\xc3\x07\x6f"sv;
+
+} // namespace
+
+int main() {
+    etest::test("zlib", [] {
+        expect_eq(zlib_decode(zlibbed_css, ZlibMode::Zlib), expected);
+        expect(!zlib_decode(gzipped_css, ZlibMode::Zlib).has_value());
+    });
+
+    etest::test("gzip", [] {
+        expect(!zlib_decode(zlibbed_css, ZlibMode::Gzip), std::nullopt);
+        expect_eq(zlib_decode(gzipped_css, ZlibMode::Gzip), expected);
+    });
+
+    etest::test("zlib and gzip", [] {
+        expect_eq(zlib_decode(zlibbed_css, ZlibMode::GzipAndZlib), expected);
+        expect_eq(zlib_decode(gzipped_css, ZlibMode::GzipAndZlib), expected);
+    });
+
+    return etest::run_all_tests();
+}

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -111,8 +111,9 @@ void Engine::on_navigation_success() {
 
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding#directives
             auto encoding = style_data.headers.get("Content-Encoding");
-            if (encoding == "gzip" || encoding == "x-gzip") {
-                auto decoded = archive::zlib_decode(style_data.body, archive::ZlibMode::Gzip);
+            if (encoding == "gzip" || encoding == "x-gzip" || encoding == "deflate") {
+                auto zlib_mode = encoding == "deflate" ? archive::ZlibMode::Zlib : archive::ZlibMode::Gzip;
+                auto decoded = archive::zlib_decode(style_data.body, zlib_mode);
                 if (!decoded) {
                     auto const &err = decoded.error();
                     spdlog::error("Failed {}-decoding of '{}': '{}: {}'",

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -112,7 +112,7 @@ void Engine::on_navigation_success() {
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding#directives
             auto encoding = style_data.headers.get("Content-Encoding");
             if (encoding == "gzip" || encoding == "x-gzip") {
-                auto decoded = archive::zlib_decode(style_data.body);
+                auto decoded = archive::zlib_decode(style_data.body, archive::ZlibMode::GzipAndZlib);
                 if (!decoded) {
                     auto const &err = decoded.error();
                     spdlog::error("Failed {}-decoding of '{}': '{}: {}'",

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -112,7 +112,7 @@ void Engine::on_navigation_success() {
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding#directives
             auto encoding = style_data.headers.get("Content-Encoding");
             if (encoding == "gzip" || encoding == "x-gzip") {
-                auto decoded = archive::zlib_decode(style_data.body, archive::ZlibMode::GzipAndZlib);
+                auto decoded = archive::zlib_decode(style_data.body, archive::ZlibMode::Gzip);
                 if (!decoded) {
                     auto const &err = decoded.error();
                     spdlog::error("Failed {}-decoding of '{}': '{}: {}'",


### PR DESCRIPTION
* Error when served zlib as if it were gzip
* Handle `Content-Encoding: deflate`