### PR TITLE
deps/sfml: Fix macOS build, depending on window_macos

### DIFF
--- a/browser/gui/BUILD
+++ b/browser/gui/BUILD
@@ -31,9 +31,7 @@ cc_binary(
         "@imgui-sfml",
         "@sfml//:graphics",
         "@sfml//:system",
+        "@sfml//:window",
         "@spdlog",
-    ] + select({
-        "@platforms//os:macos": ["@sfml//:window_macos"],
-        "//conditions:default": ["@sfml//:window"],
-    }),
+    ],
 )

--- a/gfx/BUILD
+++ b/gfx/BUILD
@@ -107,8 +107,6 @@ cc_binary(
         ":sfml",
         "//type:sfml",
         "@sfml//:graphics",
-    ] + select({
-        "@platforms//os:macos": ["@sfml//:window_macos"],
-        "//conditions:default": ["@sfml//:window"],
-    }),
+        "@sfml//:window",
+    ],
 )

--- a/img/BUILD
+++ b/img/BUILD
@@ -79,8 +79,6 @@ cc_binary(
         "//gfx:sfml",
         "//type:sfml",
         "@sfml//:graphics",
-    ] + select({
-        "@platforms//os:macos": ["@sfml//:window_macos"],
-        "//conditions:default": ["@sfml//:window"],
-    }),
+        "@sfml//:window",
+    ],
 )

--- a/third_party/imgui-sfml.BUILD
+++ b/third_party/imgui-sfml.BUILD
@@ -19,8 +19,6 @@ cc_library(
         "@imgui",
         "@sfml//:graphics",
         "@sfml//:system",
-    ] + select({
-        "@platforms//os:macos": ["@sfml//:window_macos"],
-        "//conditions:default": ["@sfml//:window"],
-    }),
+        "@sfml//:window",
+    ],
 )

--- a/third_party/sfml.BUILD
+++ b/third_party/sfml.BUILD
@@ -120,9 +120,8 @@ objc_library(
             "src/SFML/Window/*.cpp",
             "src/SFML/Window/*.hpp",
             "src/SFML/Window/OSX/*.cpp",
+            "src/SFML/Window/OSX/*.h",
             "src/SFML/Window/OSX/*.hpp",
-            "src/SFML/Window/OSX/*.m",
-            "src/SFML/Window/OSX/*.mm",
         ],
         exclude = [
             "src/SFML/Window/EGLCheck.cpp",
@@ -132,14 +131,31 @@ objc_library(
         ],
     ),
     hdrs = glob(["include/SFML/Window/*"]),
-    copts = ["-Iexternal/sfml/src/"],
+    copts = [
+        "-Iexternal/sfml/src/",
+        "-frtti",
+    ],
     defines = SFML_DEFINES,
