### PR TITLE
ci: Apply the ASLR+sanitizer workaround to all jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,8 +90,7 @@ jobs:
       # See:
       # * https://github.com/actions/runner-images/issues/9491#issuecomment-1989718917
       # * https://github.com/google/sanitizers/issues/1716
-      - name: Work around Clang 14 and high-entropy ASLR incompatibility
-        if: startsWith(matrix.compiler, 'clang') && matrix.version == 14
+      - name: Work around sanitizer and high-entropy ASLR incompatibility
         run: sudo sysctl vm.mmap_rnd_bits=28
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
The clang 15 ubsan/asan and the gcc 12 valgrind jobs both fail due to the entropy change, we were just "lucky" with them getting runners with older kernels until after the last PR was already merged.