### PR TITLE
css2: Support parsing integers into number tokens

### DIFF
--- a/css2/tokenizer.cpp
+++ b/css2/tokenizer.cpp
@@ -63,6 +63,16 @@ void Tokenizer::run() {
                     case ')':
                         emit(CloseParenToken{});
                         continue;
+                    case '+': {
+                        // TODO(robinlinden): This only handles integers.
+                        if (auto next_input = peek_input(0); next_input && util::is_digit(*next_input)) {
+                            auto number = consume_number(*c);
+                            emit(NumberToken{number.second, number.first});
+                        } else {
+                            emit(DelimToken{'+'});
+                        }
+                        continue;
+                    }
                     case ',':
                         emit(CommaToken{});
                         continue;
@@ -319,10 +329,14 @@ std::pair<std::variant<int, double>, NumericType> Tokenizer::consume_number(char
     std::variant<int, double> result{};
     std::string repr{};
 
-    // TODO(robinlinden): Step 2
+    std::optional<char> next_input;
+    if (first_byte == '+') {
+        next_input = consume_next_input_character();
+    } else {
+        next_input = first_byte;
+    }
 
-    for (std::optional<char> next_input = first_byte; next_input && util::is_digit(*next_input);
-            next_input = consume_next_input_character()) {
+    for (; next_input && util::is_digit(*next_input); next_input = consume_next_input_character()) {
         repr += *next_input;
     }
 

--- a/css2/tokenizer.h
+++ b/css2/tokenizer.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -13,6 +13,7 @@
 #include <optional>
 #include <string_view>
 #include <utility>
+#include <variant>
 
 namespace css2 {
 
@@ -62,6 +63,8 @@ private:
     bool inputs_starts_ident_sequence(char first_character) const;
     bool is_eof() const;
     void reconsume_in(State);
+
+    std::pair<std::variant<int, double>, NumericType> consume_number(char first_byte);
 };
 
 } // namespace css2

--- a/css2/tokenizer_test.cpp
+++ b/css2/tokenizer_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -304,6 +304,16 @@ int main() {
         auto output = run_tokenizer("}");
 
         expect_token(output, CloseCurlyToken{});
+    });
+
+    etest::test("number: ez", [] {
+        auto output = run_tokenizer("13");
+        expect_token(output, NumberToken{.data = 13});
+    });
+
+    etest::test("number: leading 0", [] {
+        auto output = run_tokenizer("00000001");
+        expect_token(output, NumberToken{.data = 1});
     });
 
     return etest::run_all_tests();

--- a/css2/tokenizer_test.cpp
+++ b/css2/tokenizer_test.cpp
@@ -332,5 +332,21 @@ int main() {
         expect_token(output, IdentToken{"hello"});
     });
 
+    etest::test("hyphen: negative number", [] {
+        auto output = run_tokenizer("-13");
+        expect_token(output, NumberToken{.data = -13});
+    });
+
+    etest::test("hyphen: negative number w/ leading 0", [] {
+        auto output = run_tokenizer("-00000001");
+        expect_token(output, NumberToken{.data = -1});
+    });
+
+    etest::test("hyphen: cdc", [] {
+        auto output = run_tokenizer("-->lol");
+        expect_token(output, CdcToken{});
+        expect_token(output, IdentToken{"lol"});
+    });
+
     return etest::run_all_tests();
 }

--- a/css2/tokenizer_test.cpp
+++ b/css2/tokenizer_test.cpp
@@ -316,5 +316,21 @@ int main() {
         expect_token(output, NumberToken{.data = 1});
     });
 
+    etest::test("plus: number", [] {
+        auto output = run_tokenizer("+13");
+        expect_token(output, NumberToken{.data = 13});
+    });
+
+    etest::test("plus: number w/ leading 0", [] {
+        auto output = run_tokenizer("+00000001");
+        expect_token(output, NumberToken{.data = 1});
+    });
+
+    etest::test("plus: delim", [] {
+        auto output = run_tokenizer("+hello");
+        expect_token(output, DelimToken{'+'});
+        expect_token(output, IdentToken{"hello"});
+    });
+
     return etest::run_all_tests();
 }


### PR DESCRIPTION
The end goal of this is that I want to rewrite media-query parsing in terms of the new correct tokenizer and #679. No point in adding to mq-parsing while it's still ad-hoc and this is *so close* to being able to do everything we need to parse them.