### PR TITLE
meta: Re-enable some clang-tidy warnings we had to disable

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,13 +21,6 @@
 #
 # -google-build-using-namespace: We use `using namespace` in tests and for std::literals.
 #
-# -google-readability-braces-around-statements: Crashes clang-tidy-14/15.
-# Stack dump:
-# 0.      Program arguments: clang-tidy-15 -p=/home/robin/code/hastur -quiet /home/robin/code/hastur/dom2/character_data_test.cpp
-# 1.      <eof> parser at end of file
-# 2.      ASTMatcher: Processing 'google-readability-braces-around-statements' against:
-#         IfStmt : </usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/x86_64-linux-gnu/c++/12/bits/c++config.h:520:5, col:56>
-#
 # -misc-const-correctness: Consts some things that can't be const, and very very noisy.
 #
 # -misc-no-recursion: We use a lot of recursion.
@@ -64,7 +57,6 @@ Checks: >
   -clang-analyzer-cplusplus.NewDeleteLeaks,
   -clang-diagnostic-builtin-macro-redefined,
   -google-build-using-namespace,
-  -google-readability-braces-around-statements,
   -misc-const-correctness,
   -misc-no-recursion,
   -modernize-make-unique,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,9 +16,6 @@
 # field '_M_pi' [clang-analyzer-cplusplus.NewDeleteLeaks,-warnings-as-errors]
 # Very similar call stack to https://github.com/llvm/llvm-project/issues/55219
 #
-# -clang-analyzer-optin.cplusplus.UninitializedObject: Triggered by libfmt
-# format strings on the line we instantiate them.
-#
 # -clang-diagnostic-builtin-macro-redefined: Bazel redefines a lot of builtin
 # macros to set up a reproducible build.
 #
@@ -65,7 +62,6 @@ Checks: >
   -bugprone-unchecked-optional-access,
   -cert-dcl21-cpp,
   -clang-analyzer-cplusplus.NewDeleteLeaks,
-  -clang-analyzer-optin.cplusplus.UninitializedObject,
   -clang-diagnostic-builtin-macro-redefined,
   -google-build-using-namespace,
   -google-readability-braces-around-statements,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@
 # -bugprone-narrowing-conversions: Very noisy for not much gain.
 #
 # -bugprone-unchecked-optional-access: Makes clang-tidy hang during CI.
+# https://github.com/llvm/llvm-project/issues/59492
 #
 # -cert-dcl21-cpp: Deprecated, will be removed in clang-tidy 19.
 # https://clang.llvm.org/extra/clang-tidy/checks/cert/dcl21-cpp.html


### PR DESCRIPTION
See: `https://github.com/llvm/llvm-project/issues/57568`, `https://github.com/fmtlib/fmt/issues/3541`.