### PR TITLE
ci: Check that all GitHub links are permalinks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
+      - id: check-vcs-permalinks
       - id: trailing-whitespace
       - id: end-of-file-fixer
         exclude: fuzz_test_corpus

--- a/third_party/icu.BUILD
+++ b/third_party/icu.BUILD
@@ -217,8 +217,8 @@ RANLIB=ranlib
 INSTALL_CMD=install -c" > $(RULEDIR)/pkgdata.inc
 """
 
-# https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/pkgdata/pkgdata.cpp#L2206
-# https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/pkgdata/pkgdata.cpp#L179
+# https://github.com/unicode-org/icu/blob/fd5d6c97b1d0cff4a07db3c7e7ab04b20099e124/icu4c/source/tools/pkgdata/pkgdata.cpp#L2204
+# https://github.com/unicode-org/icu/blob/fd5d6c97b1d0cff4a07db3c7e7ab04b20099e124/icu4c/source/tools/pkgdata/pkgdata.cpp#L177
 # For generating the data lib, ICU uses build options from a "pkgdata.inc" file generated and installed as part of the normal ICU build. We don't do a "normal" ICU build, so we have to provide our own.
 genrule(
     name = "pkgdata_inc",


### PR DESCRIPTION
@Zer0-One do the icu permalinks point to the right things? I went back a few commits in the history of that file, and it looks like they were pointing to the start of the enum (but I don't understand why) and the pkgdata.inc-comment most of the time.