### PR TITLE
Improve rendering of the nginx default error pages

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -82,28 +82,15 @@ wbr {
   display: inline;
 }
 
-address,
-blockquote,
 details,
-dialog,
-div,
 fieldset,
-figcaption,
-figure,
-footer,
-form,
-header,
-hr,
 li,
-main,
-pre,
 table {
   display: block;
 }
 
 /* TODO(robinlinden): margin-top/bottom -> margin-block-start/end once handled. */
 p {
-  display: block;
   margin-top: 1em;
   margin-bottom: 1em;
 }
@@ -172,6 +159,28 @@ h6 {
 
 /* Flow content */
 /* https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3 */
+
+address,
+blockquote,
+center,
+dialog,
+div,
+figure,
+figcaption,
+footer,
+form,
+header,
+hr,
+legend,
+listing,
+main,
+p,
+plaintext,
+pre,
+search,
+xmp {
+  display: block;
+}
 
 listing,
 plaintext,

--- a/css/default.css
+++ b/css/default.css
@@ -343,3 +343,15 @@ ol,
 ul {
   padding-left: 40px;
 }
+
+/* 15.3.11 The hr element */
+/* https://html.spec.whatwg.org/multipage/rendering.html#the-hr-element-2 */
+
+hr {
+  color: gray;
+  border-style: inset;
+  border-width: 1px;
+  margin-block: 0.5em;
+  margin-inline: auto;
+  overflow: hidden;
+}

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -124,7 +124,7 @@ bool should_render(layout::LayoutBox const &layout) {
 }
 
 void render_layout_impl(gfx::ICanvas &painter, layout::LayoutBox const &layout, std::optional<geom::Rect> const &clip) {
-    if (clip && clip->intersected(layout.dimensions.padding_box()).empty()) {
+    if (clip && clip->intersected(layout.dimensions.border_box()).empty()) {
         return;
     }
 


### PR DESCRIPTION
We were missing the `display: block` for `<center>`, and we had no CSS at all for `<hr>`. We were also dropping any elements that had either height or width == 0, even if a border size would cause things to be rendered anyway.

We're still not centering things inside of the `<center>` element, but that's a future someone's problem.

Before:
![image](https://github.com/robinlinden/hastur/assets/8304462/a4cc49d9-00ce-49b2-a393-170c4b3d5d80)

After:
![image](https://github.com/robinlinden/hastur/assets/8304462/b398bbf3-0dc3-4b62-8a92-3377c44439d8)
