### PR TITLE
css: Yoink the initial property values from //style, add the `color-scheme` property

### DIFF
--- a/css/property_id.cpp
+++ b/css/property_id.cpp
@@ -44,6 +44,7 @@ std::map<std::string_view, PropertyId> const known_properties{
         {"border-top-width"sv, PropertyId::BorderTopWidth},
         {"caption-side"sv, PropertyId::CaptionSide},
         {"color"sv, PropertyId::Color},
+        {"color-scheme"sv, PropertyId::ColorScheme},
         {"cursor"sv, PropertyId::Cursor},
         {"direction"sv, PropertyId::Direction},
         {"display"sv, PropertyId::Display},
@@ -129,6 +130,9 @@ std::map<css::PropertyId, std::string_view> const initial_values{
 
         // https://developer.mozilla.org/en-US/docs/Web/CSS/color#formal_definition
         {css::PropertyId::Color, "canvastext"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme#formal_definition
+        {css::PropertyId::ColorScheme, "normal"sv},
 
         // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis#formal_definition
         {css::PropertyId::FlexBasis, "auto"sv},

--- a/css/property_id.cpp
+++ b/css/property_id.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -121,6 +121,102 @@ std::map<std::string_view, PropertyId> const known_properties{
         {"word-spacing"sv, PropertyId::WordSpacing},
 };
 
+// https://www.w3.org/TR/css-cascade/#initial-values
+// NOLINTNEXTLINE(cert-err58-cpp)
+std::map<css::PropertyId, std::string_view> const initial_values{
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/background-color#formal_definition
+        {css::PropertyId::BackgroundColor, "transparent"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/color#formal_definition
+        {css::PropertyId::Color, "canvastext"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis#formal_definition
+        {css::PropertyId::FlexBasis, "auto"sv},
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction#formal_definition
+        {css::PropertyId::FlexDirection, "row"sv},
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow#formal_definition
+        {css::PropertyId::FlexGrow, "0"sv},
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink#formal_definition
+        {css::PropertyId::FlexShrink, "1"sv},
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap#formal_definition
+        {css::PropertyId::FlexWrap, "nowrap"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#formal_definition
+        {css::PropertyId::FontSize, "medium"sv},
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#formal_definition
+        {css::PropertyId::FontFamily, "sans-serif"sv},
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/font-style#formal_definition
+        {css::PropertyId::FontStyle, "normal"sv},
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#formal_definition
+        {css::PropertyId::FontWeight, "normal"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration
+        {css::PropertyId::TextDecorationColor, "currentcolor"sv},
+        {css::PropertyId::TextDecorationLine, "none"sv},
+        {css::PropertyId::TextDecorationStyle, "solid"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/border-color#formal_definition
+        {css::PropertyId::BorderBottomColor, "currentcolor"sv},
+        {css::PropertyId::BorderLeftColor, "currentcolor"sv},
+        {css::PropertyId::BorderRightColor, "currentcolor"sv},
+        {css::PropertyId::BorderTopColor, "currentcolor"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius
+        {css::PropertyId::BorderBottomLeftRadius, "0"sv},
+        {css::PropertyId::BorderBottomRightRadius, "0"sv},
+        {css::PropertyId::BorderTopLeftRadius, "0"sv},
+        {css::PropertyId::BorderTopRightRadius, "0"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#formal_definition
+        {css::PropertyId::BorderBottomStyle, "none"sv},
+        {css::PropertyId::BorderLeftStyle, "none"sv},
+        {css::PropertyId::BorderRightStyle, "none"sv},
+        {css::PropertyId::BorderTopStyle, "none"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/border-width#formal_definition
+        {css::PropertyId::BorderBottomWidth, "medium"sv},
+        {css::PropertyId::BorderLeftWidth, "medium"sv},
+        {css::PropertyId::BorderRightWidth, "medium"sv},
+        {css::PropertyId::BorderTopWidth, "medium"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/outline
+        {css::PropertyId::OutlineColor, "currentcolor"},
+        {css::PropertyId::OutlineStyle, "none"},
+        {css::PropertyId::OutlineWidth, "medium"},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/padding#formal_definition
+        {css::PropertyId::PaddingBottom, "0"sv},
+        {css::PropertyId::PaddingLeft, "0"sv},
+        {css::PropertyId::PaddingRight, "0"sv},
+        {css::PropertyId::PaddingTop, "0"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/display#formal_definition
+        {css::PropertyId::Display, "inline"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/height#formal_definition
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/max-height#formal_definition
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/min-height#formal_definition
+        {css::PropertyId::Height, "auto"sv},
+        {css::PropertyId::MaxHeight, "none"sv},
+        {css::PropertyId::MinHeight, "auto"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/margin#formal_definition
+        {css::PropertyId::MarginBottom, "0"sv},
+        {css::PropertyId::MarginLeft, "0"sv},
+        {css::PropertyId::MarginRight, "0"sv},
+        {css::PropertyId::MarginTop, "0"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/width#formal_definition
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/max-width#formal_definition
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/min-width#formal_definition
+        {css::PropertyId::Width, "auto"sv},
+        {css::PropertyId::MaxWidth, "none"sv},
+        {css::PropertyId::MinWidth, "auto"sv},
+
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
+        {css::PropertyId::WhiteSpace, "normal"sv},
+};
+
 } // namespace
 
 PropertyId property_id_from_string(std::string_view id) {
@@ -138,6 +234,10 @@ std::string_view to_string(PropertyId id) {
     }
 
     return "unknown"sv;
+}
+
+std::string_view initial_value(PropertyId id) {
+    return initial_values.at(id);
 }
 
 } // namespace css

--- a/css/property_id.h
+++ b/css/property_id.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -121,6 +121,8 @@ enum class PropertyId {
 PropertyId property_id_from_string(std::string_view);
 
 std::string_view to_string(PropertyId);
+
+std::string_view initial_value(PropertyId);
 
 // https://www.w3.org/TR/CSS22/propidx.html
 constexpr bool is_inherited(PropertyId id) {

--- a/css/property_id.h
+++ b/css/property_id.h
@@ -41,6 +41,7 @@ enum class PropertyId {
     BorderTopWidth,
     CaptionSide,
     Color,
+    ColorScheme,
     Cursor,
     Direction,
     Display,
@@ -132,6 +133,7 @@ constexpr bool is_inherited(PropertyId id) {
         case css::PropertyId::BorderSpacing:
         case css::PropertyId::CaptionSide:
         case css::PropertyId::Color:
+        case css::PropertyId::ColorScheme:
         case css::PropertyId::Cursor:
         case css::PropertyId::Direction:
         case css::PropertyId::Elevation:

--- a/css/property_id_test.cpp
+++ b/css/property_id_test.cpp
@@ -1,39 +1,39 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "css/property_id.h"
 
-#include "etest/etest.h"
+#include "etest/etest2.h"
 
 #include <fmt/core.h>
 
 #include <string_view>
 
-using etest::expect;
-using etest::expect_eq;
 using namespace std::literals;
 
 int main() {
-    etest::test("property_id_from_string", [] {
-        expect_eq(css::property_id_from_string("width"), css::PropertyId::Width);
-        expect_eq(css::property_id_from_string("aaaaa"), css::PropertyId::Unknown);
+    etest::Suite s;
+
+    s.add_test("property_id_from_string", [](etest::IActions &a) {
+        a.expect_eq(css::property_id_from_string("width"), css::PropertyId::Width);
+        a.expect_eq(css::property_id_from_string("aaaaa"), css::PropertyId::Unknown);
     });
 
-    etest::test("to_string", [] {
-        expect_eq(css::to_string(css::PropertyId::Width), "width");
-        expect_eq(css::to_string(css::PropertyId::Unknown), "unknown");
+    s.add_test("to_string", [](etest::IActions &a) {
+        a.expect_eq(css::to_string(css::PropertyId::Width), "width");
+        a.expect_eq(css::to_string(css::PropertyId::Unknown), "unknown");
     });
 
-    etest::test("all ids have strings", [] {
+    s.add_test("all ids have strings", [](etest::IActions &a) {
         auto id = static_cast<int>(css::PropertyId::Unknown) + 1;
         // Requires a manual update every time we add something last in the enum.
         while (id <= static_cast<int>(css::PropertyId::WordSpacing)) {
-            expect(css::to_string(static_cast<css::PropertyId>(id)) != "unknown"sv,
+            a.expect(css::to_string(static_cast<css::PropertyId>(id)) != "unknown"sv,
                     fmt::format("Property {} is missing a string mapping", id));
             id += 1;
         }
     });
 
-    return etest::run_all_tests();
+    return s.run();
 }

--- a/css/property_id_test.cpp
+++ b/css/property_id_test.cpp
@@ -35,5 +35,11 @@ int main() {
         }
     });
 
+    s.add_test("initial_value", [](etest::IActions &a) {
+        a.expect_eq(css::initial_value(css::PropertyId::Width), "auto");
+        a.expect_eq(css::initial_value(css::PropertyId::Color), "canvastext");
+        a.expect_eq(css::initial_value(css::PropertyId::ColorScheme), "normal");
+    });
+
     return s.run();
 }

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -33,102 +33,6 @@ using namespace std::literals;
 namespace style {
 namespace {
 
-// https://www.w3.org/TR/css-cascade/#initial-values
-// NOLINTNEXTLINE(cert-err58-cpp)
-std::map<css::PropertyId, std::string_view> const initial_values{
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/background-color#formal_definition
-        {css::PropertyId::BackgroundColor, "transparent"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/color#formal_definition
-        {css::PropertyId::Color, "canvastext"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis#formal_definition
-        {css::PropertyId::FlexBasis, "auto"sv},
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction#formal_definition
-        {css::PropertyId::FlexDirection, "row"sv},
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow#formal_definition
-        {css::PropertyId::FlexGrow, "0"sv},
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink#formal_definition
-        {css::PropertyId::FlexShrink, "1"sv},
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap#formal_definition
-        {css::PropertyId::FlexWrap, "nowrap"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#formal_definition
-        {css::PropertyId::FontSize, "medium"sv},
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#formal_definition
-        {css::PropertyId::FontFamily, "sans-serif"sv},
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/font-style#formal_definition
-        {css::PropertyId::FontStyle, "normal"sv},
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#formal_definition
-        {css::PropertyId::FontWeight, "normal"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration
-        {css::PropertyId::TextDecorationColor, "currentcolor"sv},
-        {css::PropertyId::TextDecorationLine, "none"sv},
-        {css::PropertyId::TextDecorationStyle, "solid"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/border-color#formal_definition
-        {css::PropertyId::BorderBottomColor, "currentcolor"sv},
-        {css::PropertyId::BorderLeftColor, "currentcolor"sv},
-        {css::PropertyId::BorderRightColor, "currentcolor"sv},
-        {css::PropertyId::BorderTopColor, "currentcolor"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius
-        {css::PropertyId::BorderBottomLeftRadius, "0"sv},
-        {css::PropertyId::BorderBottomRightRadius, "0"sv},
-        {css::PropertyId::BorderTopLeftRadius, "0"sv},
-        {css::PropertyId::BorderTopRightRadius, "0"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#formal_definition
-        {css::PropertyId::BorderBottomStyle, "none"sv},
-        {css::PropertyId::BorderLeftStyle, "none"sv},
-        {css::PropertyId::BorderRightStyle, "none"sv},
-        {css::PropertyId::BorderTopStyle, "none"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/border-width#formal_definition
-        {css::PropertyId::BorderBottomWidth, "medium"sv},
-        {css::PropertyId::BorderLeftWidth, "medium"sv},
-        {css::PropertyId::BorderRightWidth, "medium"sv},
-        {css::PropertyId::BorderTopWidth, "medium"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/outline
-        {css::PropertyId::OutlineColor, "currentcolor"},
-        {css::PropertyId::OutlineStyle, "none"},
-        {css::PropertyId::OutlineWidth, "medium"},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/padding#formal_definition
-        {css::PropertyId::PaddingBottom, "0"sv},
-        {css::PropertyId::PaddingLeft, "0"sv},
-        {css::PropertyId::PaddingRight, "0"sv},
-        {css::PropertyId::PaddingTop, "0"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/display#formal_definition
-        {css::PropertyId::Display, "inline"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/height#formal_definition
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/max-height#formal_definition
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/min-height#formal_definition
-        {css::PropertyId::Height, "auto"sv},
-        {css::PropertyId::MaxHeight, "none"sv},
-        {css::PropertyId::MinHeight, "auto"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/margin#formal_definition
-        {css::PropertyId::MarginBottom, "0"sv},
-        {css::PropertyId::MarginLeft, "0"sv},
-        {css::PropertyId::MarginRight, "0"sv},
-        {css::PropertyId::MarginTop, "0"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/width#formal_definition
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/max-width#formal_definition
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/min-width#formal_definition
-        {css::PropertyId::Width, "auto"sv},
-        {css::PropertyId::MaxWidth, "none"sv},
-        {css::PropertyId::MinWidth, "auto"sv},
-
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
-        {css::PropertyId::WhiteSpace, "normal"sv},
-};
-
 std::optional<gfx::Color> try_from_hex_chars(std::string_view hex_chars) {
     if (!hex_chars.starts_with('#')) {
         return std::nullopt;
@@ -268,7 +172,7 @@ std::string_view get_parent_raw_property(style::StyledNode const &node, css::Pro
         return node.parent->get_raw_property(property);
     }
 
-    return initial_values.at(property);
+    return css::initial_value(property);
 }
 
 std::optional<std::pair<float, std::string_view>> split_into_value_and_unit(std::string_view property) {
@@ -305,12 +209,12 @@ std::string_view StyledNode::get_raw_property(css::PropertyId property) const {
             return parent->get_raw_property(property);
         }
 
-        return initial_values.at(property);
+        return css::initial_value(property);
     }
 
     if (it->second == "initial") {
         // https://developer.mozilla.org/en-US/docs/Web/CSS/initial
-        return initial_values.at(property);
+        return css::initial_value(property);
     }
 
     if (it->second == "inherit") {


### PR DESCRIPTION
At first I was only going to add the color-scheme property, but I didn't like having to touch both //css and //style when doing it.