### PR TITLE
build: Fix broken fuzz test platform selection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
             os: ubuntu-22.04
             compiler: clang
             version: 18
+            apt: libclang-rt-18-dev
 
           - name: clang-15-libc++
             os: ubuntu-22.04
@@ -54,7 +55,7 @@ jobs:
             compiler: clang
             version: 17
             bazel: --config libc++
-            apt: libc++abi-17-dev libc++-17-dev
+            apt: libc++abi-17-dev libc++-17-dev libclang-rt-17-dev
 
     steps:
       - name: Prepare gcc install
@@ -103,6 +104,14 @@ jobs:
         run: |
           echo "<html><body><h1>Example</h1><p>This is an example page.</p></body></html>" >example.html
           bazel run browser:tui file://$(pwd)/example.html ${{ matrix.bazel }}
+      # TODO(robinlinden): Run all fuzz tests for "some time" in CI.
+      - name: Fuzz test sanity check
+        if: startsWith(matrix.compiler, 'clang') && !endsWith(matrix.name, 'libc++')
+        run: |
+          bazel run wasm:leb128_fuzz_test_run \
+            --config libfuzzer \
+            ${{ matrix.bazel }} \
+            -- --timeout_secs=10
 
   coverage:
     name: linux-${{ matrix.compiler }}-${{ matrix.version }}-coverage

--- a/bzl/BUILD
+++ b/bzl/BUILD
@@ -3,3 +3,13 @@ filegroup(
     srcs = ["run_xfail_test"],
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "linux_or_macos",
+    actual = select({
+        "@platforms//os:linux": "@platforms//os:linux",
+        "@platforms//os:macos": "@platforms//os:macos",
+        "//conditions:default": "@platforms//:incompatible",
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/bzl/copts.bzl
+++ b/bzl/copts.bzl
@@ -45,9 +45,6 @@ HASTUR_COPTS = select({
 
 # C++ fuzzing requires a Clang compiler: https://github.com/bazelbuild/rules_fuzzing#prerequisites
 HASTUR_FUZZ_PLATFORMS = select({
-    "@rules_cc//cc/compiler:clang": [
-        "@platforms//os:linux",
-        "@platforms//os:macos",
-    ],
+    "@rules_cc//cc/compiler:clang": ["//bzl:linux_or_macos"],
     "//conditions:default": ["@platforms//:incompatible"],
 })


### PR DESCRIPTION
I broke this in https://github.com/robinlinden/hastur/commit/9e3b54318b6f7a7547183e942a72e3a8ef95bbb4, and since we don't explicitly run any fuzz tests in CI, they were just quietly disabled.

This fixes the fuzz testing platform selection and explicitly runs a fuzz test in CI to make sure this can't happen again.