### PR TITLE
build: Fix analysis cache being discarded too often

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,12 +2,11 @@
 # =========================================================
 
 build --enable_platform_specific_config
+build --test_env=HASTUR_ICU_DATA=external/icu-data/
 coverage --combined_report=lcov
 test --test_output=errors
 test --test_summary=terse
 test --test_verbose_timeout_warnings
-# Set ICU data directory for tests
-test --test_env=HASTUR_ICU_DATA=external/icu-data/
 
 # Bazel deprecations
 # =========================================================


### PR DESCRIPTION
`test_env` only affects the `bazel test` command anyway, so let's include it everywhere to keep the analysis cache stuff happy.

See: https://bazel.build/reference/command-line-reference#flag--test_env

After this, the `INFO: Build option --test_env has changed, discarding analysis cache.` prints you get when and after you use `bazel test` to build things.