### PR TITLE
style: Handle weird display and float css property interactions

### DIFF
--- a/css/property_id.cpp
+++ b/css/property_id.cpp
@@ -55,6 +55,7 @@ std::map<std::string_view, PropertyId> const known_properties{
         {"flex-grow"sv, PropertyId::FlexGrow},
         {"flex-shrink"sv, PropertyId::FlexShrink},
         {"flex-wrap"sv, PropertyId::FlexWrap},
+        {"float"sv, PropertyId::Float},
         {"font-family"sv, PropertyId::FontFamily},
         {"font-feature-settings"sv, PropertyId::FontFeatureSettings},
         {"font-kerning"sv, PropertyId::FontKerning},
@@ -196,6 +197,8 @@ std::map<css::PropertyId, std::string_view> const initial_values{
 
         // https://developer.mozilla.org/en-US/docs/Web/CSS/display#formal_definition
         {css::PropertyId::Display, "inline"sv},
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/float#formal_definition
+        {css::PropertyId::Float, "none"sv},
 
         // https://developer.mozilla.org/en-US/docs/Web/CSS/height#formal_definition
         // https://developer.mozilla.org/en-US/docs/Web/CSS/max-height#formal_definition

--- a/css/property_id.h
+++ b/css/property_id.h
@@ -53,6 +53,7 @@ enum class PropertyId : std::uint8_t {
     FlexGrow,
     FlexShrink,
     FlexWrap,
+    Float,
     FontFamily,
     FontFeatureSettings,
     FontKerning,

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -311,6 +311,8 @@ gfx::Color StyledNode::get_color_property(css::PropertyId property) const {
     return parse_color(color_text);
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/CSS/float
+// ^ has info about the weird float<->display property interaction.
 DisplayValue StyledNode::get_display_property() const {
     auto raw = get_raw_property(css::PropertyId::Display);
     if (raw == "none") {
@@ -318,7 +320,11 @@ DisplayValue StyledNode::get_display_property() const {
     }
 
     if (raw == "inline") {
-        return DisplayValue::Inline;
+        if (get_property<css::PropertyId::Float>().value_or(Float::None) == Float::None) {
+            return DisplayValue::Inline;
+        }
+
+        return DisplayValue::Block;
     }
 
     if (raw == "block") {

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -329,6 +329,31 @@ DisplayValue StyledNode::get_display_property() const {
     return DisplayValue::Block;
 }
 
+std::optional<Float> StyledNode::get_float_property() const {
+    auto raw = get_raw_property(css::PropertyId::Float);
+    if (raw == "none") {
+        return Float::None;
+    }
+
+    if (raw == "left") {
+        return Float::Left;
+    }
+
+    if (raw == "right") {
+        return Float::Right;
+    }
+
+    if (raw == "inline-start") {
+        return Float::InlineStart;
+    }
+
+    if (raw == "inline-end") {
+        return Float::InlineEnd;
+    }
+
+    return std::nullopt;
+}
+
 FontStyle StyledNode::get_font_style_property() const {
     auto raw = get_raw_property(css::PropertyId::FontStyle);
     if (raw == "normal") {

--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -42,6 +42,14 @@ enum class DisplayValue : std::uint8_t {
     Block,
 };
 
+enum class Float : std::uint8_t {
+    None,
+    Left,
+    Right,
+    InlineStart,
+    InlineEnd,
+};
+
 enum class FontStyle : std::uint8_t {
     Normal,
     Italic,
@@ -105,6 +113,8 @@ struct StyledNode {
             return get_color_property(T);
         } else if constexpr (T == css::PropertyId::Display) {
             return get_display_property();
+        } else if constexpr (T == css::PropertyId::Float) {
+            return get_float_property();
         } else if constexpr (T == css::PropertyId::FontFamily) {
             auto raw_font_family = get_raw_property(T);
             auto families = util::split(raw_font_family, ",");
@@ -133,6 +143,7 @@ private:
     BorderStyle get_border_style_property(css::PropertyId) const;
     gfx::Color get_color_property(css::PropertyId) const;
     DisplayValue get_display_property() const;
+    std::optional<Float> get_float_property() const;
     FontStyle get_font_style_property() const;
     int get_font_size_property() const;
     std::optional<FontWeight> get_font_weight_property() const;

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -358,6 +358,15 @@ int main() {
         expect_property_eq<css::PropertyId::Color>("rgba(1 2)", kErrorColor);
     });
 
+    etest::test("get_property, float", [] {
+        expect_property_eq<css::PropertyId::Float>("none", style::Float::None);
+        expect_property_eq<css::PropertyId::Float>("left", style::Float::Left);
+        expect_property_eq<css::PropertyId::Float>("right", style::Float::Right);
+        expect_property_eq<css::PropertyId::Float>("inline-start", style::Float::InlineStart);
+        expect_property_eq<css::PropertyId::Float>("inline-end", style::Float::InlineEnd);
+        expect_property_eq<css::PropertyId::Float>("???", std::nullopt);
+    });
+
     etest::test("get_property, text-decoration-line", [] {
         using enum style::TextDecorationLine;
         expect_property_eq<css::PropertyId::TextDecorationLine>("none", std::vector{None});

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -305,8 +305,23 @@ int main() {
         expect_eq(styled_node.get_property<css::PropertyId::Display>(), style::DisplayValue::None);
     });
 
-    etest::test("get_property, unhandled display value",
-            [] { expect_property_eq<css::PropertyId::Display>("i cant believe this", style::DisplayValue::Block); });
+    etest::test("get_property, display", [] {
+        expect_property_eq<css::PropertyId::Display>("inline", style::DisplayValue::Inline);
+        expect_property_eq<css::PropertyId::Display>("i cant believe this", style::DisplayValue::Block);
+
+        // Weird float interactions.
+        dom::Node dom_node = dom::Element{"dummy"s};
+        style::StyledNode styled{
+                .node = dom_node,
+                .properties{
+                        {css::PropertyId::Display, "???"s},
+                        {css::PropertyId::Float, "left"s},
+                },
+        };
+
+        styled.properties[0] = {css::PropertyId::Display, "inline"s};
+        expect_eq(styled.get_property<css::PropertyId::Display>(), style::DisplayValue::Block);
+    });
 
     etest::test("get_property, border-style", [] {
         expect_property_eq<css::PropertyId::BorderBottomStyle>("none", style::BorderStyle::None);


### PR DESCRIPTION
All inline-ish display values should be mapped to block-ish in the presence of a float value that is not none.

This fixes the content on https://00f.net/2023/01/04/webassembly-benchmark-2023/ not being visible.