### PR TITLE
browser/tui: Use https if the provided url is missing a scheme

### DIFF
--- a/browser/tui/BUILD
+++ b/browser/tui/BUILD
@@ -12,6 +12,7 @@ cc_binary(
         "//protocol",
         "//tui",
         "//uri",
+        "@fmt",
         "@spdlog",
     ],
 )


### PR DESCRIPTION
Previously `bazel run browser:tui -- example.com` would just fail due to the missing scheme.