### PR TITLE
layout: Actually measure the width of text runs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -76,7 +76,7 @@ Checks: >
 # clang-tidy-16.
 WarningsAsErrors: "*,-clang-diagnostic-builtin-macro-redefined"
 
-HeaderFilterRegex: "\\./(archive|azm|browser|css|css2|dom|dom2|engine|etest|geom|gfx|html|html2|idna|img|js|layout|net|os|protocol|render|style|tui|uri|url|util|wasm)/"
+HeaderFilterRegex: "\\./(archive|azm|browser|css|css2|dom|dom2|engine|etest|geom|gfx|html|html2|idna|img|js|layout|net|os|protocol|render|style|tui|type|uri|url|util|wasm)/"
 
 CheckOptions:
   # performance-move-const-arg

--- a/.gitlint
+++ b/.gitlint
@@ -4,4 +4,4 @@ ignore=body-is-missing
 # TODO(robinlinden): Better way of documenting and setting this up.
 # Each commit must start with the main area it affects.
 [title-match-regex]
-regex=^(archive|azm|browser|bzl|css|css2|dom|dom2|engine|etest|geom|gfx|html|html2|idna|img|js|layout|net|os|protocol|render|style|tui|uri|url|util|wasm|all|build|ci|deps|doc|meta)(/.*|\+.*)?:
+regex=^(archive|azm|browser|bzl|css|css2|dom|dom2|engine|etest|geom|gfx|html|html2|idna|img|js|layout|net|os|protocol|render|style|tui|type|uri|url|util|wasm|all|build|ci|deps|doc|meta)(/.*|\+.*)?:

--- a/browser/gui/BUILD
+++ b/browser/gui/BUILD
@@ -20,6 +20,7 @@ cc_binary(
         "//os:system_info",
         "//protocol",
         "//render",
+        "//type:sfml",
         "//uri",
         "//util:history",
         "@fmt",

--- a/browser/gui/app.h
+++ b/browser/gui/app.h
@@ -11,6 +11,7 @@
 #include "gfx/sfml_canvas.h"
 #include "layout/layout_box.h"
 #include "protocol/handler_factory.h"
+#include "type/sfml.h"
 #include "uri/uri.h"
 #include "util/history.h"
 
@@ -35,7 +36,8 @@ public:
 private:
     // Latest Firefox ESR user agent (on Windows). This matches what the Tor browser does.
     engine::Engine engine_{protocol::HandlerFactory::create(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0")};
+                                   "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0"),
+            std::make_unique<type::SfmlType>()};
     bool page_loaded_{};
 
     std::string browser_title_{};

--- a/engine/BUILD
+++ b/engine/BUILD
@@ -15,6 +15,8 @@ cc_library(
         "//layout",
         "//protocol",
         "//style",
+        "//type",
+        "//type:naive",
         "//uri",
         "@spdlog",
     ],

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -43,7 +43,7 @@ void Engine::set_layout_width(int width) {
     }
 
     styled_ = style::style_tree(dom_.html_node, stylesheet_, {.window_width = layout_width_});
-    layout_ = layout::create_layout(*styled_, layout_width_);
+    layout_ = layout::create_layout(*styled_, layout_width_, *type_);
     on_layout_update_();
 }
 
@@ -128,7 +128,7 @@ void Engine::on_navigation_success() {
 
     spdlog::info("Styling dom w/ {} rules", stylesheet_.rules.size());
     styled_ = style::style_tree(dom_.html_node, stylesheet_, {.window_width = layout_width_});
-    layout_ = layout::create_layout(*styled_, layout_width_);
+    layout_ = layout::create_layout(*styled_, layout_width_, *type_);
     on_page_loaded_();
 }
 

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -12,6 +12,8 @@
 #include "protocol/iprotocol_handler.h"
 #include "protocol/response.h"
 #include "style/styled_node.h"
+#include "type/naive.h"
+#include "type/type.h"
 #include "uri/uri.h"
 
 #include <functional>
