### PR TITLE
url: Fix assert() in parse_host w/ empty nonspecial input

### DIFF
--- a/url/url.cpp
+++ b/url/url.cpp
@@ -1271,8 +1271,6 @@ void UrlParser::shorten_url_path(Url &url) const {
 
 // https://url.spec.whatwg.org/#concept-host-parser
 std::optional<Host> UrlParser::parse_host(std::string_view input, bool is_not_special) const {
-    assert(!input.empty());
-
     if (input.starts_with("[")) {
         if (!input.ends_with("]")) {
             validation_error(ValidationError::IPv6Unclosed);
@@ -1301,6 +1299,8 @@ std::optional<Host> UrlParser::parse_host(std::string_view input, bool is_not_sp
 
         return Host{HostType::Opaque, *host};
     }
+
+    assert(!input.empty());
 
     std::string domain = util::percent_decode(input);
 

--- a/url/url_test.cpp
+++ b/url/url_test.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2023 David Zero <zero-one@zer0-one.net>
+// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -623,6 +624,14 @@ int main() {
 
         etest::expect_eq(o.serialize(), "https://whatwg.org");
         etest::expect_eq(o2.serialize(), "null");
+    });
+
+    etest::test("URL parsing: parse_host w/ empty input", [] {
+        url::UrlParser p;
+        auto url = p.parse("a://");
+
+        etest::require(url.has_value());
+        etest::expect_eq(*url, url::Url{.scheme = "a", .host = url::Host{.type = url::HostType::Opaque}});
     });
 
     int ret = etest::run_all_tests();


### PR DESCRIPTION
https://url.spec.whatwg.org/#concept-host-parser says that the assert should come after the check for is_not_special, so this change conforms to what the spec wants.