### PR TITLE
deps/icu: Be more specific about what lib.exe we're looking for

### DIFF
--- a/third_party/icu.BUILD
+++ b/third_party/icu.BUILD
@@ -181,7 +181,11 @@ genrule(
         "uts46.nrm",
     ] + SPREP_DATA_COMPILED,
     outs = ["libicudt73l.a"],
-    cmd = r"""srcs=($(SRCS)); export PATH=$$PATH:$(location icupkg); $(location pkgdata) --entrypoint icudt73 --sourcedir $(RULEDIR) --destdir $(RULEDIR) --name icudt73l --mode static $${srcs[0]}""",
+    cmd = r"""
+        srcs=($(SRCS));
+        export PATH=$$PATH:$(location icupkg);
+        $(location pkgdata) --entrypoint icudt73 --sourcedir $(RULEDIR) --destdir $(RULEDIR) --name icudt73l --mode static $${srcs[0]}
+    """,
     tools = [
         ":icupkg",
         ":pkgdata",
@@ -196,7 +200,11 @@ genrule(
         "uts46.nrm",
     ] + SPREP_DATA_COMPILED,
     outs = ["sicudt73l.lib"],
-    cmd = r"""srcs=($(SRCS)); export PATH=$$PATH:$(location icupkg):"/$$('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -prerelease -find '**\lib.exe' | grep x64 | grep -v llvm | head -n1 | awk -F '\' 'BEGIN{OFS=FS} {$$NF=""; print}' | tr -d ':' | tr '\134' '/')"; $(location pkgdata) --entrypoint icudt73 --sourcedir $(RULEDIR) --destdir $(RULEDIR) --name icudt73l --mode static $${srcs[0]}""",
+    cmd = r"""
+        srcs=($(SRCS));
+        export PATH=$$PATH:$(location icupkg):"/$$('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -prerelease -find '**\lib.exe' | grep x64 | grep -v llvm | head -n1 | awk -F '\' 'BEGIN{OFS=FS} {$$NF=""; print}' | tr -d ':' | tr '\134' '/')";
+        $(location pkgdata) --entrypoint icudt73 --sourcedir $(RULEDIR) --destdir $(RULEDIR) --name icudt73l --mode static $${srcs[0]}
+    """,
     tools = [
         ":icupkg",
         ":pkgdata",

--- a/third_party/icu.BUILD
+++ b/third_party/icu.BUILD
@@ -202,7 +202,7 @@ genrule(
     outs = ["sicudt73l.lib"],
     cmd = r"""
         srcs=($(SRCS));
-        export PATH=$$PATH:$(location icupkg):"/$$('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -prerelease -find '**\lib.exe' | grep x64 | grep -v llvm | head -n1 | awk -F '\' 'BEGIN{OFS=FS} {$$NF=""; print}' | tr -d ':' | tr '\134' '/')";
+        export PATH=$$PATH:$(location icupkg):"/$$('C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -prerelease -find 'VC\Tools\MSVC\*\bin\Hostx64\x64\lib.exe' | grep -v llvm | head -n1 | awk -F '\' 'BEGIN{OFS=FS} {$$NF=""; print}' | tr -d ':' | tr '\134' '/')";
         $(location pkgdata) --entrypoint icudt73 --sourcedir $(RULEDIR) --destdir $(RULEDIR) --name icudt73l --mode static $${srcs[0]}
     """,
     tools = [


### PR DESCRIPTION
This shaves 5-10 minutes off of the GitHub Actions build time for
run_pkgdata_windows.

After: https://github.com/robinlinden/hastur/actions/runs/7175346860
Before: https://github.com/robinlinden/hastur/actions/runs/7066894570

I did add some debug prints to verify that this was the pattern we were getting, so this is just a faster way of finding the same `lib.exe`.