### PR TITLE
ci: Re-enable the clang-cl job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,27 +211,29 @@ jobs:
       # - name: Run
       #   run: bazel run browser:tui -c dbg
 
-  # Bazel doesn't understand the clang-cl 16 include path yet.
+  # The current Bazel release doesn't understand the clang-cl 16 include path
+  # yet, so patch the .bazelversion to a version that does.
   # see: https://github.com/bazelbuild/bazel/issues/17863
-  #
-  # windows-clang-cl:
-  #   runs-on: windows-2022
-  #   timeout-minutes: 30
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: ~/.cache/bazel
-  #         key: windows_clang_cl-${{ hashFiles('WORKSPACE', 'third_party/**') }}
-  #     - run: echo "build --config clang-cl" >.bazelrc.local
-  #     - run: echo "build --disk_cache ~/.cache/bazel" >>.bazelrc.local
-  #     - run: bazel test ...
-  #     # TODO(robinlinden): This no longer runs in CI due to http://example.com
-  #     # being inaccessible.
-  #     # - run: bazel run browser:tui
+  windows-clang-cl:
+    runs-on: windows-2022
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/bazel
+          key: windows_clang_cl-${{ hashFiles('WORKSPACE', 'third_party/**') }}
+      - run: echo "build --config clang-cl" >.bazelrc.local
+      - run: echo "build --disk_cache ~/.cache/bazel" >>.bazelrc.local
+      - run: echo "6.4.0rc1" >.bazelversion
+      - run: bazel --version
+      - run: bazel test ...
+      # TODO(robinlinden): This no longer runs in CI due to http://example.com
+      # being inaccessible.
+      # - run: bazel run browser:tui
 
   clang-format:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
We do this by switching to a Bazel release candidate as that's the only option that supports clang-cl-16's include paths.

The timeout for the clang-cl job was also increased a bit as it timed out due to waiting an extra 10 minutes before getting any output from Bazel and the build actually showed any progress.