### PR TITLE
meta: Enable clang-tidy's cert-* checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -45,6 +45,7 @@
 # harmful.
 Checks: >
   bugprone-*,
+  cert-*,
   cppcoreguidelines-pro-type-cstyle-cast,
   cppcoreguidelines-pro-type-member-init,
   google-*,

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -31,6 +31,7 @@ namespace {
     return os;
 }
 
+// NOLINTNEXTLINE(cert-err58-cpp)
 auto const initial_background_values =
         std::map<css::PropertyId, std::string>{{css::PropertyId::BackgroundImage, "none"},
                 {css::PropertyId::BackgroundPosition, "0% 0%"},
@@ -48,6 +49,7 @@ bool check_initial_background_values(std::map<css::PropertyId, std::string> cons
     });
 }
 
+// NOLINTNEXTLINE(cert-err58-cpp)
 auto const initial_font_values = std::map<css::PropertyId, std::string>{{css::PropertyId::FontStretch, "normal"},
         {css::PropertyId::FontVariant, "normal"},
         {css::PropertyId::FontWeight, "normal"},

--- a/css/property_id.cpp
+++ b/css/property_id.cpp
@@ -13,6 +13,7 @@ using namespace std::literals;
 namespace css {
 namespace {
 
+// NOLINTNEXTLINE(cert-err58-cpp)
 std::map<std::string_view, PropertyId> const known_properties{
         {"azimuth"sv, PropertyId::Azimuth},
         {"background-attachment"sv, PropertyId::BackgroundAttachment},

--- a/etest/etest.cpp
+++ b/etest/etest.cpp
@@ -45,6 +45,7 @@ Registry &registry() {
 
 struct TestFailure : public std::exception {};
 
+// NOLINTNEXTLINE(cert-err58-cpp)
 std::stringstream test_log{};
 
 } // namespace

--- a/gfx/color.cpp
+++ b/gfx/color.cpp
@@ -22,6 +22,7 @@ struct CaseInsensitiveLess {
 };
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/named-color#list_of_all_color_keywords
+// NOLINTNEXTLINE(cert-err58-cpp)
 std::map<std::string_view, gfx::Color, CaseInsensitiveLess> const named_colors{
         // System colors.
         // https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#system_colors

--- a/img/png.cpp
+++ b/img/png.cpp
@@ -53,6 +53,7 @@ std::optional<Png> Png::from(std::istream &is) {
     // See: https://learn.microsoft.com/en-us/cpp/cpp/using-setjmp-longjmp?view=msvc-170
 #pragma warning(disable : 4611)
 #endif
+    // NOLINTNEXTLINE(cert-err52-cpp): libpng offers us this or aborting.
     if (setjmp(png_jmpbuf(png))) {
         png_destroy_read_struct(&png, &info, nullptr);
         return std::nullopt;

--- a/img/png_test.cpp
+++ b/img/png_test.cpp
@@ -16,7 +16,7 @@ using etest::expect_eq;
 
 namespace {
 #include "img/tiny_png.h"
-std::string const png_bytes(reinterpret_cast<char const *>(img_tiny_png), img_tiny_png_len);
+std::string_view const png_bytes(reinterpret_cast<char const *>(img_tiny_png), img_tiny_png_len);
 } // namespace
 
 int main() {
@@ -34,18 +34,18 @@ int main() {
             return expected;
         }();
 
-        auto png = img::Png::from(std::stringstream(png_bytes)).value();
+        auto png = img::Png::from(std::stringstream(std::string{png_bytes})).value();
         expect_eq(png, img::Png{.width = 256, .height = 256, .bytes = std::move(expected_pixels)});
     });
 
     etest::test("invalid signatures are rejected", [] {
-        auto invalid_signature_bytes = png_bytes;
+        auto invalid_signature_bytes = std::string{png_bytes};
         invalid_signature_bytes[7] = 'b';
         expect_eq(img::Png::from(std::stringstream(std::move(invalid_signature_bytes))), std::nullopt);
     });
 
     etest::test("it handles truncated files", [] {
-        auto truncated_bytes = png_bytes.substr(0, 30);
+        auto truncated_bytes = std::string{png_bytes.substr(0, 30)};
         expect_eq(img::Png::from(std::stringstream(std::move(truncated_bytes))), std::nullopt);
     });
 

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -205,6 +205,7 @@ void calculate_padding(LayoutBox &box, int const font_size, int const root_font_
 }
 
 // https://drafts.csswg.org/css-backgrounds/#the-border-width
+// NOLINTNEXTLINE(cert-err58-cpp)
 std::map<std::string_view, int> const border_width_keywords{
         {"thin", 3},
         {"medium", 5},

--- a/os/linux_test.cpp
+++ b/os/linux_test.cpp
@@ -6,7 +6,7 @@
 #ifdef _POSIX_C_SOURCE
 #undef _POSIX_C_SOURCE
 #endif
-// NOLINTNEXTLINE(bugprone-reserved-identifier)
+// NOLINTNEXTLINE: The only option is to mess with this reserved identifier.
 #define _POSIX_C_SOURCE 200112L
 
 #include "os/os.h"

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -28,6 +28,7 @@ namespace style {
 namespace {
 
 // https://www.w3.org/TR/css-cascade/#initial-values
+// NOLINTNEXTLINE(cert-err58-cpp)
 std::map<css::PropertyId, std::string_view> const initial_values{
         // https://developer.mozilla.org/en-US/docs/Web/CSS/background-color#formal_definition
         {css::PropertyId::BackgroundColor, "transparent"sv},
@@ -401,6 +402,7 @@ std::vector<TextDecorationLine> StyledNode::get_text_decoration_line_property() 
 static constexpr int kDefaultFontSize{10};
 // https://drafts.csswg.org/css-fonts-4/#absolute-size-mapping
 constexpr int kMediumFontSize = kDefaultFontSize;
+// NOLINTNEXTLINE(cert-err58-cpp)
 std::map<std::string_view, float> const font_size_absolute_size_keywords{
         {"xx-small", 3 / 5.f},
         {"x-small", 3 / 4.f},

--- a/url/url.cpp
+++ b/url/url.cpp
@@ -37,6 +37,7 @@ namespace url {
 // NOLINTBEGIN(bugprone-unchecked-optional-access)
 
 namespace {
+// NOLINTNEXTLINE(cert-err58-cpp)
 const std::map<std::string, std::uint16_t> special_schemes = {{"ftp", std::uint16_t{21}},
         {"file", std::uint16_t{0}},
         {"http", std::uint16_t{80}},
@@ -44,6 +45,7 @@ const std::map<std::string, std::uint16_t> special_schemes = {{"ftp", std::uint1
         {"ws", std::uint16_t{80}},
         {"wss", std::uint16_t{443}}};
 
+// NOLINTNEXTLINE(cert-err58-cpp)
 const std::map<UrlParser::ValidationError, std::string> validation_error_str = {
         {UrlParser::ValidationError::DomainToAscii, "Unicode ToASCII records an error or returns the empty string"},
         {UrlParser::ValidationError::DomainToUnicode, "Unicode ToUnicode records an error"},


### PR DESCRIPTION
This adds a bunch of suppressions for where we allocate outside of normal program flow, but I'll remove all of those soon.