### PR TITLE
Increase the default font-size from 10px to 16px and default links to blue

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -158,6 +158,10 @@ h6 {
 
 /* Phrasing content */
 /* https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3 */
+:link {
+  color: #0000ee;
+}
+
 ins,
 u {
   text-decoration: underline;

--- a/layout/layout_box_test.cpp
+++ b/layout/layout_box_test.cpp
@@ -167,6 +167,7 @@ int main() {
                 .properties = {{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
                 .children{{std::move(body_style)}},
         };
+        set_up_parent_ptrs(style_root);
 
         auto const *expected =
                 "html\n"
@@ -175,9 +176,9 @@ int main() {
                 "  block {0,0,50,30} {0,0,0,0} {0,0,0,0}\n"
                 "    p\n"
                 "    block {0,0,50,25} {0,0,0,0} {0,0,0,0}\n"
-                "      ablock {0,0,15,10} {0,0,0,0} {0,0,0,0}\n"
+                "      ablock {0,0,15,25} {0,0,0,0} {0,0,0,0}\n"
                 "        !!!\n"
-                "        inline {0,0,15,10} {0,0,0,0} {0,0,0,0}\n"
+                "        inline {0,0,15,25} {0,0,0,0} {0,0,0,0}\n"
                 "    p\n"
                 "    block {0,30,35,0} {5,15,0,0} {0,0,0,0}\n";
         expect_eq(to_string(layout::create_layout(style_root, 0).value()), expected);

--- a/render/render_test.cpp
+++ b/render/render_test.cpp
@@ -29,9 +29,10 @@ int main() {
         auto const &children = std::get<dom::Element>(dom).children;
         auto styled = style::StyledNode{
                 .node = dom,
-                .properties = {{css::PropertyId::Display, "inline"}},
+                .properties = {{css::PropertyId::FontSize, "10px"}, {css::PropertyId::Display, "inline"}},
                 .children = {{children[0], {{css::PropertyId::Display, "inline"}}, {}}},
         };
+        styled.children[0].parent = &styled;
 
         auto layout = layout::LayoutBox{
                 .node = &styled,
@@ -57,6 +58,7 @@ int main() {
                 .children = {{children[0],
                         {{css::PropertyId::Display, "inline"},
                                 {css::PropertyId::FontFamily, "comic sans"},
+                                {css::PropertyId::FontSize, "10px"},
                                 {css::PropertyId::FontStyle, "italic"}}}},
         };
 

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -399,7 +399,7 @@ std::vector<TextDecorationLine> StyledNode::get_text_decoration_line_property() 
     return lines;
 }
 
-static constexpr int kDefaultFontSize{10};
+static constexpr int kDefaultFontSize{16};
 // https://drafts.csswg.org/css-fonts-4/#absolute-size-mapping
 constexpr int kMediumFontSize = kDefaultFontSize;
 // NOLINTNEXTLINE(cert-err58-cpp)


### PR DESCRIPTION
This matches what other browsers are doing and makes comparing the render results easier.