### PR TITLE
archive: Fix crash when fed empty input

### DIFF
--- a/archive/BUILD
+++ b/archive/BUILD
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-load("//bzl:copts.bzl", "HASTUR_COPTS")
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS", "HASTUR_FUZZ_PLATFORMS")
 
 cc_library(
     name = "archive",
@@ -27,4 +28,16 @@ cc_library(
         ":archive",
         "//etest",
     ],
-) for src in glob(["*_test.cpp"])]
+) for src in glob(
+    include = ["*_test.cpp"],
+    exclude = ["*_fuzz_test.cpp"],
+)]
+
+[cc_fuzz_test(
+    name = src[:-4],
+    size = "small",
+    srcs = [src],
+    copts = HASTUR_COPTS,
+    target_compatible_with = HASTUR_FUZZ_PLATFORMS,
+    deps = [":archive"],
+) for src in glob(["*_fuzz_test.cpp"])]

--- a/archive/gzip_fuzz_test.cpp
+++ b/archive/gzip_fuzz_test.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "archive/zlib.h"
+
+#include <stddef.h> // NOLINT
+#include <stdint.h> // NOLINT
+#include <string_view>
+#include <tuple>
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size); // NOLINT
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size) {
+    std::string_view input{reinterpret_cast<char const *>(data), size};
+    std::ignore = archive::zlib_decode(input, archive::ZlibMode::Gzip);
+    return 0;
+}

--- a/archive/zlib.cpp
+++ b/archive/zlib.cpp
@@ -27,13 +27,11 @@ tl::expected<std::string, ZlibError> zlib_decode(std::string_view data, ZlibMode
     // only the gzip format <...>.
     int const zlib_mode = [mode] {
         switch (mode) {
-            case ZlibMode::Zlib:
-                return 0;
             case ZlibMode::Gzip:
                 return 15;
-            case ZlibMode::GzipAndZlib:
             default:
-                return 32;
+            case ZlibMode::Zlib:
+                return 0;
         }
     }();
     constexpr int kWindowBits = 15;

--- a/archive/zlib.cpp
+++ b/archive/zlib.cpp
@@ -48,7 +48,10 @@ tl::expected<std::string, ZlibError> zlib_decode(std::string_view data, ZlibMode
         s.avail_out = static_cast<uInt>(buf.size());
         int ret = inflate(&s, Z_NO_FLUSH);
         if (ret != Z_OK && ret != Z_STREAM_END) {
-            std::string msg = s.msg;
+            std::string msg;
+            if (s.msg != nullptr) {
+                msg = s.msg;
+            }
             inflateEnd(&s);
             return tl::unexpected{ZlibError{.message = std::move(msg), .code = ret}};
         }

--- a/archive/zlib.h
+++ b/archive/zlib.h
@@ -20,7 +20,6 @@ struct ZlibError {
 enum class ZlibMode {
     Zlib,
     Gzip,
-    GzipAndZlib,
 };
 
 tl::expected<std::string, ZlibError> zlib_decode(std::string_view, ZlibMode);

--- a/archive/zlib_fuzz_test.cpp
+++ b/archive/zlib_fuzz_test.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "archive/zlib.h"
+
+#include <stddef.h> // NOLINT
+#include <stdint.h> // NOLINT
+#include <string_view>
+#include <tuple>
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size); // NOLINT
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size) {
+    std::string_view input{reinterpret_cast<char const *>(data), size};
+    std::ignore = archive::zlib_decode(input, archive::ZlibMode::Zlib);
+    return 0;
+}

--- a/archive/zlib_test.cpp
+++ b/archive/zlib_test.cpp
@@ -36,7 +36,7 @@ int main() {
 
     etest::test("gzip", [] {
         expect(!zlib_decode("", ZlibMode::Gzip).has_value());
-        expect(!zlib_decode(kZlibbedCss, ZlibMode::Gzip), std::nullopt);
+        expect(!zlib_decode(kZlibbedCss, ZlibMode::Gzip).has_value());
 
         expect_eq(zlib_decode(kGzippedCss, ZlibMode::Gzip), kExpected);
     });

--- a/archive/zlib_test.cpp
+++ b/archive/zlib_test.cpp
@@ -28,12 +28,16 @@ constexpr auto kZlibbedCss =
 
 int main() {
     etest::test("zlib", [] {
-        expect_eq(zlib_decode(kZlibbedCss, ZlibMode::Zlib), kExpected);
+        expect(!zlib_decode("", ZlibMode::Zlib).has_value());
         expect(!zlib_decode(kGzippedCss, ZlibMode::Zlib).has_value());
+
+        expect_eq(zlib_decode(kZlibbedCss, ZlibMode::Zlib), kExpected);
     });
 
     etest::test("gzip", [] {
+        expect(!zlib_decode("", ZlibMode::Gzip).has_value());
         expect(!zlib_decode(kZlibbedCss, ZlibMode::Gzip), std::nullopt);
+
         expect_eq(zlib_decode(kGzippedCss, ZlibMode::Gzip), kExpected);
     });
 

--- a/archive/zlib_test.cpp
+++ b/archive/zlib_test.cpp
@@ -37,10 +37,5 @@ int main() {
         expect_eq(zlib_decode(kGzippedCss, ZlibMode::Gzip), kExpected);
     });
 
-    etest::test("zlib and gzip", [] {
-        expect_eq(zlib_decode(kZlibbedCss, ZlibMode::GzipAndZlib), kExpected);
-        expect_eq(zlib_decode(kGzippedCss, ZlibMode::GzipAndZlib), kExpected);
-    });
-
     return etest::run_all_tests();
 }


### PR DESCRIPTION
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string: construction from null is not valid
```