### PR TITLE
ci: Switch the code coverage status to informational-only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
+codecov:
+  notify:
+    # Wait for both coverage jobs to finish so we don't first get a partial
+    # coverage report and then, potentially quite a while later, it's updated to
+    # reflect the (sort of) actual coverage, which could be confusing.
+    after_n_builds: 2
+
 # https://docs.codecov.com/docs/pull-request-comments#disable-comment
 comment: false
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,16 @@
 # https://docs.codecov.com/docs/pull-request-comments#disable-comment
 comment: false
 
+# TODO(robinlinden): We don't want to manually have to check that tests cover new code.
+#
+# The coverage CI status check is only informational for now due to Bazel 7
+# switching to branch coverage with gcc and gcc appearing to not generate
+# reliable coverage reports when run in branch-coverage mode.
 coverage:
   status:
     project:
       default:
-        # Allow coverage to fluctuate a bit. This is mostly to work around gcc
-        # not always reporting e.g. functions' closing braces or lambda variable
-        # declarations as covered, leading to "indirect changes" that really
-        # aren't changes at all.
-        threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
We can't really use this to enforce tests being added due to how unreliable the coverage detection has become after the Bazel 7 update.

I'll keep looking into this, but we can't really keep it enabled when it can't even properly detect coverage for boring functions with no branches and keeps randomly flipping coverage for files not touched in a PR between partial and full coverage.

![image](https://github.com/robinlinden/hastur/assets/8304462/23c28302-4a4b-4ff8-afb2-1cda9fe8bea8)
