### PR TITLE
idna: Process ucd code point decomposition data into a C++ish table

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -250,6 +250,14 @@ http_archive(
     url = "https://github.com/nothings/stb/archive/ae721c50eaf761660b4f90cc590453cdb0c2acd0.tar.gz",
 )
 
+# https://www.unicode.org/Public/
+http_archive(
+    name = "ucd",
+    build_file_content = """exports_files(["UnicodeData.txt"])""",
+    integrity = "sha256-yxxmPQU5JlAM1QEilzYEV1JxOgZr11gCCYWYt6cFYXc=",
+    url = "https://www.unicode.org/Public/15.1.0/ucd/UCD.zip",
+)
+
 # https://github.com/illiliti/libudev-zero
 http_archive(
     name = "udev-zero",  # ISC

--- a/idna/BUILD
+++ b/idna/BUILD
@@ -15,13 +15,29 @@ genrule(
     tools = [":idna_data_processor"],
 )
 
+py_binary(
+    name = "unicode_data_processor",
+    srcs = ["unicode_data_processor.py"],
+)
+
+genrule(
+    name = "generate_unicode_data",
+    srcs = ["@ucd//:UnicodeData.txt"],
+    outs = ["unicode_data.h"],
+    cmd = "$(location :unicode_data_processor) $(location @ucd//:UnicodeData.txt) >$@",
+    tools = [":unicode_data_processor"],
+)
+
 cc_library(
     name = "idna",
     srcs = glob(
         include = ["*.cpp"],
         exclude = ["*_test.cpp"],
     ),
-    hdrs = [":generate_idna_data"] + glob(["*.h"]),
+    hdrs = glob(["*.h"]) + [
+        ":generate_idna_data",
+        ":generate_unicode_data",
+    ],
     copts = HASTUR_COPTS,
     visibility = ["//visibility:public"],
     deps = ["//util:unicode"],

--- a/idna/unicode.cpp
+++ b/idna/unicode.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "idna/unicode.h"
+
+#include "idna/unicode_data.h"
+
+#include "util/unicode.h"
+
+// NOLINTNEXTLINE(misc-include-cleaner): This is used for std::ranges::lower_bound.
+#include <algorithm>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace idna {
+namespace {
+
+void decompose_to(std::ostream &os, char32_t code_point) {
+    // * clang-tidy thinks std::ranges::lower_bound is provided by
+    //   <bits/ranges_algo.h> when it's actually provided by <algorithm>.
+    // * clang-tidy says this is pointer-ish, but msvc disagrees.
+    // NOLINTNEXTLINE(misc-include-cleaner,readability-qualified-auto)
+    auto maybe_decomposition = std::ranges::lower_bound(
+            unicode::kDecompositions, code_point, {}, &decltype(unicode::kDecompositions)::value_type::code_point);
+
+    // This code point does not decompose.
+    if (maybe_decomposition->code_point != code_point) {
+        os << util::unicode_to_utf8(code_point);
+        return;
+    }
+
+    // Recursively decompose the decomposition. This is needed as some code
+    // points decompose into code points that also decompose.
+    for (auto const decomposed : util::CodePointView{maybe_decomposition->decomposes_to}) {
+        decompose_to(os, decomposed);
+    }
+}
+
+} // namespace
+
+std::string Unicode::decompose(std::string_view input) {
+    std::stringstream ss{};
+
+    for (auto const code_point : util::CodePointView{input}) {
+        decompose_to(ss, code_point);
+    }
+
+    return std::move(ss).str();
+}
+
+} // namespace idna

--- a/idna/unicode.h
+++ b/idna/unicode.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef IDNA_UNICODE_H_
+#define IDNA_UNICODE_H_
+
+#include <string>
+#include <string_view>
+
+namespace idna {
+
+class Unicode {
+public:
+    // Normalizes the input into its canonical decomposition, NFD.
+    static std::string decompose(std::string_view);
+};
+
+} // namespace idna
+
+#endif

--- a/idna/unicode_data_processor.py
+++ b/idna/unicode_data_processor.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import dataclasses
+import operator
+import sys
+import textwrap
+import typing
+
+
+@dataclasses.dataclass
+class Decomposition:
+    code_point: int
+    decomposes_to: typing.List[int]
+
+    @staticmethod
+    def parse_from(line: str) -> "Decomposition":
+        code_point, decompositions = operator.itemgetter(0, 5)(line.split(";"))
+        return Decomposition(
+            int(code_point, base=16),
+            [int(n, base=16) for n in decompositions.split(" ")],
+        )
+
+    def to_cxx_class(self) -> str:
+        decomposition = "".join(f"\\U{c:08X}" for c in self.decomposes_to)
+        return f'{{{str(self.code_point)}, "{decomposition}"}}'
+
+
+# https://www.unicode.org/reports/tr44/#UnicodeData.txt
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(
+            f"Usage: {sys.argv[0]} <UnicodeData.txt>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    with open(sys.argv[1]) as table:
+        lines = table.readlines()
+
+    # Filter out lines not containing decomposition info.
+    lines = [line for line in lines if line.split(";")[5].strip()]
+
+    # Filter out non-canonical decompositions.
+    lines = [line for line in lines if not line.split(";")[5].startswith("<")]
+
+    decompositions = [Decomposition.parse_from(line) for line in lines]
+
+    sys.stdout.buffer.write(
+        textwrap.dedent(
+            f"""\
+            // SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+            //
+            // SPDX-License-Identifier: BSD-2-Clause
+
+            // This file is generated. Do not touch it.
+
+            #ifndef IDNA_UNICODE_DATA_H_
+            #define IDNA_UNICODE_DATA_H_
+            // clang-format off
+
+            #include <array>
+            #include <string_view>
+
+            namespace idna::unicode {{
+
+            struct Decomposition {{
+                char32_t code_point{{}};
+                std::string_view decomposes_to{{}};
+                constexpr bool operator==(Decomposition const &) const = default;
+            }};
+
+            constexpr std::array<Decomposition, {len(decompositions)}> kDecompositions{{{{
+                {",\n                ".join(d.to_cxx_class() for d in decompositions)}
+            }}}};
+
+            }} // namespace idna::unicode
+
+            // clang-format on
+            #endif
+            """
+        ).encode()
+    )

--- a/idna/unicode_test.cpp
+++ b/idna/unicode_test.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "idna/unicode.h"
+
+#include "etest/etest2.h"
+
+int main() {
+    etest::Suite s{};
+
+    s.add_test("not decomposed", [](etest::IActions &a) {
+        a.expect_eq(idna::Unicode::decompose("abc123xyz"), "abc123xyz"); //
+    });
+
+    s.add_test("decomposed", [](etest::IActions &a) {
+        // A + COMBINING RING ABOVE
+        a.expect_eq(idna::Unicode::decompose("Å"), "A\xcc\x8a");
+
+        // s + COMBINING DOT BELOW + COMBINING DOT ABOVE
+        a.expect_eq(idna::Unicode::decompose("ṩ"), "s\xcc\xa3\xcc\x87");
+    });
+
+    s.add_test("mixed", [](etest::IActions &a) {
+        // s + COMBINING DOT BELOW + COMBINING DOT ABOVE
+        a.expect_eq(idna::Unicode::decompose("123ṩ567"),
+                "123"
+                "s\xcc\xa3\xcc\x87"
+                "567");
+    });
+
+    return s.run();
+}


### PR DESCRIPTION
This is needed for the NFC normalization we have to perform when doing the UTS46 processing.