### PR TITLE
layout: Support disabling whitespace collapsing

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -214,6 +214,13 @@ int App::run() {
                             switch_canvas();
                             break;
                         }
+                        case sf::Keyboard::Key::F3: {
+                            auto mode = engine_.whitespace_mode();
+                            engine_.set_whitespace_mode(mode == layout::WhitespaceMode::Preserve
+                                            ? layout::WhitespaceMode::Collapse
+                                            : layout::WhitespaceMode::Preserve);
+                            break;
+                        }
                         case sf::Keyboard::Key::Left: {
                             if (!event.key.alt) {
                                 break;

--- a/engine/BUILD
+++ b/engine/BUILD
@@ -27,6 +27,7 @@ cc_test(
     copts = HASTUR_COPTS,
     deps = [
         ":engine",
+        "//dom",
         "//etest",
         "//protocol",
         "//uri",

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -63,6 +63,16 @@ void Engine::set_layout_width(int width) {
     on_layout_update_();
 }
 
+void Engine::set_whitespace_mode(layout::WhitespaceMode mode) {
+    whitespace_mode_ = mode;
+    if (!styled_) {
+        return;
+    }
+
+    layout_ = layout::create_layout(*styled_, layout_width_, mode);
+    on_layout_update_();
+}
+
 void Engine::on_navigation_success() {
     dom_ = html::parse(response_.body);
     stylesheet_ = css::default_style();
@@ -147,7 +157,7 @@ void Engine::on_navigation_success() {
 
     spdlog::info("Styling dom w/ {} rules", stylesheet_.size());
     styled_ = style::style_tree(dom_.html_node, stylesheet_, {.window_width = layout_width_});
-    layout_ = layout::create_layout(*styled_, layout_width_);
+    layout_ = layout::create_layout(*styled_, layout_width_, whitespace_mode_);
     on_page_loaded_();
 }
 

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -29,6 +29,8 @@ public:
     protocol::Error navigate(uri::Uri uri);
 
     void set_layout_width(int width);
+    void set_whitespace_mode(layout::WhitespaceMode);
+    layout::WhitespaceMode whitespace_mode() const { return whitespace_mode_; }
 
     void set_on_navigation_failure(auto cb) { on_navigation_failure_ = std::move(cb); }
     void set_on_page_loaded(auto cb) { on_page_loaded_ = std::move(cb); }
@@ -49,6 +51,7 @@ private:
     }};
 
     int layout_width_{};
+    layout::WhitespaceMode whitespace_mode_{layout::WhitespaceMode::Collapse};
 
     std::unique_ptr<protocol::IProtocolHandler> protocol_handler_{};
 

--- a/engine/engine_test.cpp
+++ b/engine/engine_test.cpp
@@ -4,6 +4,7 @@
 
 #include "engine/engine.h"
 
+#include "dom/dom.h"
 #include "etest/etest.h"
 #include "protocol/iprotocol_handler.h"
 #include "protocol/response.h"
@@ -391,6 +392,32 @@ int main() {
         };
         engine::Engine e{std::make_unique<FakeProtocolHandler>(std::move(responses))};
         expect_eq(e.navigate(uri::Uri::parse("hax://example.com")), protocol::Error::InvalidResponse);
+    });
+
+    etest::test("whitespace mode", [] {
+        engine::Engine e{std::make_unique<FakeProtocolHandler>(std::map<std::string, Response>{
+                {"hax://example.com", Response{Error::Ok, {.status_code = 200}, {}, "<p>  hello  </p>"}},
+        })};
+
+        // Check that the engine is happy changing this even without a page loaded.
+        e.set_whitespace_mode(layout::WhitespaceMode::Preserve);
+        expect_eq(e.whitespace_mode(), layout::WhitespaceMode::Preserve);
+
+        e.navigate(uri::Uri::parse("hax://example.com"));
+
+        e.set_whitespace_mode(layout::WhitespaceMode::Collapse);
+        expect_eq(e.whitespace_mode(), layout::WhitespaceMode::Collapse);
+
+        auto const *p = dom::nodes_by_xpath(*e.layout(), "/html/body/p").at(0);
+        auto text = p->children.at(0).children.at(0).layout_text; // anon block -> text
+        expect_eq(std::get<std::string_view>(text), "hello"sv);
+
+        e.set_whitespace_mode(layout::WhitespaceMode::Preserve);
+        expect_eq(e.whitespace_mode(), layout::WhitespaceMode::Preserve);
+
+        p = dom::nodes_by_xpath(*e.layout(), "/html/body/p").at(0);
+        text = p->children.at(0).children.at(0).layout_text; // anon block -> text
+        expect_eq(std::get<std::string_view>(text), "  hello  "sv);
     });
 
     return etest::run_all_tests();

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -321,13 +321,16 @@ void layout(LayoutBox &box, geom::Rect const &bounds, int const root_font_size) 
 
 } // namespace
 
-std::optional<LayoutBox> create_layout(style::StyledNode const &node, int width) {
+std::optional<LayoutBox> create_layout(style::StyledNode const &node, int width, WhitespaceMode ws_mode) {
     auto tree = create_tree(node);
     if (!tree) {
         return {};
     }
 
-    collapse_whitespace(*tree);
+    if (ws_mode == WhitespaceMode::Collapse) {
+        collapse_whitespace(*tree);
+    }
+
     layout(*tree, {0, 0, width, 0}, node.get_property<css::PropertyId::FontSize>());
     return *tree;
 }

--- a/layout/layout.h
+++ b/layout/layout.h
@@ -13,7 +13,14 @@
 
 namespace layout {
 
-std::optional<LayoutBox> create_layout(style::StyledNode const &node, int width);
+// Being able to toggle this is a debug feature that will go away once both it
+// and text wrapping are more ready.
+enum class WhitespaceMode {
+    Preserve,
+    Collapse,
+};
+
+std::optional<LayoutBox> create_layout(style::StyledNode const &, int width, WhitespaceMode = WhitespaceMode::Collapse);
 
 } // namespace layout
 


### PR DESCRIPTION
This serves two purposes:
1. It allows me to quickly get a sanity check of the whitespace collapsing bits I'm working on.
2. It makes pages readable after collapsing whitespace/newlines in text runs when we still don't have text wrapping.