### PR TITLE
build: Disable the duplicate 'external' legacy runfiles folder

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,8 @@ test --test_verbose_timeout_warnings
 # =========================================================
 # See: https://docs.bazel.build/versions/main/backward-compatibility.html
 
+# https://github.com/bazelbuild/bazel/issues/12821
+common --nolegacy_external_runfiles
 build --incompatible_config_setting_private_default_visibility
 build --incompatible_disallow_empty_glob
 build --incompatible_enforce_config_setting_visibility

--- a/url/url_test.cpp
+++ b/url/url_test.cpp
@@ -766,7 +766,7 @@ int main() {
 
         simdjson::ondemand::parser parser;
 
-        auto json = simdjson::padded_string::load("external/wpt/url/resources/urltestdata.json");
+        auto json = simdjson::padded_string::load("../wpt/url/resources/urltestdata.json");
 
         simdjson::ondemand::document doc = parser.iterate(json);
 


### PR DESCRIPTION
There is talk in the linked issue about disabling this by default in
Bazel 8, and disabling it appears to bring the benefit of decreasing the
build time in some scenarios due to halving the number of symlinks.