@@ -24,8 +26,9 @@ namespace engine {
 
 class Engine {
 public:
-    explicit Engine(std::unique_ptr<protocol::IProtocolHandler> protocol_handler)
-        : protocol_handler_{std::move(protocol_handler)} {}
+    explicit Engine(std::unique_ptr<protocol::IProtocolHandler> protocol_handler,
+            std::unique_ptr<type::IType const> type = std::make_unique<type::NaiveType>())
+        : protocol_handler_{std::move(protocol_handler)}, type_{std::move(type)} {}
 
     protocol::Error navigate(uri::Uri uri);
 
@@ -58,6 +61,7 @@ private:
     int layout_width_{};
 
     std::unique_ptr<protocol::IProtocolHandler> protocol_handler_{};
+    std::unique_ptr<type::IType const> type_{};
 
     uri::Uri uri_{};
     protocol::Response response_{};

--- a/layout/BUILD
+++ b/layout/BUILD
@@ -15,6 +15,8 @@ cc_library(
         "//dom",
         "//geom",
         "//style",
+        "//type",
+        "//type:naive",
         "//util:from_chars",
         "//util:string",
         "@spdlog",
@@ -29,5 +31,6 @@ cc_library(
         ":layout",
         "//dom",
         "//etest",
+        "//type",
     ],
 ) for src in glob(["*_test.cpp"])]

--- a/layout/layout.h
+++ b/layout/layout.h
@@ -8,12 +8,14 @@
 #include "layout/layout_box.h"
 
 #include "style/styled_node.h"
+#include "type/naive.h"
+#include "type/type.h"
 
 #include <optional>
 
 namespace layout {
 
-std::optional<LayoutBox> create_layout(style::StyledNode const &, int width);
+std::optional<LayoutBox> create_layout(style::StyledNode const &, int width, type::IType const & = type::NaiveType{});
 
 } // namespace layout
 

--- a/type/BUILD
+++ b/type/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bzl:copts.bzl", "HASTUR_COPTS")
 
 cc_library(
@@ -6,4 +6,23 @@ cc_library(
     hdrs = ["type.h"],
     copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "naive",
+    hdrs = ["naive.h"],
+    copts = HASTUR_COPTS,
+    visibility = ["//visibility:public"],
+    deps = [":type"],
+)
+
+cc_test(
+    name = "naive_test",
+    size = "small",
+    srcs = ["naive_test.cpp"],
+    copts = HASTUR_COPTS,
+    deps = [
+        ":naive",
+        "//etest",
+    ],
 )

--- a/type/BUILD
+++ b/type/BUILD
@@ -26,3 +26,23 @@ cc_test(
         "//etest",
     ],
 )
+
+SFML_TYPE_COPTS = HASTUR_COPTS + select({
+    # SFML leaks this into our code.
+    "@platforms//os:linux": ["-Wno-implicit-fallthrough"],
+    "//conditions:default": [],
+})
+
+cc_library(
+    name = "sfml",
+    srcs = ["sfml.cpp"],
+    hdrs = ["sfml.h"],
+    copts = SFML_TYPE_COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":type",
+        "//os:xdg",
+        "//util:string",
+        "@sfml//:graphics",
+    ],
+)

--- a/type/BUILD
+++ b/type/BUILD
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
+
+cc_library(
+    name = "type",
+    hdrs = ["type.h"],
+    copts = HASTUR_COPTS,
+    visibility = ["//visibility:public"],
+)

--- a/type/naive.h
+++ b/type/naive.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef TYPE_NAIVE_H_
+#define TYPE_NAIVE_H_
+
+#include "type/type.h"
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <utility>
+
+namespace type {
+
+class NaiveFont : public IFont {
+public:
+    explicit NaiveFont(Px font_size) : font_size_{font_size} {}
+
+    Size measure(std::string_view text) const override {
+        return Size{static_cast<int>(text.size()) * font_size_.v / 2, font_size_.v};
+    }
+
+private:
+    Px font_size_{};
+};
+
+class NaiveType : public IType {
+public:
+    std::optional<std::shared_ptr<IFont const>> font(std::string_view, Px size) const override {
+        if (auto font = font_cache_.find(size.v); font != font_cache_.end()) {
+            return font->second;
+        }
+
+        return font_cache_.insert(std::pair{size.v, std::make_shared<NaiveFont>(size)}).first->second;
+    }
+
+private:
+    mutable std::map<int, std::shared_ptr<NaiveFont>> font_cache_;
+};
+
+} // namespace type
+
+#endif

--- a/type/naive_test.cpp
+++ b/type/naive_test.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "type/naive.h"
+
+#include "etest/etest2.h"
+
+int main() {
+    etest::Suite s{"type/naive"};
+
+    s.add_test("NaiveFont::measure", [](etest::IActions &a) {
+        type::NaiveType type{};
+
+        auto font10px = type.font("a", type::Px{10}).value();
+        a.expect_eq(font10px->measure("a"), type::Size{5, 10});
+        a.expect_eq(font10px->measure("hello"), type::Size{25, 10});
+
+        auto font20px = type.font("a", type::Px{20}).value();
+        a.expect_eq(font20px->measure("a"), type::Size{10, 20});
+        a.expect_eq(font20px->measure("hello"), type::Size{50, 20});
+    });
+
+    s.add_test("NaiveType::font_cache", [](etest::IActions &a) {
+        type::NaiveType type{};
+
+        auto font0 = type.font("a", type::Px{10}).value();
+        auto font1 = type.font("a", type::Px{10}).value();
+        a.expect_eq(font0.get(), font1.get());
+    });
+
+    return s.run();
+}

