### PR TITLE
build: Explicitly disable bzlmod for now

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,9 @@
 # Bazel configuration
 # =========================================================
 
+# https://github.com/bazelbuild/bazel/issues/18958
+common --noenable_bzlmod
+
 build --enable_platform_specific_config
 build --test_env=HASTUR_ICU_DATA=external/icu-data/
 coverage --combined_report=lcov


### PR DESCRIPTION
This is flipped to enabled by default in Bazel 7 and right now most of our dependencies don't exist in any registry, so let's disable it until we decide we're ready to migrate.