### PR TITLE
ci: Drop Clang jobs where we already test earlier and later versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,16 +51,6 @@ jobs:
             version: 15
             bazel: --config ubsan
 
-          - name: clang-15
-            os: ubuntu-22.04
-            compiler: clang
-            version: 15
-
-          - name: clang-16
-            os: ubuntu-22.04
-            compiler: clang
-            version: 16
-
           - name: clang-17
             os: ubuntu-22.04
             compiler: clang
@@ -72,13 +62,6 @@ jobs:
             version: 15
             bazel: --config libc++
             apt: libc++abi-15-dev libc++-15-dev
-
-          - name: clang-16-libc++
-            os: ubuntu-22.04
-            compiler: clang
-            version: 16
-            bazel: --config libc++
-            apt: libc++abi-16-dev libc++-16-dev
 
           - name: clang-17-libc++
             os: ubuntu-22.04


### PR DESCRIPTION
This is being done both so that the GitHub Actions cache doesn't fill up as fast, and so that I won't have to spend as much time waiting for queued jobs to run.

If libc++15 and libc++17 both work, then libc++16 probably also works.

Clang 15 is used in one of the sanitizer jobs, so the plain build is sort of redundant.

The plain Clang 16 build was dropped as we test Clang 14, 15, and 17, and it'll probably work if the surrounding versions work.