### PR TITLE
style: Support lookup of inherited css variables

### DIFF
--- a/style/style.cpp
+++ b/style/style.cpp
@@ -175,6 +175,7 @@ MatchingProperties matching_properties(
             // The above should always parse to 1 rule when using the old parser.
             if (element_style.size() == 1) {
                 std::ranges::copy(element_style[0].declarations, std::back_inserter(matched_properties));
+                std::ranges::copy(element_style[0].custom_properties, std::back_inserter(matched_custom_properties));
             } else {
                 spdlog::warn("Failed to parse inline style '{}' for element '{}'", style_attr->second, element->name);
             }
@@ -215,7 +216,9 @@ void style_tree_impl(StyledNode &current,
         style_tree_impl(child_node, child, stylesheet, ctx);
     }
 
-    current.properties = matching_properties(current, stylesheet, ctx).normal;
+    auto [normal, custom] = matching_properties(current, stylesheet, ctx);
+    current.properties = std::move(normal);
+    current.custom_properties = std::move(custom);
 }
 } // namespace
 

--- a/style/style_test.cpp
+++ b/style/style_test.cpp
@@ -309,6 +309,23 @@ int main() {
         expect(res.normal.empty());
     });
 
+    etest::test("style_tree: custom variables", [] {
+        auto root = dom::Element{"html", {{"style", "--inline: 3px;"}}, {}};
+        css::StyleSheet stylesheet{{
+                {.selectors = {"html"}, .custom_properties = {{"--stylesheet", "5px"}}},
+        }};
+
+        style::StyledNode expected{
+                .node{root},
+                .custom_properties{
+                        {"--stylesheet", "5px"},
+                        {"--inline", "3px"},
+                },
+        };
+
+        expect_eq(*style::style_tree(root, stylesheet), expected);
+    });
+
     inline_css_tests();
     important_declarations_tests();
     return etest::run_all_tests();

--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -154,7 +154,8 @@ private:
 };
 
 [[nodiscard]] inline bool operator==(style::StyledNode const &a, style::StyledNode const &b) noexcept {
-    return a.node == b.node && a.properties == b.properties && a.children == b.children;
+    return a.node == b.node && a.properties == b.properties && a.custom_properties == b.custom_properties
+            && a.children == b.children;
 }
 
 inline std::string_view dom_name(StyledNode const &node) {

--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -140,6 +140,8 @@ struct StyledNode {
     }
 
 private:
+    std::optional<std::string_view> resolve_variable(std::string_view) const;
+
     BorderStyle get_border_style_property(css::PropertyId) const;
     gfx::Color get_color_property(css::PropertyId) const;
     DisplayValue get_display_property() const;

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -508,5 +508,21 @@ int main() {
                 style::FontWeight::bold());
     });
 
+    etest::test("==, custom properties", [] {
+        dom::Node dom = dom::Element{"baka"};
+
+        style::StyledNode with{
+                .node = dom,
+                .custom_properties{{"--a", "bold"}},
+        };
+
+        style::StyledNode without{.node = dom};
+
+        expect(with != without);
+
+        without.custom_properties = {{"--a", "bold"}};
+        expect_eq(with, without);
+    });
+
     return etest::run_all_tests();
 }

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -504,13 +504,8 @@ int main() {
         auto &child = styled_node.children[0];
         child.parent = &styled_node;
 
-        // TODO(robinlinden)
-#if 0
         expect_eq(child.get_property<css::PropertyId::FontWeight>(), //
                 style::FontWeight::bold());
-#endif
-        expect_eq(child.get_property<css::PropertyId::FontWeight>(), //
-                std::nullopt);
     });
 
     return etest::run_all_tests();


### PR DESCRIPTION
This fixes a lot of things on https://eatonphil.com, a blog I found browsing https://lobste.rs/ in hastur.

Part of  #189