### PR TITLE
css: Support media-type media queries

### DIFF
--- a/css/media_query.h
+++ b/css/media_query.h
@@ -50,6 +50,11 @@ struct PrefersColorScheme {
     constexpr bool evaluate(Context const &ctx) const { return ctx.color_scheme == color_scheme; }
 };
 
+struct True {
+    [[nodiscard]] bool operator==(True const &) const = default;
+    constexpr bool evaluate(Context const &) const { return true; }
+};
+
 struct Width {
     int min{};
     int max{std::numeric_limits<int>::max()};
@@ -65,9 +70,10 @@ public:
     using Context = detail::Context;
     using False = detail::False;
     using PrefersColorScheme = detail::PrefersColorScheme;
+    using True = detail::True;
     using Width = detail::Width;
 
-    using Query = std::variant<False, PrefersColorScheme, Width>;
+    using Query = std::variant<False, PrefersColorScheme, True, Width>;
     Query query{};
     [[nodiscard]] bool operator==(MediaQuery const &) const = default;
 
@@ -156,6 +162,10 @@ inline std::string to_string(MediaQuery::Width const &width) {
 
 constexpr std::string to_string(MediaQuery::False const &) {
     return "false";
+}
+
+constexpr std::string to_string(MediaQuery::True const &) {
+    return "true";
 }
 
 constexpr std::string to_string(MediaQuery::PrefersColorScheme const &q) {

--- a/css/media_query_test.cpp
+++ b/css/media_query_test.cpp
@@ -54,6 +54,11 @@ void to_string_tests(etest::Suite &s) {
                 "prefers-color-scheme: light");
     });
 
+    s.add_test("to_string: type", [](etest::IActions &a) {
+        a.expect_eq(css::to_string(css::MediaQuery::Type{.type = css::MediaType::Print}), "print");
+        a.expect_eq(css::to_string(css::MediaQuery::Type{.type = css::MediaType::Screen}), "screen");
+    });
+
     s.add_test("to_string: width", [](etest::IActions &a) {
         a.expect_eq(css::to_string(css::MediaQuery::Width{.min = 299, .max = 301}), //
                 "299 <= width <= 301");
@@ -104,6 +109,28 @@ void prefers_color_scheme_tests(etest::Suite &s) {
     });
 }
 
+void type_tests(etest::Suite &s) {
+    s.add_test("type", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("all"), css::MediaQuery{css::MediaQuery::True{}});
+
+        a.expect_eq(css::MediaQuery::parse("print"),
+                css::MediaQuery{css::MediaQuery::Type{.type = css::MediaType::Print}} //
+        );
+        a.expect_eq(css::MediaQuery::parse("screen"),
+                css::MediaQuery{css::MediaQuery::Type{.type = css::MediaType::Screen}} //
+        );
+
+        a.expect_eq(css::MediaQuery::parse("asdf"), std::nullopt);
+
+        using Type = css::MediaQuery::Type;
+        a.expect(Type{.type = css::MediaType::Print}.evaluate({.media_type = css::MediaType::Print}));
+        a.expect(!Type{.type = css::MediaType::Print}.evaluate({.media_type = css::MediaType::Screen}));
+
+        a.expect(Type{.type = css::MediaType::Screen}.evaluate({.media_type = css::MediaType::Screen}));
+        a.expect(!Type{.type = css::MediaType::Screen}.evaluate({.media_type = css::MediaType::Print}));
+    });
+}
+
 void width_tests(etest::Suite &s) {
     s.add_test("width: width", [](etest::IActions &a) {
         a.expect_eq(css::MediaQuery::parse("(width: 300px)"),
@@ -142,6 +169,7 @@ int main() {
     false_tests(s);
     true_tests(s);
     prefers_color_scheme_tests(s);
+    type_tests(s);
     width_tests(s);
     return s.run();
 }

--- a/css/media_query_test.cpp
+++ b/css/media_query_test.cpp
@@ -62,11 +62,21 @@ void to_string_tests(etest::Suite &s) {
     s.add_test("to_string: false", [](etest::IActions &a) {
         a.expect_eq(css::to_string(css::MediaQuery::False{}), "false"); //
     });
+
+    s.add_test("to_string: true", [](etest::IActions &a) {
+        a.expect_eq(css::to_string(css::MediaQuery::True{}), "true"); //
+    });
 }
 
 void false_tests(etest::Suite &s) {
     s.add_test("false", [](etest::IActions &a) {
         a.expect(!css::MediaQuery::False{}.evaluate({.window_width = 299})); //
+    });
+}
+
+void true_tests(etest::Suite &s) {
+    s.add_test("true", [](etest::IActions &a) {
+        a.expect(css::MediaQuery::True{}.evaluate({})); //
     });
 }
 
@@ -130,6 +140,7 @@ int main() {
     parser_tests(s);
     to_string_tests(s);
     false_tests(s);
+    true_tests(s);
     prefers_color_scheme_tests(s);
     width_tests(s);
     return s.run();


### PR DESCRIPTION
These are in use on e.g. https://seirdy.one/

Before:

![image](https://github.com/robinlinden/hastur/assets/8304462/a58aec6b-fffb-4385-90ea-01e790062eaf)


After:

![image](https://github.com/robinlinden/hastur/assets/8304462/0c181ef5-dd0e-42bb-a933-930cca728724)
