### PR TITLE
css: Handle property-values w/ surrounding whitespace, !important declarations

### DIFF
--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -400,7 +400,7 @@ std::optional<css::Rule> Parser::parse_rule() {
         }
 
         auto [name, value] = *decl;
-        add_declaration(rule.declarations, name, value);
+        add_declaration(rule.declarations, name, util::trim(value));
         skip_whitespace_and_comments();
     }
 

--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -400,7 +400,12 @@ std::optional<css::Rule> Parser::parse_rule() {
         }
 
         auto [name, value] = *decl;
-        add_declaration(rule.declarations, name, util::trim(value));
+        if (value.ends_with("!important")) {
+            value.remove_suffix(std::strlen("!important"));
+            add_declaration(rule.important_declarations, name, util::trim(value));
+        } else {
+            add_declaration(rule.declarations, name, util::trim(value));
+        }
         skip_whitespace_and_comments();
     }
 

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -129,6 +129,15 @@ int main() {
                 }});
     });
 
+    etest::test("property value with spaces", [] {
+        auto rules = css::parse("p { color:           green       ; }").rules;
+        expect_eq(rules,
+                std::vector<css::Rule>{{
+                        .selectors{{"p"}},
+                        .declarations{{css::PropertyId::Color, "green"}},
+                }});
+    });
+
     etest::test("parser: minified", [] {
         auto rules = css::parse("body{width:50px;font-family:inherit}head,p{display:none}"sv).rules;
         require(rules.size() == 2);

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -120,6 +120,17 @@ int main() {
         expect(body.declarations.at(css::PropertyId::Width) == "50px"s);
     });
 
+    etest::test("parser: important rule", [] {
+        auto rules = css::parse("body { width: 50px !important; }"sv).rules;
+        require_eq(rules.size(), std::size_t{1});
+
+        auto body = rules[0];
+        expect_eq(body.selectors, std::vector{"body"s});
+        expect(body.declarations.empty());
+        expect_eq(body.important_declarations.size(), std::size_t{1});
+        expect_eq(body.important_declarations.at(css::PropertyId::Width), "50px"s);
+    });
+
     etest::test("selector with spaces", [] {
         auto rules = css::parse("p a { color: green; }").rules;
         expect_eq(rules,

--- a/css/rule.cpp
+++ b/css/rule.cpp
@@ -31,6 +31,12 @@ std::string to_string(Rule const &rule) {
     for (auto const &[property, value] : rule.declarations) {
         ss << "  " << to_string(property) << ": " << value << '\n';
     }
+    if (!rule.important_declarations.empty()) {
+        ss << "Important declarations:\n";
+        for (auto const &[property, value] : rule.important_declarations) {
+            ss << "  " << to_string(property) << ": " << value << '\n';
+        }
+    }
     if (rule.media_query.has_value()) {
         ss << "Media query:\n";
         ss << "  " << to_string(*rule.media_query) << '\n';

--- a/css/rule.h
+++ b/css/rule.h
@@ -19,6 +19,7 @@ namespace css {
 struct Rule {
     std::vector<std::string> selectors;
     std::map<PropertyId, std::string> declarations;
+    std::map<PropertyId, std::string> important_declarations;
     std::optional<MediaQuery> media_query;
     [[nodiscard]] bool operator==(Rule const &) const = default;
 };

--- a/css/rule_test.cpp
+++ b/css/rule_test.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2022 Mikael Larsson <c.mikael.larsson@gmail.com>
+// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -54,6 +55,19 @@ int main() {
                 "  text-align: center\n"
                 "Media query:\n"
                 "  0 <= width <= 900\n";
+        expect_eq(css::to_string(rule), expected);
+    });
+
+    etest::test("rule to string, important declaration", [] {
+        css::Rule rule;
+        rule.selectors.emplace_back("div");
+        rule.important_declarations.emplace(css::PropertyId::BackgroundColor, "black");
+
+        auto const *expected =
+                "Selectors: div\n"
+                "Declarations:\n"
+                "Important declarations:\n"
+                "  background-color: black\n";
         expect_eq(css::to_string(rule), expected);
     });
 

--- a/style/style.cpp
+++ b/style/style.cpp
@@ -156,6 +156,18 @@ std::vector<std::pair<css::PropertyId, std::string>> matching_rules(
         }
     }
 
+    // TODO(robinlinden): !important inline styles should override the ones from
+    // the style sheets.
+    for (auto const &rule : stylesheet.rules) {
+        if (rule.important_declarations.empty() || (rule.media_query.has_value() && !rule.media_query->evaluate(ctx))) {
+            continue;
+        }
+
+        if (std::ranges::any_of(rule.selectors, [&](auto const &selector) { return is_match(node, selector); })) {
+            std::ranges::copy(rule.important_declarations, std::back_inserter(matched_rules));
+        }
+    }
+
     return matched_rules;
 }
 

--- a/style/style_test.cpp
+++ b/style/style_test.cpp
@@ -49,6 +49,25 @@ void inline_css_tests() {
                         std::pair{css::PropertyId::FontSize, "2000px"s}, std::pair{css::PropertyId::FontSize, "2px"s}});
     });
 }
+
+void important_declarations_tests() {
+    etest::test("!important: has higher priority", [] {
+        dom::Node dom = dom::Element{"div"};
+        css::StyleSheet css{.rules{{
+                .selectors = {"div"},
+                .declarations = {{css::PropertyId::FontSize, "2px"}},
+                .important_declarations = {{css::PropertyId::FontSize, "20px"}},
+        }}};
+        auto styled = style::style_tree(dom, css);
+
+        // The last property is the one that's applied.
+        expect_eq(styled->properties,
+                std::vector{
+                        std::pair{css::PropertyId::FontSize, "2px"s},
+                        std::pair{css::PropertyId::FontSize, "20px"s},
+                });
+    });
+}
 } // namespace
 
 int main() {
@@ -241,5 +260,6 @@ int main() {
     });
 
     inline_css_tests();
+    important_declarations_tests();
     return etest::run_all_tests();
 }


### PR DESCRIPTION
Not sure this data structure is what we want long-term, but it's trivial to tack on now, and things will probably change quite a bit as we work on and move to the `//css2` parser.

Resolves #362 