### PR TITLE
build: Add more cross-compilation configurations

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -100,15 +100,28 @@ build:clang-tidy --build_tag_filters=-no-clang-tidy
 # Cross-compilation
 # =========================================================
 
+# See: https://github.com/uber/hermetic_cc_toolchain/issues/134
+build:zig-cross --sandbox_add_mount_pair=/tmp
+build:zig-cross --dynamic_mode=off
+
+build:linux-aarch64-musl --config=zig-cross
 build:linux-aarch64-musl --platforms=@zig_sdk//platform:linux_arm64
 build:linux-aarch64-musl --extra_toolchains=@zig_sdk//toolchain:linux_arm64_musl
 build:linux-aarch64-musl --copt=-fPIC
-build:linux-aarch64-musl --dynamic_mode=off
 # TODO(robinlinden): asio assumes __GLIBC__ is defined.
 build:linux-aarch64-musl --copt=-Wno-error=undef
-# See: https://github.com/uber/hermetic_cc_toolchain/issues/134
-build:linux-aarch64-musl --sandbox_add_mount_pair=/tmp
 
+build:macos-amd64 --config=zig-cross
+build:macos-amd64 --platforms=@zig_sdk//platform:darwin_amd64
+build:macos-amd64 --extra_toolchains=@zig_sdk//toolchain:darwin_amd64
+
+build:macos-aarch64 --config=zig-cross
+build:macos-aarch64 --platforms=@zig_sdk//platform:darwin_aarch64
+build:macos-aarch64 --extra_toolchains=@zig_sdk//toolchain:darwin_arm64
+
+build:windows-amd64 --config=zig-cross
+build:windows-amd64 --platforms=@zig_sdk//platform:windows_amd64
+build:windows-amd64 --extra_toolchains=@zig_sdk//toolchain:windows_amd64
 
 # Fuzzing options
 # =========================================================


### PR DESCRIPTION
I tested that the Windows binaries produced by this actually run on Windows. For the macOS configurations, I just checked them w/ `file bazel-bin/util/crc32_test` to make sure that Bazel produced what I expected, but I didn't run any of them.