+    includes = ["include/"],
+    non_arc_srcs = glob([
+        "src/SFML/Window/OSX/*.m",
+        "src/SFML/Window/OSX/*.mm",
+    ]),
+    sdk_frameworks = [
+        "AppKit",
+        "Carbon",
+        "Foundation",
+        "IOKit",
+    ],
     target_compatible_with = select({
         "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     visibility = ["//visibility:public"],
-    deps = [":system"],
+    deps = [
+        ":sf_glad",
+        ":system",
+    ],
 )
 
 cc_library(

--- a/third_party/sfml.BUILD
+++ b/third_party/sfml.BUILD
@@ -57,8 +57,18 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
+alias(
     name = "window",
+    actual = select({
+        "@platforms//os:linux": ":window_cc",
+        "@platforms//os:macos": ":window_objc",
+        "@platforms//os:windows": ":window_cc",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "window_cc",
     srcs = glob(
         include = [
             "src/SFML/Window/*.cpp",
@@ -98,7 +108,6 @@ cc_library(
         "@platforms//os:macos": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    visibility = ["//visibility:public"],
     deps = [
         ":sf_glad",
         ":system",
@@ -114,7 +123,7 @@ cc_library(
 )
 
 objc_library(
-    name = "window_macos",
+    name = "window_objc",
     srcs = glob(
         include = [
             "src/SFML/Window/*.cpp",
@@ -151,7 +160,6 @@ objc_library(
         "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    visibility = ["//visibility:public"],
     deps = [
         ":sf_glad",
         ":system",


### PR DESCRIPTION
non_arc_srcs:
```
ERROR: /private/var/tmp/_bazel_runner/62407b805294e85635cf7dcde40ab730/external/sfml/BUILD.bazel:126:13: Compiling src/SFML/Window/OSX/ClipboardImpl.mm failed: (Exit 1): wrapped_clang_pp failed: error executing ObjcCompile command (from target @@sfml//:window_objc) external/local_config_apple_cc/wrapped_clang_pp -target x86_64-apple-macosx13.3 '-stdlib=libc++' '-std=gnu++14' '-D_FORTIFY_SOURCE=1' -fstack-protector -fcolor-diagnostics -Wall -Wthread-safety ... (remaining 53 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/sfml/src/SFML/Window/OSX/ClipboardImpl.mm:65:11: error: 'release' is unavailable: not available in automatic reference counting mode
    [data release];
          ^
/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include/objc/NSObject.h:37:1: note: 'release' has been explicitly marked unavailable here
- (oneway void)release OBJC_ARC_UNAVAILABLE;
^
external/sfml/src/SFML/Window/OSX/ClipboardImpl.mm:65:11: error: ARC forbids explicit message send of 'release'
    [data release];
     ~~~~ ^
2 errors generated.
Error in child process '/usr/bin/xcrun'. 1
```

missing header:
```
ERROR: /private/var/tmp/_bazel_runner/62407b805294e85635cf7dcde40ab730/external/sfml/BUILD.bazel:109:13: Compiling src/SFML/Window/OSX/cpp_objc_conversion.mm failed: (Exit 1): wrapped_clang_pp failed: error executing ObjcCompile command (from target @@sfml//:window_objc) external/local_config_apple_cc/wrapped_clang_pp -target x86_64-apple-macosx13.3 '-stdlib=libc++' '-std=gnu++14' '-D_FORTIFY_SOURCE=1' -fstack-protector -fcolor-diagnostics -Wall -Wthread-safety ... (remaining 48 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/sfml/src/SFML/Window/OSX/cpp_objc_conversion.mm:31:9: fatal error: 'SFML/Window/OSX/cpp_objc_conversion.h' file not found
#import <SFML/Window/OSX/cpp_objc_conversion.h>
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
Error in child process '/usr/bin/xcrun'. 1
```

frameworks:
```
 ERROR: /Users/runner/work/hastur/hastur/img/BUILD:69:10: Linking img/img_example failed: (Exit 1): cc_wrapper.sh failed: error executing CppLink command (from target //img:img_example) external/local_config_apple_cc/cc_wrapper.sh @bazel-out/darwin_x86_64-fastbuild/bin/img/img_example-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
Undefined symbols for architecture x86_64:
  "_CGDisplayCopyAllDisplayModes", referenced from:
      sf::priv::VideoModeImpl::getFullscreenModes() in libwindow_objc.a(VideoModeImpl.o)
  "_CGDisplayCopyDisplayMode", referenced from:
      sf::priv::VideoModeImpl::getDesktopMode() in libwindow_objc.a(VideoModeImpl.o)
      sf::priv::displayBitsPerPixel(unsigned int) in libwindow_objc.a(cg_sf_conversion.o)
  "_CGDisplayModeCopyPixelEncoding", referenced from:
      sf::priv::modeBitsPerPixel(CGDisplayMode*) in libwindow_objc.a(cg_sf_conversion.o)
  "_CGDisplayModeGetHeight", referenced from:
      sf::priv::convertCGModeToSFMode(CGDisplayMode*) in libwindow_objc.a(cg_sf_conversion.o)
  "_CGDisplayModeGetWidth", referenced from:
      sf::priv::convertCGModeToSFMode(CGDisplayMode*) in libwindow_objc.a(cg_sf_conversion.o)
  "_CGDisplayModeRelease", referenced from:
      sf::priv::VideoModeImpl::getDesktopMode() in libwindow_objc.a(VideoModeImpl.o)
      sf::priv::displayBitsPerPixel(unsigned int) in libwindow_objc.a(cg_sf_conversion.o)
  "_CGDisplayPixelsHigh", referenced from:
      -[SFWindowController screenHeight] in libwindow_objc.a(SFWindowController.o)
  "_CGMainDisplayID", referenced from:
      sf::priv::VideoModeImpl::getFullscreenModes() in libwindow_objc.a(VideoModeImpl.o)
      sf::priv::VideoModeImpl::getDesktopMode() in libwindow_objc.a(VideoModeImpl.o)
  "_IOHIDDeviceCopyMatchingElements", referenced from:
      sf::priv::JoystickImpl::open(unsigned int) in libwindow_objc.a(JoystickImpl.o)
      sf::priv::HIDInputManager::loadKeyboard(__IOHIDDevice*) in libwindow_objc.a(HIDInputManager.o)
  "_IOHIDDeviceGetProperty", referenced from:
      (anonymous namespace)::getDeviceString(__IOHIDDevice*, __CFString const*, unsigned int) in libwindow_objc.a(JoystickImpl.o)
      (anonymous namespace)::getDeviceUint(__IOHIDDevice*, __CFString const*, unsigned int) in libwindow_objc.a(JoystickImpl.o)
      sf::priv::HIDInputManager::getLocationID(__IOHIDDevice*) in libwindow_objc.a(HIDInputManager.o)
  "_IOHIDDeviceGetValue", referenced from:
      sf::priv::JoystickImpl::update() in libwindow_objc.a(JoystickImpl.o)
      sf::priv::HIDInputManager::isPressed(std::__1::vector<__IOHIDElement*, std::__1::allocator<__IOHIDElement*>>&) in libwindow_objc.a(HIDInputManager.o)
  "_IOHIDElementGetCollectionType", referenced from:
      sf::priv::JoystickImpl::open(unsigned int) in libwindow_objc.a(JoystickImpl.o)
  "_IOHIDElementGetDevice", referenced from:
      sf::priv::JoystickImpl::update() in libwindow_objc.a(JoystickImpl.o)
      sf::priv::HIDInputManager::isPressed(std::__1::vector<__IOHIDElement*, std::__1::allocator<__IOHIDElement*>>&) in libwindow_objc.a(HIDInputManager.o)
  "_IOHIDElementGetLogicalMax", referenced from:
      sf::priv::JoystickImpl::open(unsigned int) in libwindow_objc.a(JoystickImpl.o)
  "_IOHIDElementGetLogicalMin", referenced from:
      sf::priv::JoystickImpl::open(unsigned int) in libwindow_objc.a(JoystickImpl.o)
  "_IOHIDElementGetPhysicalMax", referenced from:
      sf::priv::JoystickImpl::update() in libwindow_objc.a(JoystickImpl.o)
  "_IOHIDElementGetPhysicalMin", referenced from:
      sf::priv::JoystickImpl::update() in libwindow_objc.a(JoystickImpl.o)
  "_IOHIDElementGetUsage", referenced from:
      sf::priv::JoystickImpl::open(unsigned int) in libwindow_objc.a(JoystickImpl.o)
      (anonymous namespace)::JoystickButtonSortPredicate(__IOHIDElement*, __IOHIDElement*) in libwindow_objc.a(JoystickImpl.o)
      sf::priv::HIDInputManager::loadKey(__IOHIDElement*) in libwindow_objc.a(HIDInputManager.o)
  "_IOHIDElementGetUsagePage", referenced from:
      sf::priv::JoystickImpl::open(unsigned int) in libwindow_objc.a(JoystickImpl.o)
      sf::priv::HIDInputManager::loadKeyboard(__IOHIDDevice*) in libwindow_objc.a(HIDInputManager.o)
  "_IOHIDManagerClose", referenced from:
      sf::priv::HIDJoystickManager::~HIDJoystickManager() in libwindow_objc.a(HIDJoystickManager.o)
  "_IOHIDManagerCopyDevices", referenced from:
      sf::priv::HIDInputManager::copyDevices(unsigned int, unsigned int) in libwindow_objc.a(HIDInputManager.o)
      sf::priv::HIDJoystickManager::copyJoysticks() in libwindow_objc.a(HIDJoystickManager.o)
  "_IOHIDManagerCreate", referenced from:
      sf::priv::HIDInputManager::HIDInputManager() in libwindow_objc.a(HIDInputManager.o)
      sf::priv::HIDJoystickManager::HIDJoystickManager() in libwindow_objc.a(HIDJoystickManager.o)
  "_IOHIDManagerOpen", referenced from:
      sf::priv::HIDInputManager::HIDInputManager() in libwindow_objc.a(HIDInputManager.o)
      sf::priv::HIDJoystickManager::HIDJoystickManager() in libwindow_objc.a(HIDJoystickManager.o)
  "_IOHIDManagerRegisterDeviceMatchingCallback", referenced from:
      sf::priv::HIDJoystickManager::HIDJoystickManager() in libwindow_objc.a(HIDJoystickManager.o)
      sf::priv::HIDJoystickManager::~HIDJoystickManager() in libwindow_objc.a(HIDJoystickManager.o)
  "_IOHIDManagerRegisterDeviceRemovalCallback", referenced from:
      sf::priv::HIDJoystickManager::HIDJoystickManager() in libwindow_objc.a(HIDJoystickManager.o)
      sf::priv::HIDJoystickManager::~HIDJoystickManager() in libwindow_objc.a(HIDJoystickManager.o)
  "_IOHIDManagerScheduleWithRunLoop", referenced from:
      sf::priv::HIDJoystickManager::HIDJoystickManager() in libwindow_objc.a(HIDJoystickManager.o)
  "_IOHIDManagerSetDeviceMatching", referenced from:
      sf::priv::HIDInputManager::copyDevices(unsigned int, unsigned int) in libwindow_objc.a(HIDInputManager.o)
  "_IOHIDManagerSetDeviceMatchingMultiple", referenced from:
      sf::priv::HIDJoystickManager::HIDJoystickManager() in libwindow_objc.a(HIDJoystickManager.o)
  "_IOHIDManagerUnscheduleFromRunLoop", referenced from:
      sf::priv::HIDJoystickManager::~HIDJoystickManager() in libwindow_objc.a(HIDJoystickManager.o)
  "_IOHIDValueGetIntegerValue", referenced from:
      sf::priv::JoystickImpl::update() in libwindow_objc.a(JoystickImpl.o)
      sf::priv::HIDInputManager::isPressed(std::__1::vector<__IOHIDElement*, std::__1::allocator<__IOHIDElement*>>&) in libwindow_objc.a(HIDInputManager.o)
  "_IOHIDValueGetScaledValue", referenced from:
      sf::priv::JoystickImpl::update() in libwindow_objc.a(JoystickImpl.o)
  "_KBGetLayoutType", referenced from:
      ___cxx_global_var_init in libwindow_objc.a(HIDInputManager.o)
  "_LMGetKbdType", referenced from:
      sf::priv::HIDInputManager::buildMappings() in libwindow_objc.a(HIDInputManager.o)
      ___cxx_global_var_init in libwindow_objc.a(HIDInputManager.o)
  "_NSApp", referenced from:
      sf::priv::WindowImplCocoa::setUpProcess() in libwindow_objc.a(WindowImplCocoa.o)
      sf::priv::WindowImplCocoa::~WindowImplCocoa() in libwindow_objc.a(WindowImplCocoa.o)
      +[SFApplication processEvent] in libwindow_objc.a(SFApplication.o)
      +[SFApplication setUpMenuBar] in libwindow_objc.a(SFApplication.o)
      +[SFApplication newAppleMenu] in libwindow_objc.a(SFApplication.o)
      -[SFApplication bringAllToFront:] in libwindow_objc.a(SFApplication.o)
      -[SFApplicationDelegate applicationShouldTerminate:] in libwindow_objc.a(SFApplicationDelegate.o)
      ...
     (maybe you meant: __OBJC_LABEL_PROTOCOL_$_NSApplicationDelegate, __OBJC_PROTOCOL_$_NSApplicationDelegate )
  "_NSRectFill", referenced from:
      -[SFBlackView drawRect:] in libwindow_objc.a(SFWindowController.o)
  "_NSWindowDidBecomeKeyNotification", referenced from:
      -[SFOpenGLView finishInit] in libwindow_objc.a(SFOpenGLView.o)
  "_NSWindowDidChangeScreenNotification", referenced from:
      -[SFOpenGLView finishInit] in libwindow_objc.a(SFOpenGLView.o)
  "_NSWindowDidChangeScreenProfileNotification", referenced from:
      -[SFOpenGLView finishInit] in libwindow_objc.a(SFOpenGLView.o)
  "_NSWindowDidResignKeyNotification", referenced from:
      -[SFOpenGLView finishInit] in libwindow_objc.a(SFOpenGLView.o)
  "_NSWindowWillCloseNotification", referenced from:
      -[SFOpenGLView finishInit] in libwindow_objc.a(SFOpenGLView.o)
  "_OBJC_CLASS_$_NSApplication", referenced from:
      objc-class-ref in libwindow_objc.a(WindowImplCocoa.o)
      _OBJC_CLASS_$_SFApplication in libwindow_objc.a(SFApplication.o)
  "_OBJC_CLASS_$_NSColor", referenced from:
      objc-class-ref in libwindow_objc.a(SFWindowController.o)
  "_OBJC_CLASS_$_NSCursor", referenced from:
      objc-class-ref in libwindow_objc.a(CursorImpl.o)
      objc-class-ref in libwindow_objc.a(WindowImplCocoa.o)
      objc-class-ref in libwindow_objc.a(SFOpenGLView.o)
  "_OBJC_CLASS_$_NSImage", referenced from:
      objc-class-ref in libwindow_objc.a(CursorImpl.o)
      objc-class-ref in libwindow_objc.a(SFWindowController.o)
  "_OBJC_CLASS_$_NSMenu", referenced from:
      objc-class-ref in libwindow_objc.a(SFApplication.o)
      objc-class-ref in libwindow_objc.a(SFWindowController.o)
  "_OBJC_CLASS_$_NSMenuItem", referenced from:
      objc-class-ref in libwindow_objc.a(SFApplication.o)
  "_OBJC_CLASS_$_NSOpenGLContext", referenced from:
      objc-class-ref in libwindow_objc.a(SFContext.o)
  "_OBJC_CLASS_$_NSOpenGLPixelFormat", referenced from:
      objc-class-ref in libwindow_objc.a(SFContext.o)
  "_OBJC_CLASS_$_NSOpenGLView", referenced from:
      objc-class-ref in libwindow_objc.a(SFContext.o)
      _OBJC_CLASS_$_SFOpenGLView in libwindow_objc.a(SFOpenGLView.o)
  "_OBJC_CLASS_$_NSResponder", referenced from:
      _OBJC_CLASS_$_SFWindowController in libwindow_objc.a(SFWindowController.o)
      _OBJC_CLASS_$_SFSilentResponder in libwindow_objc.a(SFSilentResponder.o)
  "_OBJC_CLASS_$_NSScreen", referenced from:
      objc-class-ref in libwindow_objc.a(WindowImplCocoa.o)
      objc-class-ref in libwindow_objc.a(cg_sf_conversion.o)
      objc-class-ref in libwindow_objc.a(SFWindowController.o)
      objc-class-ref in libwindow_objc.a(SFOpenGLView.o)
  "_OBJC_CLASS_$_NSTextView", referenced from:
      objc-class-ref in libwindow_objc.a(SFOpenGLView.o)
  "_OBJC_CLASS_$_NSTrackingArea", referenced from:
      objc-class-ref in libwindow_objc.a(SFOpenGLView.o)
  "_OBJC_CLASS_$_NSView", referenced from:
      objc-class-ref in libwindow_objc.a(WindowImplCocoa.o)
      _OBJC_CLASS_$_SFBlackView in libwindow_objc.a(SFWindowController.o)
  "_OBJC_CLASS_$_NSWindow", referenced from:
      objc-class-ref in libwindow_objc.a(WindowImplCocoa.o)
      objc-class-ref in libwindow_objc.a(SFContext.o)
      _OBJC_CLASS_$_SFWindow in libwindow_objc.a(SFWindow.o)
      __OBJC_$_CATEGORY_NSWindow_$_SFML in libwindow_objc.a(SFWindow.o)
  "_OBJC_METACLASS_$_NSApplication", referenced from:
      _OBJC_METACLASS_$_SFApplication in libwindow_objc.a(SFApplication.o)
  "_OBJC_METACLASS_$_NSOpenGLView", referenced from:
      _OBJC_METACLASS_$_SFOpenGLView in libwindow_objc.a(SFOpenGLView.o)
  "_OBJC_METACLASS_$_NSResponder", referenced from:
      _OBJC_METACLASS_$_SFWindowController in libwindow_objc.a(SFWindowController.o)
      _OBJC_METACLASS_$_SFSilentResponder in libwindow_objc.a(SFSilentResponder.o)
  "_OBJC_METACLASS_$_NSView", referenced from:
      _OBJC_METACLASS_$_SFBlackView in libwindow_objc.a(SFWindowController.o)
  "_OBJC_METACLASS_$_NSWindow", referenced from:
      _OBJC_METACLASS_$_SFWindow in libwindow_objc.a(SFWindow.o)
  "_TISCopyCurrentKeyboardLayoutInputSource", referenced from:
      sf::priv::HIDInputManager::buildMappings() in libwindow_objc.a(HIDInputManager.o)
  "_TISGetInputSourceProperty", referenced from:
      sf::priv::HIDInputManager::buildMappings() in libwindow_objc.a(HIDInputManager.o)
  "_UCKeyTranslate", referenced from:
      sf::priv::HIDInputManager::buildMappings() in libwindow_objc.a(HIDInputManager.o)
  "typeinfo for sf::priv::WindowImpl", referenced from:
      typeinfo for sf::priv::WindowImplCocoa in libwindow_objc.a(WindowImplCocoa.o)
  "typeinfo for sf::priv::GlContext", referenced from:
      typeinfo for sf::priv::SFContext in libwindow_objc.a(SFContext.o)
  "_kTISNotifySelectedKeyboardInputSourceChanged", referenced from:
      sf::priv::HIDInputManager::HIDInputManager() in libwindow_objc.a(HIDInputManager.o)
  "_kTISPropertyUnicodeKeyLayoutData", referenced from:
      sf::priv::HIDInputManager::buildMappings() in libwindow_objc.a(HIDInputManager.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Error in child process '/usr/bin/xcrun'. 1
```

rtti:
```
ERROR: /Users/runner/work/hastur/hastur/img/BUILD:69:10: Linking img/img_example failed: (Exit 1): cc_wrapper.sh failed: error executing CppLink command (from target //img:img_example) external/local_config_apple_cc/cc_wrapper.sh @bazel-out/darwin_x86_64-fastbuild/bin/img/img_example-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
Undefined symbols for architecture x86_64:
  "typeinfo for sf::priv::WindowImpl", referenced from:
      typeinfo for sf::priv::WindowImplCocoa in libwindow_objc.a(WindowImplCocoa.o)
  "typeinfo for sf::priv::GlContext", referenced from:
      typeinfo for sf::priv::SFContext in libwindow_objc.a(SFContext.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Error in child process '/usr/bin/xcrun'. 1
```