### PR TITLE
style: Trim quotes from font-family entries

### DIFF
--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -90,7 +90,10 @@ struct StyledNode {
         } else if constexpr (T == css::PropertyId::FontFamily) {
             auto raw_font_family = get_raw_property(T);
             auto families = util::split(raw_font_family, ",");
-            std::ranges::for_each(families, [](auto &family) { family = util::trim(family); });
+            static constexpr auto kShouldTrim = [](char c) {
+                return util::is_whitespace(c) || c == '\'' || c == '"';
+            };
+            std::ranges::for_each(families, [](auto &family) { family = util::trim(family, kShouldTrim); });
             return families;
         } else if constexpr (T == css::PropertyId::FontSize) {
             return get_font_size_property();

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -161,7 +161,12 @@ int main() {
     });
 
     etest::test("get_font_family_property", [] {
-        expect_property_eq<css::PropertyId::FontFamily>("abc, def", std::vector<std::string_view>{"abc", "def"});
+        using FontFamilies = std::vector<std::string_view>;
+        expect_property_eq<css::PropertyId::FontFamily>("abc, def", FontFamilies{"abc", "def"});
+        expect_property_eq<css::PropertyId::FontFamily>(R"('abc', "def")", FontFamilies{"abc", "def"});
+        expect_property_eq<css::PropertyId::FontFamily>("arial", FontFamilies{"arial"});
+        expect_property_eq<css::PropertyId::FontFamily>("'arial'", FontFamilies{"arial"});
+        expect_property_eq<css::PropertyId::FontFamily>(R"("arial")", FontFamilies{"arial"});
     });
 
     etest::test("get_font_size_property", [] {

--- a/util/string.h
+++ b/util/string.h
@@ -113,24 +113,36 @@ constexpr bool is_whitespace(char ch) {
     return std::ranges::any_of(kWsChars, [ch](char ws_ch) { return ch == ws_ch; });
 }
 
-constexpr std::string_view trim_start(std::string_view s) {
+constexpr std::string_view trim_start(std::string_view s, std::predicate<char> auto should_trim) {
     // clang-tidy says this is pointer-ish, but msvc disagrees.
     // NOLINTNEXTLINE(readability-qualified-auto)
-    auto it = std::ranges::find_if(s, [](char ch) { return !is_whitespace(ch); });
+    auto it = std::ranges::find_if(s, [&](char ch) { return !should_trim(ch); });
     s.remove_prefix(std::distance(cbegin(s), it));
     return s;
 }
 
-constexpr std::string_view trim_end(std::string_view s) {
-    auto it = std::find_if(crbegin(s), crend(s), [](char ch) { return !is_whitespace(ch); });
+constexpr std::string_view trim_start(std::string_view s) {
+    return trim_start(s, is_whitespace);
+}
+
+constexpr std::string_view trim_end(std::string_view s, std::predicate<char> auto should_trim) {
+    auto it = std::find_if(crbegin(s), crend(s), [&](char ch) { return !should_trim(ch); });
     s.remove_suffix(std::distance(crbegin(s), it));
     return s;
 }
 
-constexpr std::string_view trim(std::string_view s) {
-    s = trim_start(s);
-    s = trim_end(s);
+constexpr std::string_view trim_end(std::string_view s) {
+    return trim_end(s, is_whitespace);
+}
+
+constexpr std::string_view trim(std::string_view s, std::predicate<char> auto should_trim) {
+    s = trim_start(s, should_trim);
+    s = trim_end(s, should_trim);
     return s;
+}
+
+constexpr std::string_view trim(std::string_view s) {
+    return trim(s, is_whitespace);
 }
 
 // https://url.spec.whatwg.org/#concept-ipv4-serializer

--- a/util/string_test.cpp
+++ b/util/string_test.cpp
@@ -232,12 +232,27 @@ int main() {
         expect_eq(trim_start("\r\n"sv), ""sv);
     });
 
+    etest::test("trim start, should_trim", [] {
+        expect_eq(trim_start(" abc "sv, [](char c) { return c == ' '; }), "abc "sv);
+        expect_eq(trim_start(" abc "sv, [](char c) { return c <= 'a'; }), "bc "sv);
+        expect_eq(trim_start(" abc "sv, [](char c) { return c <= 'b'; }), "c "sv);
+        expect_eq(trim_start(" abc "sv, [](char c) { return c <= 'c'; }), ""sv);
+        expect_eq(trim_start(" abc "sv, [](char c) { return c == '\t'; }), " abc "sv);
+    });
+
     etest::test("trim end", [] {
         expect_eq(trim_end("abc "sv), "abc"sv);
         expect_eq(trim_end("53 \r\n"sv), "53"sv);
         expect_eq(trim_end("hello world!\t"sv), "hello world!"sv);
         expect_eq(trim_end(" word"sv), " word"sv);
         expect_eq(trim_end("\r\n"sv), ""sv);
+    });
+
+    etest::test("trim end, should_trim", [] {
+        expect_eq(trim_end(" abc "sv, [](char c) { return c == ' '; }), " abc"sv);
+        expect_eq(trim_end(" abc "sv, [](char c) { return c <= 'c'; }), ""sv);
+        expect_eq(trim_end(" abc "sv, [](char c) { return c == ' ' || c >= 'b'; }), " a"sv);
+        expect_eq(trim_end(" abc "sv, [](char c) { return c == '\t'; }), " abc "sv);
     });
 
     etest::test("trim", [] {
@@ -247,6 +262,13 @@ int main() {
         expect_eq(trim("\t\thello world\n"sv), "hello world"sv);
         expect_eq(trim(" a b c d "sv), "a b c d"sv);
         expect_eq(trim("\r\n"sv), ""sv);
+    });
+
+    etest::test("trim, should_trim", [] {
+        expect_eq(trim("abcba"sv, [](char c) { return c == ' '; }), "abcba"sv);
+        expect_eq(trim("abcba"sv, [](char c) { return c <= 'a'; }), "bcb"sv);
+        expect_eq(trim("abcba"sv, [](char c) { return c <= 'b'; }), "c"sv);
+        expect_eq(trim("abcba"sv, [](char c) { return c <= 'c'; }), ""sv);
     });
 
     etest::test("trim with non-ascii characters", [] {


### PR DESCRIPTION
CSS with quotes around font names, like `font-family: "Arial", serif` was being parsed as `[\"Arial\", serif]` instead of `[Arial, serif]`.