### PR TITLE
layout: Collapse leading whitespace in more places

### DIFF
--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -86,6 +86,12 @@ void collapse_whitespace(LayoutBox &box) {
             last_text_box = current;
             last_text_box->layout_text = util::trim_start(std::get<std::string_view>(last_text_box->layout_text));
         } else if (!std::holds_alternative<std::monostate>(current->layout_text)) {
+            if (last_text_box != nullptr
+                    && last_text_box->text()
+                               .transform([](auto sv) { return sv.empty() || util::is_whitespace(sv.back()); })
+                               .value_or(false)) {
+                current->layout_text = util::trim_start(std::get<std::string_view>(current->layout_text));
+            }
             last_text_box = current;
         } else if (ends_text_run(*current)) {
             last_text_box->layout_text = util::trim_end(std::get<std::string_view>(last_text_box->layout_text));

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -37,7 +37,7 @@ bool last_node_was_anonymous(LayoutBox const &box) {
 // https://www.w3.org/TR/CSS2/visuren.html#box-gen
 std::optional<LayoutBox> create_tree(style::StyledNode const &node) {
     if (auto const *text = std::get_if<dom::Text>(&node.node)) {
-        return LayoutBox{.node = &node, .type = LayoutType::Inline, .layout_text = text->text};
+        return LayoutBox{.node = &node, .type = LayoutType::Inline, .layout_text = std::string_view{text->text}};
     }
 
     assert(std::holds_alternative<dom::Element>(node.node));

--- a/layout/layout.h
+++ b/layout/layout.h
@@ -32,7 +32,7 @@ struct LayoutBox {
     LayoutType type;
     BoxModel dimensions;
     std::vector<LayoutBox> children;
-    std::optional<std::string_view> layout_text;
+    std::variant<std::monostate, std::string_view, std::string> layout_text;
     [[nodiscard]] bool operator==(LayoutBox const &) const = default;
 
     std::optional<std::string_view> text() const;

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -1259,14 +1259,11 @@ int main() {
     });
 
     etest::test("whitespace collapsing: text split across multiple inline elements", [] {
-        // This will break when we add more complete ws-collapsing to the layout
-        // system as the 2 spaces between "cr" and "lf" will be collapsed to
-        // only being 1 space.
         constexpr auto kFirstText = "   cr "sv;
         constexpr auto kSecondText = " lf   "sv;
         constexpr auto kCollapsedFirst = util::trim_start(kFirstText);
         constexpr auto kFirstWidth = kCollapsedFirst.length() * 5;
-        constexpr auto kCollapsedSecond = util::trim_end(kSecondText);
+        constexpr auto kCollapsedSecond = util::trim(kSecondText);
         constexpr auto kSecondWidth = kCollapsedSecond.length() * 5;
 
         dom::Element a{.name{"a"}, .children{dom::Text{std::string{kSecondText}}}};

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -202,8 +202,8 @@ int main() {
             .children = {
                 {&style_root.children[0], LayoutType::Block, {{0, 0, 0, 10}}, {
                     {nullptr, LayoutType::AnonymousBlock, {{0, 0, 60, 10}}, {
-                        {&style_root.children[0].children[0], LayoutType::Inline, {{0, 0, 25, 10}}, {}, "hello"},
-                        {&style_root.children[0].children[1], LayoutType::Inline, {{25, 0, 35, 10}}, {}, "goodbye"},
+                        {&style_root.children[0].children[0], LayoutType::Inline, {{0, 0, 25, 10}}, {}, "hello"sv},
+                        {&style_root.children[0].children[1], LayoutType::Inline, {{25, 0, 35, 10}}, {}, "goodbye"sv},
                     }},
                 }},
             }

--- a/render/render_test.cpp
+++ b/render/render_test.cpp
@@ -12,9 +12,13 @@
 #include "layout/layout.h"
 #include "style/styled_node.h"
 
+#include <string_view>
+
 using etest::expect_eq;
 
 using CanvasCommands = std::vector<gfx::CanvasCommand>;
+
+using namespace std::literals;
 
 constexpr auto kInvalidColor = gfx::Color{0xFF, 0, 0};
 
@@ -33,7 +37,7 @@ int main() {
                 .node = &styled,
                 .type = layout::LayoutType::Inline,
                 .dimensions = {},
-                .children = {{&styled.children[0], layout::LayoutType::Inline, {}, {}, "hello"}},
+                .children = {{&styled.children[0], layout::LayoutType::Inline, {}, {}, "hello"sv}},
         };
 
         gfx::CanvasCommandSaver saver;
@@ -59,7 +63,7 @@ int main() {
         auto layout = layout::LayoutBox{
                 .node = &styled,
                 .type = layout::LayoutType::Inline,
-                .children = {{&styled.children[0], layout::LayoutType::Inline, {}, {}, "hello"}},
+                .children = {{&styled.children[0], layout::LayoutType::Inline, {}, {}, "hello"sv}},
         };
 
         gfx::CanvasCommandSaver saver;
@@ -329,7 +333,7 @@ int main() {
                         {css::PropertyId::FontFamily, "arial"},
                         {css::PropertyId::FontSize, "16px"},
                 }};
-        auto layout = layout::LayoutBox{.node = &styled, .layout_text = "hello"};
+        auto layout = layout::LayoutBox{.node = &styled, .layout_text = "hello"sv};
 
         gfx::CanvasCommandSaver saver;
         render::render_layout(saver, layout);


### PR DESCRIPTION
This also sets up the infrastructure for me to be able to finish whitespace-collapsing functionality where it would require allocations, e.g. when words are separated by >1 space: `hello     world` should be collapsed to `hello world`.