### PR TITLE
ci: Add a Clang 16 code coverage job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,33 +124,28 @@ jobs:
           path: ~/.cache/bazel
           key: coverage-${{ matrix.compiler }}-${{ matrix.version }}-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
           restore-keys: coverage-${{ matrix.compiler }}-${{ matrix.version }}-
-      - run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        if: startsWith(matrix.compiler, 'gcc')
-      - name: Install
+      - name: Setup (gcc)
         if: startsWith(matrix.compiler, 'gcc')
         run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install --no-install-recommends libgl-dev lcov gcc-${{ matrix.version }} g++-${{ matrix.version }}
-      - name: Setup
-        if: startsWith(matrix.compiler, 'gcc')
-        run: |
           echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
           echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
           echo "GCOV=gcov-${{ matrix.version }}" >> $GITHUB_ENV
-      - name: Install
+      - name: Setup (clang)
         if: startsWith(matrix.compiler, 'clang')
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{ matrix.version }} main"
           sudo apt-get update
           sudo apt-get install --no-install-recommends libgl-dev lcov clang-${{ matrix.version }} libclang-rt-${{ matrix.version }}-dev llvm-${{ matrix.version }}
+          echo "CC=clang-16" >> $GITHUB_ENV
+          echo "CXX=clang++-16" >> $GITHUB_ENV
           # See: https://github.com/actions/runner-images/issues/8659
           sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
           sudo apt-get update
           sudo apt-get install --allow-downgrades libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
-      - name: Setup
-        if: startsWith(matrix.compiler, 'clang')
-        run: echo "CC=clang-16" >> $GITHUB_ENV && echo "CXX=clang++-16" >> $GITHUB_ENV
       - name: Coverage
         run: bazel coverage ... ${{ matrix.bazel }}
       - name: Summary

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,6 +112,9 @@ jobs:
         include:
           - compiler: gcc
             version: 13
+          - compiler: clang
+            version: 16
+            bazel: --config=clang16-coverage
     steps:
       - uses: actions/checkout@v4
         with:
@@ -122,17 +125,34 @@ jobs:
           key: coverage-${{ matrix.compiler }}-${{ matrix.version }}-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
           restore-keys: coverage-${{ matrix.compiler }}-${{ matrix.version }}-
       - run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        if: startsWith(matrix.compiler, 'gcc')
       - name: Install
+        if: startsWith(matrix.compiler, 'gcc')
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends libgl-dev lcov gcc-${{ matrix.version }} g++-${{ matrix.version }}
       - name: Setup
+        if: startsWith(matrix.compiler, 'gcc')
         run: |
           echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
           echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
           echo "GCOV=gcov-${{ matrix.version }}" >> $GITHUB_ENV
+      - name: Install
+        if: startsWith(matrix.compiler, 'clang')
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{ matrix.version }} main"
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends libgl-dev lcov clang-${{ matrix.version }} libclang-rt-${{ matrix.version }}-dev llvm-${{ matrix.version }}
+          # See: https://github.com/actions/runner-images/issues/8659
+          sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
+          sudo apt-get update
+          sudo apt-get install --allow-downgrades libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
+      - name: Setup
+        if: startsWith(matrix.compiler, 'clang')
+        run: echo "CC=clang-16" >> $GITHUB_ENV && echo "CXX=clang++-16" >> $GITHUB_ENV
       - name: Coverage
-        run: bazel coverage ...
+        run: bazel coverage ... ${{ matrix.bazel }}
       - name: Summary
         run: lcov --summary bazel-out/_coverage/_coverage_report.dat
       - name: Upload

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,9 +101,17 @@ jobs:
           echo "<html><body><h1>Example</h1><p>This is an example page.</p></body></html>" >example.html
           bazel run browser:tui file://$(pwd)/example.html ${{ matrix.bazel }}
 
-  linux-gcc-13-coverage:
+  coverage:
+    name: linux-${{ matrix.compiler }}-${{ matrix.version }}-coverage
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - compiler: gcc
+            version: 13
     steps:
       - uses: actions/checkout@v4
         with:
@@ -111,18 +119,18 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.cache/bazel
-          key: coverage13-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
-          restore-keys: coverage13-
+          key: coverage-${{ matrix.compiler }}-${{ matrix.version }}-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
+          restore-keys: coverage-${{ matrix.compiler }}-${{ matrix.version }}-
       - run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - name: Install
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends libgl-dev lcov gcc-13 g++-13
+          sudo apt-get install --no-install-recommends libgl-dev lcov gcc-${{ matrix.version }} g++-${{ matrix.version }}
       - name: Setup
         run: |
-          echo "CC=gcc-13" >> $GITHUB_ENV
-          echo "CXX=g++-13" >> $GITHUB_ENV
-          echo "GCOV=gcov-13" >> $GITHUB_ENV
+          echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "GCOV=gcov-${{ matrix.version }}" >> $GITHUB_ENV
       - name: Coverage
         run: bazel coverage ...
       - name: Summary


### PR DESCRIPTION
I looked into this like half a year and dismissed it due to a lot of weird coverage misses that couldn't happen. Well, now Clang outperforms gcc in spite of those things due to gcc's branch coverage appearing to be pretty broken. Maybe we're missing some flag in gcc to make it produce more accurate coverage, but I didn't see anything obvious.