### PR TITLE
deps/imgui-sfml: Fix crash due to missing glad-init

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -167,6 +167,7 @@ http_archive(
         # Use glad for OpenGL instead of the system OpenGL headers.
         "sed -i'' -e /OpenGL.hpp/d imgui-SFML.cpp",
         "sed -i'' -e '4i\\\n#include <glad/gl.h>' imgui-SFML.cpp",
+        "sed -i'' -e '277i\\\n\\\tif (gladLoaderLoadGL() == 0) return false;' imgui-SFML.cpp",
     ],
     sha256 = "b1195ca1210dd46c8049cfc8cae7f31cd34f1591da7de1c56297b277ac9c5cc0",
     strip_prefix = "imgui-sfml-2.6",

--- a/third_party/imgui-sfml.BUILD
+++ b/third_party/imgui-sfml.BUILD
@@ -1,12 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
-# TODO(robinlinden): False positive layering check error. Related to glad being
-# a local_repository? See: bazel-out/k8-fastbuild/bin/external/glad/glad.cppmap
-#
-# external/imgui-sfml/imgui-SFML.cpp:4:10: error: module imgui-sfml//:imgui-sfml
-# does not depend on a module exporting 'glad/gl.h'
-package(features = ["-layering_check"])
-
 cc_library(
     name = "imgui-sfml",
     srcs = ["imgui-SFML.cpp"],

--- a/third_party/sfml.BUILD
+++ b/third_party/sfml.BUILD
@@ -93,6 +93,7 @@ cc_library(
     hdrs = glob(["include/SFML/Window/*"]),
     copts = ["-Iexternal/sfml/src/"],
     defines = SFML_DEFINES,
+    implementation_deps = [":sf_glad"],
     linkopts = select({
         "@platforms//os:linux": ["-lX11"],
         "@platforms//os:windows": [
@@ -109,7 +110,6 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
-        ":sf_glad",
         ":system",
         "@vulkan",
     ] + select({
@@ -145,6 +145,7 @@ objc_library(
         "-frtti",
     ],
     defines = SFML_DEFINES,
+    implementation_deps = [":sf_glad"],
     includes = ["include/"],
     non_arc_srcs = glob([
         "src/SFML/Window/OSX/*.m",
@@ -161,7 +162,6 @@ objc_library(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
-        ":sf_glad",
         ":system",
     ],
 )
@@ -177,6 +177,7 @@ cc_library(
     hdrs = glob(["include/SFML/Graphics/*"]),
     copts = ["-Iexternal/sfml/src/"],
     defines = SFML_DEFINES,
+    implementation_deps = [":sf_glad"],
     includes = ["include/"],
     linkopts = select({
         "@platforms//os:linux": ["-lX11"],
@@ -186,7 +187,6 @@ cc_library(
     strip_include_prefix = "include/",
     visibility = ["//visibility:public"],
     deps = [
-        ":sf_glad",
         ":system",
         ":window",
         "@freetype2",


### PR DESCRIPTION
This broke in 042be7e73fea6d6bcc4990fc367d61c04030e27a when switching to dynamically loading OpenGL w/ glad.