### PR TITLE
build: Drop support for Clang 14 code coverage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -74,10 +74,6 @@ build:clang-coverage
 build:clang-coverage --action_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
 build:clang-coverage --experimental_generate_llvm_lcov
 
-build:clang14-coverage --config=clang-coverage
-build:clang14-coverage --action_env=BAZEL_LLVM_COV=llvm-cov-14
-build:clang14-coverage --action_env=GCOV=llvm-profdata-14
-
 build:clang16-coverage --config=clang-coverage
 build:clang16-coverage --action_env=BAZEL_LLVM_COV=llvm-cov-16
 build:clang16-coverage --action_env=GCOV=llvm-profdata-16

--- a/.bazelrc.local.example
+++ b/.bazelrc.local.example
@@ -18,4 +18,4 @@ build -c dbg
 # build --config ubsan
 
 # build --config libc++ # only supported when compiling with Clang.
-# build --config clang14-coverage # required to generate code coverage reports with Clang 14.
+# build --config clang16-coverage # required to generate code coverage reports with Clang 16.


### PR DESCRIPTION
While this probably still works, it's also been unused since the Clang 16 code coverage option was added.