### PR TITLE
build: Use a more correct workaround for the slow cross-compile linking

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -106,10 +106,8 @@ build:linux-aarch64-musl --copt=-fPIC
 build:linux-aarch64-musl --dynamic_mode=off
 # TODO(robinlinden): asio assumes __GLIBC__ is defined.
 build:linux-aarch64-musl --copt=-Wno-error=undef
-# --incompatible_sandbox_hermetic_tmp (defaults to true in Bazel 7) leads to
-# incredibly long link times.
 # See: https://github.com/uber/hermetic_cc_toolchain/issues/134
-build:linux-aarch64-musl --noincompatible_sandbox_hermetic_tmp
+build:linux-aarch64-musl --sandbox_add_mount_pair=/tmp
 
 
 # Fuzzing options


### PR DESCRIPTION
The kind people over at uber/hermetic_cc_toolchain suggested this as a nicer alternative to my completely switching back to the deprecated behaviour of `sandbox_hermetic_tmp`.