### PR TITLE
util/string: Fix ipv6_serialize requiring mutable input

### DIFF
--- a/util/string.h
+++ b/util/string.h
@@ -152,7 +152,7 @@ constexpr std::string ipv4_serialize(std::uint32_t addr) {
 }
 
 // https://url.spec.whatwg.org/#concept-ipv6-serializer
-inline std::string ipv6_serialize(std::span<std::uint16_t, 8> addr) {
+inline std::string ipv6_serialize(std::span<std::uint16_t const, 8> addr) {
     std::stringstream out;
 
     std::size_t compress = 0;

--- a/util/string_test.cpp
+++ b/util/string_test.cpp
@@ -271,7 +271,7 @@ int main() {
     });
 
     etest::test("IPv6 serialization", [] {
-        std::array<std::uint16_t, 8> loopback{0, 0, 0, 0, 0, 0, 0, 1};
+        std::array<std::uint16_t, 8> const loopback{0, 0, 0, 0, 0, 0, 0, 1};
         std::array<std::uint16_t, 8> global{0x2001, 0xdb8, 0x85a3, 0, 0, 0x8a2e, 0x370, 0x7334};
 
         std::cout << "Serialized IPv6 Loopback Address: " << util::ipv6_serialize(loopback) << "\n";


### PR DESCRIPTION
I could've sworn I'd fixed this before, but I guess I either dropped the commit or didn't do it globally or something.