### PR TITLE
ci: Switch the clang-17 libstdc++ job over to clang-18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,10 +37,10 @@ jobs:
             version: 15
             bazel: --config asan --config ubsan
 
-          - name: clang-17
+          - name: clang-18
             os: ubuntu-22.04
             compiler: clang
-            version: 17
+            version: 18
 
           - name: clang-15-libc++
             os: ubuntu-22.04


### PR DESCRIPTION
We still test clang-17 in the libc++ job.