### PR TITLE
css: Parse (and ignore) charset at-rules

### DIFF
--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -266,6 +266,21 @@ StyleSheet Parser::parse_rules() {
 
     skip_whitespace_and_comments();
     while (!is_eof()) {
+        if (starts_with("@charset ")) {
+            advance(std::strlen("@charset"));
+            skip_whitespace_and_comments();
+            if (auto charset = consume_while([](char c) { return c != ';'; }); charset) {
+                spdlog::warn("Ignoring charset: {}", *charset);
+            } else {
+                spdlog::error("Eof while parsing charset");
+                return style;
+            }
+
+            consume_char(); // ;
+            skip_whitespace_and_comments();
+            continue;
+        }
+
         if (starts_with("@media ") || starts_with("@media(")) {
             advance(std::strlen("@media"));
             skip_whitespace_and_comments();

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -1248,5 +1248,14 @@ int main() {
                 std::map<css::PropertyId, std::string>{{css::PropertyId::Unknown, "3px"}});
     });
 
+    etest::test("parser: @charset", [] {
+        expect_eq(css::parse("@charset 'shift-jis'; p { font-size: 3px; }").rules.at(0),
+                css::Rule{.selectors = {{"p"}}, .declarations{{css::PropertyId::FontSize, "3px"}}});
+    });
+
+    etest::test("parser: @charset eof", [] {
+        expect(css::parse("@charset 'shi").rules.empty()); //
+    });
+
     return etest::run_all_tests();
 }


### PR DESCRIPTION
These are in use on e.g. https://www.iana.org/help/example-domains and the parser didn't like just running over them.