### PR TITLE
browser/gui: Log page navigations

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -447,6 +447,7 @@ int App::run() {
 }
 
 void App::navigate() {
+    spdlog::info("Navigating to '{}'", url_buf_);
     window_.setIcon(16, 16, kBrowserIcon.data());
     page_loaded_ = false;
     auto uri = uri::Uri::parse(url_buf_, engine_.uri());


### PR DESCRIPTION
This is helpful when looking back at old logs and trying to work out what page caused what prints. :P