### PR TITLE
deps: Suppress warnings in third-party libraries

### DIFF
--- a/third_party/icu.BUILD
+++ b/third_party/icu.BUILD
@@ -24,6 +24,7 @@ cc_library(
             "-I source/common/",
             "-I source/common/unicode/",
             "-I source/stubdata/",
+            "-Wno-deprecated-declarations",
         ],
     }) + select({
         "@bazel_tools//tools/cpp:clang-cl": [

--- a/third_party/imgui-sfml.BUILD
+++ b/third_party/imgui-sfml.BUILD
@@ -1,9 +1,17 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
+IMGUI_SFML_COPTS = select({
+    "@platforms//os:linux": [
+        "-Wno-switch",
+    ],
+    "//conditions:default": [],
+})
+
 cc_library(
     name = "imgui-sfml",
     srcs = ["imgui-SFML.cpp"],
     hdrs = glob(["*.h"]),
+    copts = IMGUI_SFML_COPTS,
     defines = ["IMGUI_SFML_SHARED_LIB=0"],
     includes = ["."],
     linkopts = select({

--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -1,5 +1,12 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
+ZLIB_COPTS = select({
+    "@platforms//os:linux": [
+        "-Wno-deprecated-non-prototype",
+    ],
+    "//conditions:default": [],
+})
+
 cc_library(
     name = "zlib",
     srcs = glob([
@@ -7,6 +14,7 @@ cc_library(
         "*.h",
     ]),
     hdrs = ["zlib.h"],
+    copts = ZLIB_COPTS,
     defines = ["ZLIB_CONST"],
     includes = ["."],
     local_defines = select({


### PR DESCRIPTION
We don't explicitly enable any warnings in third-party libraries, but that doesn't mean they don't trigger warnings enabled by default.