### PR TITLE
ci: Combine the asan and ubsan jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,18 +32,12 @@ jobs:
             version: 14
             bazel: --config tsan
 
-          - name: clang-asan
-            os: ubuntu-22.04
-            compiler: clang
-            version: 14
-            bazel: --config asan
-
           # https://github.com/llvm/llvm-project/issues/49689
-          - name: clang-ubsan
+          - name: clang-15-asan-ubsan
             os: ubuntu-22.04
             compiler: clang
             version: 15
-            bazel: --config ubsan
+            bazel: --config asan --config ubsan
 
           - name: clang-17
             os: ubuntu-22.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 on:
   pull_request:
   workflow_dispatch:
-  push:
-    branches: [master]
 name: ci
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions


### PR DESCRIPTION
Running these two sanitizers together is fine, so let's do that to save
ourselves a job. This means we're also updating the asan job to use LLVM
15 instead of 14, but that's fine since we still use LLVM 14 for our
tsan tests.