### PR TITLE
css: Implement prefers-color-scheme media queries

### DIFF
--- a/css/media_query_test.cpp
+++ b/css/media_query_test.cpp
@@ -1,109 +1,106 @@
-// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "css/media_query.h"
 
-#include "etest/etest.h"
+#include "etest/etest2.h"
 
 #include <optional>
 
-using etest::expect;
-using etest::expect_eq;
-
 namespace {
-void parser_tests() {
-    // The comments are to encourage clang-format to format these in a nice way.
-    etest::test("parser: missing parens", [] {
-        expect_eq(css::MediaQuery::parse("width: 300px"), std::nullopt); //
+void parser_tests(etest::Suite &s) {
+    s.add_test("parser: missing parens", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("width: 300px"), std::nullopt); //
     });
 
-    etest::test("parser: only feature-name", [] {
-        expect_eq(css::MediaQuery::parse("(name)"), std::nullopt); //
+    s.add_test("parser: only feature-name", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(name)"), std::nullopt); //
     });
 
-    etest::test("parser: missing value", [] {
-        expect_eq(css::MediaQuery::parse("(name:)"), std::nullopt); //
+    s.add_test("parser: missing value", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(name:)"), std::nullopt); //
     });
 
-    etest::test("parser: invalid value", [] {
-        expect_eq(css::MediaQuery::parse("(name: abc)"), std::nullopt); //
+    s.add_test("parser: invalid value", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(name: abc)"), std::nullopt); //
     });
 
-    etest::test("parser: unhandled value unit", [] {
-        expect_eq(css::MediaQuery::parse("(name: 10abc)"), std::nullopt); //
+    s.add_test("parser: unhandled value unit", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(name: 10abc)"), std::nullopt); //
     });
 
-    etest::test("parser: value with no unit", [] {
-        expect_eq(css::MediaQuery::parse("(name: 10)"), std::nullopt); //
+    s.add_test("parser: value with no unit", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(name: 10)"), std::nullopt); //
     });
 
-    etest::test("parser: 0 is fine w/o a unit", [] {
-        expect_eq(css::MediaQuery::parse("(max-width: 0)"), css::MediaQuery{css::MediaQuery::Width{.max = 0}}); //
+    s.add_test("parser: 0 is fine w/o a unit", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(max-width: 0)"), css::MediaQuery{css::MediaQuery::Width{.max = 0}}); //
     });
 
-    etest::test("parser: unhandled feature name", [] {
-        expect_eq(css::MediaQuery::parse("(disp: 0)"), std::nullopt); //
+    s.add_test("parser: unhandled feature name", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(disp: 0)"), std::nullopt); //
     });
 }
 
-void to_string_tests() {
-    etest::test("to_string", [] {
-        expect_eq(css::to_string(css::MediaQuery::parse("(width: 300px)").value()), //
+void to_string_tests(etest::Suite &s) {
+    s.add_test("to_string", [](etest::IActions &a) {
+        a.expect_eq(css::to_string(css::MediaQuery::parse("(width: 300px)").value()), //
                 "300 <= width <= 300");
     });
 
-    etest::test("to_string: width", [] {
-        expect_eq(css::to_string(css::MediaQuery::Width{.min = 299, .max = 301}), //
+    s.add_test("to_string: width", [](etest::IActions &a) {
+        a.expect_eq(css::to_string(css::MediaQuery::Width{.min = 299, .max = 301}), //
                 "299 <= width <= 301");
     });
 
-    etest::test("to_string: false", [] {
-        expect_eq(css::to_string(css::MediaQuery::False{}), "false"); //
+    s.add_test("to_string: false", [](etest::IActions &a) {
+        a.expect_eq(css::to_string(css::MediaQuery::False{}), "false"); //
     });
 }
 
-void false_tests() {
-    etest::test("false", [] {
-        expect(!css::MediaQuery::False{}.evaluate({.window_width = 299})); //
+void false_tests(etest::Suite &s) {
+    s.add_test("false", [](etest::IActions &a) {
+        a.expect(!css::MediaQuery::False{}.evaluate({.window_width = 299})); //
     });
 }
 
-void width_tests() {
-    etest::test("width: width", [] {
-        expect_eq(css::MediaQuery::parse("(width: 300px)"),
+void width_tests(etest::Suite &s) {
+    s.add_test("width: width", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(width: 300px)"),
                 css::MediaQuery{css::MediaQuery::Width{.min = 300, .max = 300}});
 
         auto query = css::MediaQuery::Width{.min = 300, .max = 300};
-        expect(!query.evaluate({.window_width = 299}));
-        expect(query.evaluate({.window_width = 300}));
-        expect(!query.evaluate({.window_width = 301}));
+        a.expect(!query.evaluate({.window_width = 299}));
+        a.expect(query.evaluate({.window_width = 300}));
+        a.expect(!query.evaluate({.window_width = 301}));
     });
 
-    etest::test("width: min-width", [] {
-        expect_eq(css::MediaQuery::parse("(min-width: 300px)"), css::MediaQuery{css::MediaQuery::Width{.min = 300}});
+    s.add_test("width: min-width", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(min-width: 300px)"), css::MediaQuery{css::MediaQuery::Width{.min = 300}});
 
         auto query = css::MediaQuery::Width{.min = 300};
-        expect(!query.evaluate({.window_width = 299}));
-        expect(query.evaluate({.window_width = 300}));
-        expect(query.evaluate({.window_width = 301}));
+        a.expect(!query.evaluate({.window_width = 299}));
+        a.expect(query.evaluate({.window_width = 300}));
+        a.expect(query.evaluate({.window_width = 301}));
     });
 
-    etest::test("width: max-width", [] {
-        expect_eq(css::MediaQuery::parse("(max-width: 300px)"), css::MediaQuery{css::MediaQuery::Width{.max = 300}});
+    s.add_test("width: max-width", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(max-width: 300px)"), css::MediaQuery{css::MediaQuery::Width{.max = 300}});
 
         auto query = css::MediaQuery::Width{.max = 300};
-        expect(query.evaluate({.window_width = 299}));
-        expect(query.evaluate({.window_width = 300}));
-        expect(!query.evaluate({.window_width = 301}));
+        a.expect(query.evaluate({.window_width = 299}));
+        a.expect(query.evaluate({.window_width = 300}));
+        a.expect(!query.evaluate({.window_width = 301}));
     });
 }
 } // namespace
 
 int main() {
-    parser_tests();
-    to_string_tests();
-    false_tests();
-    width_tests();
-    return etest::run_all_tests();
+    etest::Suite s{"css::MediaQuery"};
+    parser_tests(s);
+    to_string_tests(s);
+    false_tests(s);
+    width_tests(s);
+    return s.run();
 }

--- a/css/media_query_test.cpp
+++ b/css/media_query_test.cpp
@@ -49,6 +49,11 @@ void to_string_tests(etest::Suite &s) {
                 "300 <= width <= 300");
     });
 
+    s.add_test("to_string: prefers-color-scheme", [](etest::IActions &a) {
+        a.expect_eq(css::to_string(css::MediaQuery::PrefersColorScheme{.color_scheme = css::ColorScheme::Light}), //
+                "prefers-color-scheme: light");
+    });
+
     s.add_test("to_string: width", [](etest::IActions &a) {
         a.expect_eq(css::to_string(css::MediaQuery::Width{.min = 299, .max = 301}), //
                 "299 <= width <= 301");
@@ -62,6 +67,30 @@ void to_string_tests(etest::Suite &s) {
 void false_tests(etest::Suite &s) {
     s.add_test("false", [](etest::IActions &a) {
         a.expect(!css::MediaQuery::False{}.evaluate({.window_width = 299})); //
+    });
+}
+
+void prefers_color_scheme_tests(etest::Suite &s) {
+    s.add_test("prefers-color-scheme: light", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(prefers-color-scheme: light)"),
+                css::MediaQuery{css::MediaQuery::PrefersColorScheme{.color_scheme = css::ColorScheme::Light}});
+
+        auto query = css::MediaQuery::PrefersColorScheme{.color_scheme = css::ColorScheme::Light};
+        a.expect(query.evaluate({.color_scheme = css::ColorScheme::Light}));
+        a.expect(!query.evaluate({.color_scheme = css::ColorScheme::Dark}));
+    });
+
+    s.add_test("prefers-color-scheme: dark", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(prefers-color-scheme: dark)"),
+                css::MediaQuery{css::MediaQuery::PrefersColorScheme{.color_scheme = css::ColorScheme::Dark}});
+
+        auto query = css::MediaQuery::PrefersColorScheme{.color_scheme = css::ColorScheme::Dark};
+        a.expect(!query.evaluate({.color_scheme = css::ColorScheme::Light}));
+        a.expect(query.evaluate({.color_scheme = css::ColorScheme::Dark}));
+    });
+
+    s.add_test("prefers-color-scheme: invalid-value", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(prefers-color-scheme: invalid)"), std::nullopt); //
     });
 }
 
@@ -101,6 +130,7 @@ int main() {
     parser_tests(s);
     to_string_tests(s);
     false_tests(s);
+    prefers_color_scheme_tests(s);
     width_tests(s);
     return s.run();
 }


### PR DESCRIPTION
With some [additional fixes](https://github.com/robinlinden/hastur/pull/945) in `//style` to deal with `.class1.class2` selectors, this makes the

```html
<head>
  <style>
    .theme-a {
      background: #dca;
      color: #731;
    }

    @media (prefers-color-scheme: dark) {
      .theme-a.adaptive {
        background: #753;
        color: #dcb;
        outline: 5px dashed #000;
      }
    }

    .theme-b {
      background: #447;
      color: #bbd;
    }

    @media (prefers-color-scheme: light) {
      .theme-b.adaptive {
        background: #bcd;
        color: #334;
        outline: 5px dotted #000;
      }
    }
  </style>
</head>

<body>
  <div class="box theme-a">Theme A (initial)</div>
  <div class="box theme-a adaptive">Theme A (changed if dark preferred)</div>
  <br />

  <div class="box theme-b">Theme B (initial)</div>
  <div class="box theme-b adaptive">Theme B (changed if light preferred)</div>
</body>
```
example from https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme work as expected.