### PR TITLE
html2: Fix U+1FFF taking U+1FFFE's place as a noncharacter

### DIFF
--- a/html2/tokenizer.cpp
+++ b/html2/tokenizer.cpp
@@ -42,58 +42,6 @@ constexpr bool is_ascii_whitespace(int code_point) {
     }
 }
 
-// https://infra.spec.whatwg.org/#surrogate
-constexpr bool is_unicode_surrogate(int code_point) {
-    return code_point >= 0xD800 && code_point <= 0xDFFF;
-}
-
-// https://infra.spec.whatwg.org/#noncharacter
-constexpr bool is_unicode_noncharacter(int code_point) {
-    if (code_point >= 0xFDD0 && code_point <= 0xFDEF) {
-        return true;
-    }
-
-    switch (code_point) {
-        case 0xFFFE:
-        case 0xFFFF:
-        case 0x1FFF:
-        case 0x1FFFF:
-        case 0x2FFFE:
-        case 0x2FFFF:
-        case 0x3FFFE:
-        case 0x3FFFF:
-        case 0x4FFFE:
-        case 0x4FFFF:
-        case 0x5FFFE:
-        case 0x5FFFF:
-        case 0x6FFFE:
-        case 0x6FFFF:
-        case 0x7FFFE:
-        case 0x7FFFF:
-        case 0x8FFFE:
-        case 0x8FFFF:
-        case 0x9FFFE:
-        case 0x9FFFF:
-        case 0xAFFFE:
-        case 0xAFFFF:
-        case 0xBFFFE:
-        case 0xBFFFF:
-        case 0xCFFFE:
-        case 0xCFFFF:
-        case 0xDFFFE:
-        case 0xDFFFF:
-        case 0xEFFFE:
-        case 0xEFFFF:
-        case 0xFFFFE:
-        case 0xFFFFF:
-        case 0x10FFFE:
-        case 0x10FFFF:
-            return true;
-        default:
-            return false;
-    }
-}
-
 std::string const kReplacementCharacter = util::unicode_to_utf8(0xFFFD);
 
 } // namespace
@@ -2368,12 +2316,12 @@ void Tokenizer::run() {
                     character_reference_code_ = 0xFFFD;
                 }
 
