### PR TITLE
build: Simplify cross-compilation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -102,6 +102,13 @@ build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
 # See: https://github.com/uber/hermetic_cc_toolchain/issues/134
 build:zig-cross --sandbox_add_mount_pair=/tmp
 build:zig-cross --dynamic_mode=off
+# TODO(robinlinden): Make this transitive so we can tag the no-cross targets
+#                    instead of everything depending on no-cross targets.
+# * icu's pkgdata stuff doesn't work w/ cross-compilation.
+# * sfml links against host libraries: GL, X11.
+# * py_test targets have host dependencies.
+build:zig-cross --build_tag_filters=-no-cross
+build:zig-cross --test_tag_filters=-no-cross
 
 build:linux-aarch64-musl --config=zig-cross
 build:linux-aarch64-musl --platforms=@zig_sdk//platform:linux_arm64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,11 +177,7 @@ jobs:
       - run: sudo update-binfmts --enable qemu-aarch64
       - run: wget --no-verbose --output-document=bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64 && chmod +x bazelisk
       - run: echo "build --config=linux-aarch64-musl" >.bazelrc.local
-      # TODO(robinlinden): Improve. We shouldn't be excluding targets like this.
-      # Include all targets except for
-      # * py_test targets: not fully statically linked
-      # * targets that depend on sfml: it pulls in host dependencies.
-      - run: ./bazelisk test --skip_incompatible_explicit_targets -- $(bazel query '... except (kind("py_test", ...) union rdeps(..., @sfml//:window) union rdeps(..., @icu//:common))')
+      - run: ./bazelisk test ...
       - name: Run tui
         run: |
           echo "<html><body><h1>Example</h1><p>This is an example page.</p></body></html>" >example.html

--- a/browser/BUILD
+++ b/browser/BUILD
@@ -1,6 +1,7 @@
 alias(
     name = "browser",
     actual = "//browser/gui",
+    tags = ["no-cross"],
     visibility = ["//visibility:public"],
 )
 

--- a/browser/gui/BUILD
+++ b/browser/gui/BUILD
@@ -8,6 +8,7 @@ cc_binary(
         "*.h",
     ]),
     copts = HASTUR_COPTS,
+    tags = ["no-cross"],
     visibility = ["//visibility:public"],
     deps = [
         "//css",

--- a/gfx/BUILD
+++ b/gfx/BUILD
@@ -72,6 +72,7 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
+    tags = ["no-cross"],
     visibility = ["//visibility:public"],
     deps = [
         ":gfx",
@@ -99,6 +100,7 @@ cc_binary(
     name = "gfx_example",
     srcs = ["gfx_example.cpp"],
     copts = HASTUR_COPTS,
+    tags = ["no-cross"],
     deps = [
         ":gfx",
         ":opengl",

--- a/img/BUILD
+++ b/img/BUILD
@@ -70,6 +70,7 @@ cc_binary(
     name = "img_example",
     srcs = ["img_example.cpp"],
     copts = HASTUR_COPTS,
+    tags = ["no-cross"],
     deps = [
         ":gif",
         ":png",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -7,6 +7,7 @@ compile_pip_requirements(
     timeout = "moderate",
     requirements_in = "requirements.in",
     requirements_txt = "requirements.txt",
+    tags = ["no-cross"],
 )
 
 test_suite(

--- a/type/BUILD
+++ b/type/BUILD
@@ -40,6 +40,7 @@ cc_library(
     srcs = ["sfml.cpp"],
     hdrs = ["sfml.h"],
     copts = SFML_TYPE_COPTS,
+    tags = ["no-cross"],
     visibility = ["//visibility:public"],
     deps = [
         ":type",

--- a/url/BUILD
+++ b/url/BUILD
@@ -8,6 +8,7 @@ cc_import(
         "@platforms//os:windows": "@icu//:sicudt74l.lib",
         "//conditions:default": "@icu//:libicudt74l.a",
     }),
+    tags = ["no-cross"],
     visibility = ["//visibility:private"],
     alwayslink = True,
 )
@@ -30,6 +31,7 @@ cc_library(
     ],
     hdrs = ["url.h"],
     copts = HASTUR_COPTS,
+    tags = ["no-cross"],
     visibility = ["//visibility:public"],
     deps = [
         ":icudata",
@@ -54,6 +56,7 @@ cc_test(
         "//conditions:default": [],
     }),
     data = ["@wpt//:url/resources/urltestdata.json"],
+    tags = ["no-cross"],
     deps = [
         ":url",
         "//etest",
@@ -68,6 +71,7 @@ cc_fuzz_test(
     srcs = ["url_fuzz_test.cpp"],
     copts = HASTUR_COPTS,
     corpus = glob(["url_fuzz_test_corpus/**"]),
+    tags = ["no-cross"],
     target_compatible_with = HASTUR_FUZZ_PLATFORMS,
     deps = [":url"],
 )


### PR DESCRIPTION
It's now possible to build for aarch64 and friends without manually excluding all targets that can't yet be cross-compiled.