### PR TITLE
ci: Add workaround for Clang 14 on newer GH Actions runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,12 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
           sudo apt-get update
           sudo apt-get install --allow-downgrades libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
+      # See:
+      # * https://github.com/actions/runner-images/issues/9491#issuecomment-1989718917
+      # * https://github.com/google/sanitizers/issues/1716
+      - name: Work around Clang 14 and high-entropy ASLR incompatibility
+        if: startsWith(matrix.compiler, 'clang') && matrix.version == 14
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - uses: actions/cache@v4
         with:
           path: ~/.cache/bazel


### PR DESCRIPTION
This hasn't hit us fully yet since the new runners are still being rolled out, but it's made the Clang 14 job quite flaky.