### PR TITLE
ci: Fix clang-tidy job using the wrong version of clang-tidy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,6 +235,7 @@ jobs:
           sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
       - run: sudo apt-get update && sudo apt-get install --no-install-recommends clang-tidy-15
       - run: echo "CC=clang-15" >>$GITHUB_ENV && echo "CXX=clang++-15" >>$GITHUB_ENV
+      - run: clang-tidy --version
       - run: bazel build ... --config clang-tidy --keep_going
 
   buildifier:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,7 +235,11 @@ jobs:
           sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
       - run: sudo apt-get update && sudo apt-get install --no-install-recommends clang-tidy-15
       - run: echo "CC=clang-15" >>$GITHUB_ENV && echo "CXX=clang++-15" >>$GITHUB_ENV
-      - run: clang-tidy --version
+      - run: |
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 100
+          sudo update-alternatives --set clang-tidy /usr/bin/clang-tidy-15
+          update-alternatives --query clang-tidy
+          clang-tidy --version
       - run: bazel build ... --config clang-tidy --keep_going
 
   buildifier:


### PR DESCRIPTION
Since we switched to running clang-tidy using Bazel, clang-tidy has been
taken from the path, and the default GitHub Actions runner already has a
clang-tidy (as clang-tidy-14) on the $PATH.