### PR TITLE
ci: Use a Codecov upload token for coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,7 +154,7 @@ jobs:
         run: |
           wget --no-verbose --output-document=codecov https://github.com/codecov/uploader/releases/download/v0.7.1/codecov-linux
           chmod +x codecov
-          ./codecov -Z -f bazel-out/_coverage/_coverage_report.dat
+          ./codecov --token ${{ secrets.CODECOV_TOKEN }} -Z -f bazel-out/_coverage/_coverage_report.dat
 
   linux-gcc-13-no-exceptions:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This should resolve the coverage upload step being flaky.

```
['error'] There was an error running the uploader: Error uploading to
https://codecov.io: Error: There was an error fetching the storage URL
during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build
via Github Actions API. Please upload with the Codecov repository upload
token to resolve issue.', code='not_found')}
```

It should be noted that this secret is only for uploading reports to Codecov and has nothing to do with this repository other than letting Codecov know that the report's from us.

Fixes #797 (probably!)