-                if (is_unicode_surrogate(character_reference_code_)) {
+                if (util::is_unicode_surrogate(character_reference_code_)) {
                     emit(ParseError::SurrogateCharacterReference);
                     character_reference_code_ = 0xFFFD;
                 }
 
-                if (is_unicode_noncharacter(character_reference_code_)) {
+                if (util::is_unicode_noncharacter(character_reference_code_)) {
                     emit(ParseError::NoncharacterCharacterReference);
                 }
 

--- a/util/unicode.h
+++ b/util/unicode.h
@@ -62,12 +62,12 @@ constexpr std::string unicode_to_utf8(std::uint32_t code_point) {
 }
 
 // https://infra.spec.whatwg.org/#surrogate
-constexpr bool is_unicode_surrogate(int code_point) {
+constexpr bool is_unicode_surrogate(std::uint32_t code_point) {
     return code_point >= 0xD800 && code_point <= 0xDFFF;
 }
 
 // https://infra.spec.whatwg.org/#noncharacter
-constexpr bool is_unicode_noncharacter(int code_point) {
+constexpr bool is_unicode_noncharacter(std::uint32_t code_point) {
     if (code_point >= 0xFDD0 && code_point <= 0xFDEF) {
         return true;
     }

--- a/util/unicode.h
+++ b/util/unicode.h
@@ -75,7 +75,7 @@ constexpr bool is_unicode_noncharacter(int code_point) {
     switch (code_point) {
         case 0xFFFE:
         case 0xFFFF:
-        case 0x1FFF:
+        case 0x1FFFE:
         case 0x1FFFF:
         case 0x2FFFE:
         case 0x2FFFF:

--- a/util/unicode.h
+++ b/util/unicode.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -58,6 +58,58 @@ constexpr std::string unicode_to_utf8(std::uint32_t code_point) {
             };
         default:
             return std::string{};
+    }
+}
+
+// https://infra.spec.whatwg.org/#surrogate
+constexpr bool is_unicode_surrogate(int code_point) {
+    return code_point >= 0xD800 && code_point <= 0xDFFF;
+}
+
+// https://infra.spec.whatwg.org/#noncharacter
+constexpr bool is_unicode_noncharacter(int code_point) {
+    if (code_point >= 0xFDD0 && code_point <= 0xFDEF) {
+        return true;
+    }
+
+    switch (code_point) {
+        case 0xFFFE:
+        case 0xFFFF:
+        case 0x1FFF:
+        case 0x1FFFF:
+        case 0x2FFFE:
+        case 0x2FFFF:
+        case 0x3FFFE:
+        case 0x3FFFF:
+        case 0x4FFFE:
+        case 0x4FFFF:
+        case 0x5FFFE:
+        case 0x5FFFF:
+        case 0x6FFFE:
+        case 0x6FFFF:
+        case 0x7FFFE:
+        case 0x7FFFF:
+        case 0x8FFFE:
+        case 0x8FFFF:
+        case 0x9FFFE:
+        case 0x9FFFF:
+        case 0xAFFFE:
+        case 0xAFFFF:
+        case 0xBFFFE:
+        case 0xBFFFF:
+        case 0xCFFFE:
+        case 0xCFFFF:
+        case 0xDFFFE:
+        case 0xDFFFF:
+        case 0xEFFFE:
+        case 0xEFFFF:
+        case 0xFFFFE:
+        case 0xFFFFF:
+        case 0x10FFFE:
+        case 0x10FFFF:
+            return true;
+        default:
+            return false;
     }
 }
 

--- a/util/unicode_test.cpp
+++ b/util/unicode_test.cpp
@@ -6,6 +6,7 @@
 
 #include "etest/etest.h"
 
+#include <cstdint>
 #include <string_view>
 
 using namespace std::literals;
@@ -61,7 +62,7 @@ int main() {
     etest::test("is_unicode_noncharacter", [] {
         expect(!is_unicode_noncharacter(0xFDD0 - 1));
 
-        for (int i = 0xFDD0; i <= 0xFDEF; ++i) {
+        for (std::uint32_t i = 0xFDD0; i <= 0xFDEF; ++i) {
             expect(is_unicode_noncharacter(i));
         }
 
@@ -69,7 +70,7 @@ int main() {
         expect(!is_unicode_noncharacter(0xFFFE - 1));
 
         // Every 0x10000 pair of values ending in FFFE and FFFF are noncharacters.
-        for (int i = 0xFFFE; i <= 0x10FFFE; i += 0x10000) {
+        for (std::uint32_t i = 0xFFFE; i <= 0x10FFFE; i += 0x10000) {
             expect(!is_unicode_noncharacter(i - 1));
             expect(is_unicode_noncharacter(i));
             expect(is_unicode_noncharacter(i + 1));

--- a/util/unicode_test.cpp
+++ b/util/unicode_test.cpp
@@ -71,8 +71,7 @@ int main() {
         // Every 0x10000 pair of values ending in FFFE and FFFF are noncharacters.
         for (int i = 0xFFFE; i <= 0x10FFFE; i += 0x10000) {
             expect(!is_unicode_noncharacter(i - 1));
-            // TODO(robinlinden): Fix bug.
-            // expect(is_unicode_noncharacter(i));
+            expect(is_unicode_noncharacter(i));
             expect(is_unicode_noncharacter(i + 1));
             expect(!is_unicode_noncharacter(i + 2));
         }


### PR DESCRIPTION
I also yoinked these helpers into util/unicode so I could add some tests without going via the html tokenizer.