--- a/type/sfml.cpp
+++ b/type/sfml.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022 Mikael Larsson <c.mikael.larsson@gmail.com>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "type/sfml.h"
+
+#include "os/xdg.h"
+#include "util/string.h"
+
+#include <SFML/Graphics/Text.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+namespace type {
+namespace {
+
+std::filesystem::recursive_directory_iterator get_font_dir_iterator(std::filesystem::path const &path) {
+    std::error_code errc;
+    if (auto it = std::filesystem::recursive_directory_iterator(path, errc); !errc) {
+        return it;
+    }
+
+    return {};
+}
+
+// TODO(robinlinden): We should be looking at font names rather than filenames.
+std::optional<std::string> find_path_to_font(std::string_view font_filename) {
+    for (auto const &path : os::font_paths()) {
+        for (auto const &entry : get_font_dir_iterator(path)) {
+            auto name = entry.path().filename().string();
+            // TODO(robinlinden): std::ranges once Clang supports it. Last tested w/ 15.
+            if (std::search(begin(name), end(name), begin(font_filename), end(font_filename), [](char a, char b) {
+                    return util::lowercased(a) == util::lowercased(b);
+                }) != end(name)) {
+                return std::make_optional(entry.path().string());
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+} // namespace
+
+Size SfmlFont::measure(std::string_view text) const {
+    sf::Text sf_text{
+            sf::String::fromUtf8(text.data(), text.data() + text.size()), font_, static_cast<unsigned>(font_size_.v)};
+    auto bounds = sf_text.getLocalBounds();
+    return Size{static_cast<int>(bounds.width), static_cast<int>(bounds.height)};
+}
+
+std::optional<std::shared_ptr<IFont const>> SfmlType::font(std::string_view name, Px size) const {
+    if (auto font = font_cache_.find(name); font != font_cache_.end()) {
+        font->second->set_font_size(size);
+        return font->second;
+    }
+
+    sf::Font font;
+    if (auto path = find_path_to_font(name); !path || !font.loadFromFile(*path)) {
+        return std::nullopt;
+    }
+
+    return font_cache_.insert(std::pair{std::string{name}, std::make_shared<SfmlFont>(font, size)}).first->second;
+}
+
+} // namespace type

--- a/type/sfml.h
+++ b/type/sfml.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef TYPE_SFML_H_
+#define TYPE_SFML_H_
+
+#include "type/type.h"
+
+#include <SFML/Graphics/Font.hpp>
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <utility>
+
+namespace type {
+
+class SfmlFont : public IFont {
+public:
+    SfmlFont(sf::Font const &font, Px font_size) : font_{font}, font_size_{font_size} {}
+
+    Size measure(std::string_view text) const override;
+    void set_font_size(Px size) { font_size_ = size; }
+
+private:
+    sf::Font font_{};
+    Px font_size_{};
+};
+
+class SfmlType : public IType {
+public:
+    std::optional<std::shared_ptr<IFont const>> font(std::string_view name, Px size) const override;
+
+private:
+    mutable std::map<std::string, std::shared_ptr<SfmlFont>, std::less<>> font_cache_;
+};
+
+} // namespace type
+
+#endif

--- a/type/type.h
+++ b/type/type.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef TYPE_TYPE_H_
+#define TYPE_TYPE_H_
+
+#include <memory>
+#include <optional>
+#include <string_view>
+
+namespace type {
+
+struct Size {
+    int width{};
+    int height{};
+    [[nodiscard]] bool operator==(Size const &) const = default;
+};
+
+struct Px {
+    int v{};
+    [[nodiscard]] bool operator==(Px const &) const = default;
+};
+
+class IFont {
+public:
+    virtual ~IFont() = default;
+    [[nodiscard]] virtual Size measure(std::string_view) const = 0;
+};
+
+class IType {
+public:
+    virtual ~IType() = default;
+    [[nodiscard]] virtual std::optional<std::shared_ptr<IFont const>> font(std::string_view name, Px size) const = 0;
+};
+
+} // namespace type
+
+#endif


### PR DESCRIPTION
Previously we were just making a number up (50% of the font-width for the width, 100% for the height.) The making-things-up behaviour is preserved in the `type::NaiveType` `type::IType` implementation as it's useful for tests and things like the tui where we don't care about the measurements.

This currently duplicates some font-search code from `gfx::SfmlCanvas`, but `gfx::SfmlCanvas` should be updated to use the new text/font/typeface system.