### PR TITLE
etest: Support compiling etest w/ -fno-exceptions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,6 +149,7 @@ jobs:
       - run: apt-get update && apt-get install -y --no-install-recommends libgl-dev xxd
       - run: wget --no-verbose --output-document=bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-amd64 && chmod +x bazelisk
       - run: ./bazelisk test ...
+      - run: ./bazelisk test etest/... --copt=-fno-exceptions
       - name: Run tui
         run: |
           echo "<html><body><h1>Example</h1><p>This is an example page.</p></body></html>" >example.html


### PR DESCRIPTION
Running etest without exception support will result in less information for hard test requirements right now.