### PR TITLE
style: Support matching the :root psuedo-class

### DIFF
--- a/style/style.cpp
+++ b/style/style.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -95,16 +95,25 @@ bool is_match(style::StyledNode const &node, std::string_view selector) {
     }
 
     if (!psuedo_class.empty()) {
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/:link
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/:visited
-        // Ignoring :visited for now as we treat all links as unvisited.
         if (psuedo_class == "link" || psuedo_class == "any-link") {
+            // https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link
+            // https://developer.mozilla.org/en-US/docs/Web/CSS/:link
+            // https://developer.mozilla.org/en-US/docs/Web/CSS/:visited
+            // Ignoring :visited for now as we treat all links as unvisited.
             if (!element.attributes.contains("href")) {
                 return false;
             }
 
             if (element.name != "a" && element.name != "area") {
+                return false;
+            }
+
+            if (selector_.empty()) {
+                return true;
+            }
+        } else if (psuedo_class == "root") {
+            // https://developer.mozilla.org/en-US/docs/Web/CSS/:root
+            if (node.parent != nullptr) {
                 return false;
             }
 

--- a/style/style.h
+++ b/style/style.h
@@ -24,15 +24,6 @@ bool is_match(StyledNode const &, std::string_view selector);
 std::vector<std::pair<css::PropertyId, std::string>> matching_rules(
         StyledNode const &, css::StyleSheet const &stylesheet, css::MediaQuery::Context const &);
 
-inline bool is_match(dom::Element const &e, std::string_view selector) {
-    return is_match(StyledNode{e}, selector);
-}
-
-inline std::vector<std::pair<css::PropertyId, std::string>> matching_rules(
-        dom::Element const &element, css::StyleSheet const &stylesheet, css::MediaQuery::Context const &context = {}) {
-    return matching_rules(StyledNode{element}, stylesheet, context);
-}
-
 std::unique_ptr<StyledNode> style_tree(
         dom::Node const &root, css::StyleSheet const &stylesheet, css::MediaQuery::Context const & = {});
 

--- a/style/style_test.cpp
+++ b/style/style_test.cpp
@@ -136,6 +136,15 @@ int main() {
         });
     }
 
+    etest::test("is_match: :root", [] {
+        dom::Element dom = dom::Element{"html", {}, {dom::Element{"body"}}};
+        style::StyledNode node{dom, {}, {style::StyledNode{dom.children[0]}}};
+        node.children[0].parent = &node;
+
+        expect(style::is_match(node, ":root"));
+        expect(!style::is_match(node.children[0], ":root"));
+    });
+
     etest::test("is_match: child", [] {
         dom::Element dom = dom::Element{"div", {{"class", "logo"}}, {dom::Element{"span"}}};
         style::StyledNode node{dom, {}, {style::StyledNode{dom.children[0]}}};


### PR DESCRIPTION
`:root` is commonly used for declaring global CSS variables:
```css
:root {
  --myvar: 13px;
}
```

Part of #189 