### PR TITLE
ci: Update buildifier and prettier

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -236,7 +236,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install
         run: |
-          wget --output-document=buildifier https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildifier-linux-amd64
+          wget --output-document=buildifier https://github.com/bazelbuild/buildtools/releases/download/v6.3.2/buildifier-linux-amd64
           sudo chmod +x buildifier
       - name: Check
         run: ./buildifier --lint=warn --warnings=all -mode diff WORKSPACE $(find . -type f -iname "*.BUILD" -or -iname BUILD -or -iname "*.bzl")
@@ -246,7 +246,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-      - run: npm install --global prettier@3.0.1
+      - run: npm install --global prettier@3.0.2
       # Prettier thinks our fragment shaders are JS-something and complains
       # about syntax errors.
       - run: npx prettier --ignore-path .gitignore --write . '!**/*.frag'


### PR DESCRIPTION
https://github.com/prettier/prettier/releases/tag/3.0.2
https://github.com/bazelbuild/buildtools/releases/tag/v6.3.2