### PR TITLE
ci: Run aarch64 binaries using binfmt-misc magic

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -89,7 +89,6 @@ build:clang-tidy --build_tag_filters=-no-clang-tidy
 
 build:linux-aarch64-musl --platforms=@zig_sdk//platform:linux_arm64
 build:linux-aarch64-musl --extra_toolchains=@zig_sdk//toolchain:linux_arm64_musl
-build:linux-aarch64-musl --run_under=qemu-aarch64-static
 build:linux-aarch64-musl --copt=-fPIC
 build:linux-aarch64-musl --dynamic_mode=off
 # TODO(robinlinden): asio assumes __GLIBC__ is defined.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,15 +175,15 @@ jobs:
           path: ~/.cache/bazel
           key: aarch64_linux_muslc-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
           restore-keys: aarch64_linux_muslc-
-      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends qemu-user-static
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends qemu-user-static binfmt-support
+      - run: sudo update-binfmts --enable qemu-aarch64
       - run: wget --no-verbose --output-document=bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-amd64 && chmod +x bazelisk
       - run: echo "build --config=linux-aarch64-musl" >.bazelrc.local
       # TODO(robinlinden): Improve. We shouldn't be excluding targets like this.
       # Include all targets except for
-      # * fuzzing_regression_test, sh_test, and py_test targets: not sure, scripts
-      #     probably don't get along with --run_under=qemu-aarch64-static.
+      # * py_test targets: not fully statically linked
       # * targets that depend on sfml: it pulls in host dependencies.
-      - run: ./bazelisk test -- $(bazel query '... except (kind("fuzzing_regression_test|sh_test|py_test", ...) union rdeps(..., @sfml//:window))')
+      - run: ./bazelisk test -- $(bazel query '... except (kind("py_test", ...) union rdeps(..., @sfml//:window))')
       - name: Run tui
         run: |
           echo "<html><body><h1>Example</h1><p>This is an example page.</p></body></html>" >example.html


### PR DESCRIPTION
This works better than Bazel's `--run_under=qemu-aarch64-static` as it only applies to aarch64 targets and not e.g. shell scripts.