### PR TITLE
ci: Drop unnecessary libgl-dev install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Install
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends libgl-dev ${{ matrix.compiler }}-${{ matrix.version }} ${{ matrix.apt }}
+          sudo apt-get install --no-install-recommends ${{ matrix.compiler }}-${{ matrix.version }} ${{ matrix.apt }}
       # See: https://github.com/actions/runner-images/issues/8659
       - name: Work around libstdc++ and Clang incompabilities
         if: startsWith(matrix.compiler, 'clang') && matrix.version <= 16
@@ -127,7 +127,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install --no-install-recommends libgl-dev lcov gcc-${{ matrix.version }} g++-${{ matrix.version }}
+          sudo apt-get install --no-install-recommends lcov gcc-${{ matrix.version }} g++-${{ matrix.version }}
           echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
           echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
           echo "GCOV=gcov-${{ matrix.version }}" >> $GITHUB_ENV
@@ -137,7 +137,7 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{ matrix.version }} main"
           sudo apt-get update
-          sudo apt-get install --no-install-recommends libgl-dev lcov clang-${{ matrix.version }} libclang-rt-${{ matrix.version }}-dev llvm-${{ matrix.version }}
+          sudo apt-get install --no-install-recommends lcov clang-${{ matrix.version }} libclang-rt-${{ matrix.version }}-dev llvm-${{ matrix.version }}
           echo "CC=clang-16" >> $GITHUB_ENV
           echo "CXX=clang++-16" >> $GITHUB_ENV
           # See: https://github.com/actions/runner-images/issues/8659


### PR DESCRIPTION
We have no dependencies to the system gl headers after updating SFML to 2.6 and patching imgui-sfml to also use glad.


See: https://github.com/robinlinden/hastur/pull/834, https://github.com/robinlinden/hastur/pull/836