### PR TITLE
css: Skip over nested CSS instead of letting them break things

### DIFF
--- a/css/parser.h
+++ b/css/parser.h
@@ -52,7 +52,7 @@ private:
     void skip_whitespace_and_comments();
 
     std::optional<css::Rule> parse_rule();
-    std::optional<std::pair<std::string_view, std::string_view>> parse_declaration();
+    std::optional<std::pair<std::string_view, std::string_view>> parse_declaration(std::string_view name);
 
     static void add_declaration(Declarations &, std::string_view name, std::string_view value);
 

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -1243,5 +1243,10 @@ int main() {
         expect(css::parse("p { color: green; a { font-size: 3px; ").rules.empty()); //
     });
 
+    etest::test("parser: -webkit-lol", [] {
+        expect_eq(css::parse("p { -webkit-font-size: 3px; }").rules.at(0).declarations,
+                std::map<css::PropertyId, std::string>{{css::PropertyId::Unknown, "3px"}});
+    });
+
     return etest::run_all_tests();
 }

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -1224,5 +1224,24 @@ int main() {
                 css::Rule{.selectors = {{"p"}}, .custom_properties = {{"--var", "value"}}});
     });
 
+    // TODO(robinlinden): Nested rules are currently skipped, but at least
+    // they mostly don't break parsing of the rule they're nested in.
+    etest::test("parser: nested rule", [] {
+        expect_eq(css::parse("p { color: green; a { font-size: 3px; } font-size: 5px; }").rules, //
+                std::vector{
+                        css::Rule{
+                                .selectors = {{"p"}},
+                                .declarations{
+                                        {css::PropertyId::Color, "green"},
+                                        {css::PropertyId::FontSize, "5px"},
+                                },
+                        },
+                });
+    });
+
+    etest::test("parser: eof in nested rule", [] {
+        expect(css::parse("p { color: green; a { font-size: 3px; ").rules.empty()); //
+    });
+
     return etest::run_all_tests();
 }


### PR DESCRIPTION
This makes https://srctree.gr.ht/repos look like
![after](https://github.com/robinlinden/hastur/assets/8304462/9117fcfc-d793-49d5-be5a-7b87b9534bfb)
instead of
![before](https://github.com/robinlinden/hastur/assets/8304462/06a5b7c5-0ca4-4fea-b3ab-cc3ae5bec666)

Part of #774 