### PR TITLE
browser/gui: Always show page titles as UTF-8

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -543,7 +543,8 @@ void App::on_navigation_failure(protocol::Error err) {
 
 void App::on_page_loaded() {
     if (auto page_title = try_get_text_content(page().dom, "/html/head/title"sv)) {
-        window_.setTitle(fmt::format("{} - {}", *page_title, browser_title_));
+        auto title = fmt::format("{} - {}", *page_title, browser_title_);
+        window_.setTitle(sf::String::fromUtf8(title.begin(), title.end()));
     } else {
         window_.setTitle(browser_title_);
     }


### PR DESCRIPTION
SFML defaults to interpreting string bytes as having the locale the current system does. This doesn't work for us as we treat everything as UTF-8 internally, and most of the web uses UTF-8.