### PR TITLE
engine: Follow redirects when loading stylesheets

### DIFF
--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -78,7 +78,10 @@ void Engine::on_navigation_success() {
             auto stylesheet_url = uri::Uri::parse(href, uri_);
 
             spdlog::info("Downloading stylesheet from {}", stylesheet_url.uri);
-            auto style_data = protocol_handler_->handle(stylesheet_url);
+            auto res = load(stylesheet_url);
+            auto &style_data = res.response;
+            stylesheet_url = std::move(res.uri_after_redirects);
+
             if (style_data.err != protocol::Error::Ok) {
                 spdlog::warn("Error {} downloading {}", static_cast<int>(style_data.err), stylesheet_url.uri);
                 return {};

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -10,6 +10,7 @@
 #include "dom/dom.h"
 #include "layout/layout.h"
 #include "protocol/iprotocol_handler.h"
+#include "protocol/response.h"
 #include "style/styled_node.h"
 #include "uri/uri.h"
 
@@ -60,6 +61,12 @@ private:
     std::optional<layout::LayoutBox> layout_{};
 
     void on_navigation_success();
+
+    struct [[nodiscard]] LoadResult {
+        protocol::Response response;
+        uri::Uri uri_after_redirects;
+    };
+    LoadResult load(uri::Uri);
 };
 
 } // namespace engine


### PR DESCRIPTION
#740 will be rebased to use `LoadResult Engine::load(Uri)` once this is merged so we don't hand out the protocol-handler and get redirect-handling and stuff for free.