### PR TITLE
style: Fix font-size: {inherit,unset}

### DIFF
--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -437,7 +437,7 @@ int StyledNode::get_font_size_property() const {
             auto it = std::ranges::find_if(rbegin(n->properties), rend(n->properties), [](auto const &v) {
                 return v.first == css::PropertyId::FontSize;
             });
-            if (it != rend(n->properties)) {
+            if (it != rend(n->properties) && it->second != "inherit" && it->second != "unset") {
                 return {{it->second, n}};
             }
         }

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -190,6 +190,12 @@ int main() {
         expect_eq(child.get_property<css::PropertyId::FontSize>(), 10);
         expect_eq(root.get_property<css::PropertyId::FontSize>(), 50);
 
+        // inherit, unset
+        child.properties[0] = {css::PropertyId::FontSize, "unset"};
+        expect_eq(child.get_property<css::PropertyId::FontSize>(), 50);
+        child.properties[0] = {css::PropertyId::FontSize, "inherit"};
+        expect_eq(child.get_property<css::PropertyId::FontSize>(), 50);
+
         // %
         child.properties[0] = {css::PropertyId::FontSize, "100%"};
         expect_eq(child.get_property<css::PropertyId::FontSize>(), 50);


### PR DESCRIPTION
For all other properties, these keywords are handled by StyledNode::get_raw_property, but font-size is special as it needs to know the node its value originated from.