### PR TITLE
ci: Downgrade Windows runners to work around broken MSVC setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,8 +149,10 @@ jobs:
           echo "<html><body><h1>Example</h1><p>This is an example page.</p></body></html>" >example.html
           ./bazelisk run browser:tui file://$(pwd)/example.html ${{ matrix.bazel }}
 
+  # Windows jobs are on 2019 instead of 2022 until
+  # https://github.com/actions/runner-images/issues/7662 is resolved.
   windows-msvc:
-    runs-on: windows-2022
+    runs-on: windows-2019
     timeout-minutes: 30
     defaults:
       run:
@@ -172,7 +174,7 @@ jobs:
       #   run: bazel run browser:tui -c dbg
 
   windows-clang-cl:
-    runs-on: windows-2022
+    runs-on: windows-2019
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
Bazel no longer seems to work in windows-2022 runners as of version 20230517.1, so we'll use windows-2019 as a workaround for now.