### PR TITLE
deps/icu: Fix warning spam when building w/ clang-cl

### DIFF
--- a/third_party/icu.BUILD
+++ b/third_party/icu.BUILD
@@ -90,6 +90,11 @@ cc_library(
         "//conditions:default": [
             "-frtti",
         ],
+    }) + select({
+        "@rules_cc//cc/compiler:clang-cl": [
+            "-Wno-microsoft-include",
+        ],
+        "//conditions:default": [],
     }),
     linkstatic = True,
     local_defines = [


### PR DESCRIPTION
This was printing ~23k lines of warnings in CI.