### PR TITLE
deps: Give the Python requirements.txt-check a more generous timeout

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,7 +1,10 @@
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 
+# //third_party:requirements_test ocasionally times out on slower machines (like
+# when running on GH Actions), so let's give it a generous timeout.
 compile_pip_requirements(
     name = "requirements",
+    timeout = "moderate",
     requirements_in = "requirements.in",
     requirements_txt = "requirements.txt",
 )


### PR DESCRIPTION
This is a workaround for the occasional timeouts in the clang-cl job on GH Actions.