### PR TITLE
protocol: Split success and error results into separate types

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -522,7 +522,7 @@ void App::reload() {
     navigate();
 }
 
-void App::on_navigation_failure(protocol::Error err) {
+void App::on_navigation_failure(protocol::ErrorCode err) {
     update_status_line();
     response_headers_str_ = maybe_page_.error().response.headers.to_string();
     dom_str_.clear();
@@ -530,27 +530,27 @@ void App::on_navigation_failure(protocol::Error err) {
     layout_str_.clear();
 
     switch (err) {
-        case protocol::Error::Unresolved: {
+        case protocol::ErrorCode::Unresolved: {
             nav_widget_extra_info_ = fmt::format("Unable to resolve endpoint for '{}'", url_buf_);
             spdlog::error(nav_widget_extra_info_);
             break;
         }
-        case protocol::Error::Unhandled: {
+        case protocol::ErrorCode::Unhandled: {
             nav_widget_extra_info_ = fmt::format("Unhandled protocol for '{}'", url_buf_);
             spdlog::error(nav_widget_extra_info_);
             break;
         }
-        case protocol::Error::InvalidResponse: {
+        case protocol::ErrorCode::InvalidResponse: {
             nav_widget_extra_info_ = fmt::format("Invalid response from '{}'", url_buf_);
             spdlog::error(nav_widget_extra_info_);
             break;
         }
-        case protocol::Error::RedirectLimit: {
+        case protocol::ErrorCode::RedirectLimit: {
             nav_widget_extra_info_ = fmt::format("Redirect limit hit while loading '{}'", url_buf_);
             spdlog::error(nav_widget_extra_info_);
             break;
         }
-        case protocol::Error::Ok:
+        case protocol::ErrorCode::Ok:
         default:
             spdlog::error("This should never happen: {}", static_cast<int>(err));
             break;
@@ -587,7 +587,7 @@ void App::on_page_loaded() {
 
         auto icon = engine_.load(*uri).response;
         sf::Image favicon;
-        if (icon.err != protocol::Error::Ok || !favicon.loadFromMemory(icon.body.data(), icon.body.size())) {
+        if (icon.err != protocol::ErrorCode::Ok || !favicon.loadFromMemory(icon.body.data(), icon.body.size())) {
             spdlog::warn("Error loading favicon from '{}': {}", uri->uri, to_string(icon.err));
             continue;
         }

--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -550,10 +550,6 @@ void App::on_navigation_failure(protocol::ErrorCode err) {
             spdlog::error(nav_widget_extra_info_);
             break;
         }
-        case protocol::ErrorCode::Ok:
-        default:
-            spdlog::error("This should never happen: {}", static_cast<int>(err));
-            break;
     }
 }
 

--- a/browser/gui/app.h
+++ b/browser/gui/app.h
@@ -76,7 +76,7 @@ private:
     engine::PageState &page() { return *maybe_page_.value(); }
     engine::PageState const &page() const { return *maybe_page_.value(); }
 
-    void on_navigation_failure(protocol::Error);
+    void on_navigation_failure(protocol::ErrorCode);
     void on_page_loaded();
     void on_layout_updated();
 

--- a/engine/BUILD
+++ b/engine/BUILD
@@ -39,5 +39,6 @@ cc_test(
         "//type",
         "//type:naive",
         "//uri",
+        "@expected",
     ],
 )

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -36,7 +36,7 @@ struct PageState {
 
 struct NavigationError {
     uri::Uri uri{};
-    protocol::Response response{};
+    protocol::Error response{};
 };
 
 class Engine {
@@ -52,7 +52,7 @@ public:
     void relayout(PageState &, int layout_width);
 
     struct [[nodiscard]] LoadResult {
-        protocol::Response response;
+        tl::expected<protocol::Response, protocol::Error> response;
         uri::Uri uri_after_redirects;
     };
     LoadResult load(uri::Uri);

--- a/engine/engine_test.cpp
+++ b/engine/engine_test.cpp
@@ -16,6 +16,8 @@
 #include "type/type.h"
 #include "uri/uri.h"
 
+#include <tl/expected.hpp>
+
 #include <algorithm>
 #include <map>
 #include <memory>
@@ -31,15 +33,19 @@ using etest::require;
 using protocol::ErrorCode;
 using protocol::Response;
 
+using Responses = std::map<std::string, tl::expected<Response, protocol::Error>>;
+
 namespace {
 
 class FakeProtocolHandler final : public protocol::IProtocolHandler {
 public:
-    explicit FakeProtocolHandler(std::map<std::string, Response> responses) : responses_{std::move(responses)} {}
-    [[nodiscard]] Response handle(uri::Uri const &uri) override { return responses_.at(uri.uri); }
+    explicit FakeProtocolHandler(Responses responses) : responses_{std::move(responses)} {}
+    [[nodiscard]] tl::expected<Response, protocol::Error> handle(uri::Uri const &uri) override {
+        return responses_.at(uri.uri);
+    }
 
 private:
-    std::map<std::string, Response> responses_;
+    Responses responses_;
 };
 
 bool contains(std::vector<css::Rule> const &stylesheet, css::Rule const &rule) {
@@ -50,10 +56,9 @@ bool contains(std::vector<css::Rule> const &stylesheet, css::Rule const &rule) {
 
 int main() {
     etest::test("css in <head><style>", [] {
-        std::map<std::string, Response> responses{{
+        Responses responses{{
                 "hax://example.com"s,
                 Response{
-                        .err = ErrorCode::Ok,
                         .status_line = {.status_code = 200},
                         .body{"<html><head><style>p { font-size: 123em; }</style></head></html>"},
                 },
@@ -68,8 +73,8 @@ int main() {
     });
 
     etest::test("navigation failure", [] {
-        engine::Engine e{std::make_unique<FakeProtocolHandler>(std::map{
-                std::pair{"hax://example.com"s, Response{.err = ErrorCode::Unresolved}},
+        engine::Engine e{std::make_unique<FakeProtocolHandler>(Responses{
+                std::pair{"hax://example.com"s, tl::unexpected{protocol::Error{ErrorCode::Unresolved}}},
         })};
 
         auto page = e.navigate(uri::Uri::parse("hax://example.com").value());
@@ -77,8 +82,8 @@ int main() {
     });
 
     etest::test("page load", [] {
-        engine::Engine e{std::make_unique<FakeProtocolHandler>(std::map{
-                std::pair{"hax://example.com"s, Response{.err = ErrorCode::Ok}},
+        engine::Engine e{std::make_unique<FakeProtocolHandler>(Responses{
+                std::pair{"hax://example.com"s, Response{}},
         })};
 
         auto page = e.navigate(uri::Uri::parse("hax://example.com").value());
@@ -86,8 +91,8 @@ int main() {
     });
 
     etest::test("layout update", [] {
-        engine::Engine e{std::make_unique<FakeProtocolHandler>(std::map{
-                std::pair{"hax://example.com"s, Response{.err = ErrorCode::Ok}},
+        engine::Engine e{std::make_unique<FakeProtocolHandler>(Responses{
+                std::pair{"hax://example.com"s, Response{}},
         })};
         e.set_layout_width(123);
 
@@ -99,10 +104,9 @@ int main() {
     });
 
     etest::test("css in <head><style> takes priority over browser built-in css", [] {
-        std::map<std::string, Response> responses{{
+        Responses responses{{
                 "hax://example.com"s,
                 Response{
-                        .err = ErrorCode::Ok,
                         .status_line = {.status_code = 200},
                         .body{"<html></html>"},
                 },
@@ -113,10 +117,9 @@ int main() {
         require(page->layout.has_value());
         expect_eq(page->layout->get_property<css::PropertyId::Display>(), style::DisplayValue::Block);
 
-        responses = std::map<std::string, Response>{{
+        responses = Responses{{
                 "hax://example.com"s,
                 Response{
-                        .err = ErrorCode::Ok,
                         .status_line = {.status_code = 200},
                         .body{"<html><head><style>html { display: inline; }</style></head></html>"},
                 },
@@ -132,10 +135,9 @@ int main() {
     });
 
     etest::test("multiple inline <head><style> elements are allowed", [] {
-        std::map<std::string, Response> responses{{
+        Responses responses{{
                 "hax://example.com"s,
                 Response{
-                        .err = ErrorCode::Ok,
                         .status_line = {.status_code = 200},
                         .body{"<html><head><style>"
                               "a { color: red; } "
@@ -156,9 +158,8 @@ int main() {
     });
 
     etest::test("stylesheet link, parallel download", [] {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"<html><head>"
                       "<link rel=stylesheet href=one.css />"
@@ -166,12 +167,10 @@ int main() {
                       "</head></html>"},
         };
         responses["hax://example.com/one.css"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"p { font-size: 123em; }"},
         };
         responses["hax://example.com/two.css"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"p { color: green; }"},
         };
@@ -183,14 +182,12 @@ int main() {
     });
 
     etest::test("stylesheet link, unsupported Content-Encoding", [] {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"<html><head><link rel=stylesheet href=lol.css /></head></html>"},
         };
         responses["hax://example.com/lol.css"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .headers{{"Content-Encoding", "really-borked-content-type"}},
                 .body{"p { font-size: 123em; }"},
@@ -209,14 +206,12 @@ int main() {
             "\x78\x5e\x2b\x50\xa8\x56\x48\xcb\xcf\x2b\xd1\x2d\xce\xac\x4a\xb5\x52\x30\x34\x32\x4e\xcd\xb5\x56\xa8\xe5\x02\x00\x63\xc3\x07\x6f"s;
 
     etest::test("stylesheet link, gzip Content-Encoding", [gzipped_css]() mutable {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"<html><head><link rel=stylesheet href=lol.css /></head></html>"},
         };
         responses["hax://example.com/lol.css"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .headers{{"Content-Encoding", "gzip"}},
                 .body{gzipped_css},
@@ -232,7 +227,6 @@ int main() {
 
         // And again, but with x-gzip instead.
         responses["hax://example.com/lol.css"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .headers{{"Content-Encoding", "x-gzip"}},
                 .body{std::move(gzipped_css)},
@@ -248,16 +242,14 @@ int main() {
     });
 
     etest::test("stylesheet link, gzip Content-Encoding, bad header", [gzipped_css]() mutable {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"<html><head><link rel=stylesheet href=lol.css /></head></html>"},
         };
         // Ruin the gzip header.
         gzipped_css[1] += 1;
         responses["hax://example.com/lol.css"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .headers{{"Content-Encoding", "gzip"}},
                 .body{std::move(gzipped_css)},
@@ -273,16 +265,14 @@ int main() {
     });
 
     etest::test("stylesheet link, gzip Content-Encoding, crc32 mismatch", [gzipped_css]() mutable {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"<html><head><link rel=stylesheet href=lol.css /></head></html>"},
         };
         // Ruin the content.
         gzipped_css[20] += 1;
         responses["hax://example.com/lol.css"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .headers{{"Content-Encoding", "gzip"}},
                 .body{std::move(gzipped_css)},
@@ -298,14 +288,12 @@ int main() {
     });
 
     etest::test("stylesheet link, gzip Content-Encoding, served zlib", [zlibbed_css] {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"<html><head><link rel=stylesheet href=lol.css /></head></html>"},
         };
         responses["hax://example.com/lol.css"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .headers{{"Content-Encoding", "gzip"}},
                 .body{zlibbed_css},
@@ -321,14 +309,12 @@ int main() {
     });
 
     etest::test("stylesheet link, deflate Content-Encoding", [zlibbed_css] {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"<html><head><link rel=stylesheet href=lol.css /></head></html>"},
         };
         responses["hax://example.com/lol.css"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .headers{{"Content-Encoding", "deflate"}},
                 .body{zlibbed_css},
@@ -344,20 +330,17 @@ int main() {
     });
 
     etest::test("redirect", [] {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 301},
                 .headers = {{"Location", "hax://example.com/redirected"}},
         };
         responses["hax://example.com/redirected"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"<html><body>hello!</body></html>"},
         };
         engine::Engine e{std::make_unique<FakeProtocolHandler>(std::move(responses))};
         auto page = e.navigate(uri::Uri::parse("hax://example.com").value()).value();
-        expect_eq(page->response.err, protocol::ErrorCode::Ok);
         expect_eq(page->uri.uri, "hax://example.com/redirected");
 
         auto const &body = std::get<dom::Element>(page->dom.html().children.at(1));
@@ -365,9 +348,8 @@ int main() {
     });
 
     etest::test("redirect not providing Location header", [] {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 301},
         };
         engine::Engine e{std::make_unique<FakeProtocolHandler>(std::move(responses))};
@@ -376,34 +358,29 @@ int main() {
     });
 
     etest::test("redirect, style", [] {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"<html><head>"
                       "<link rel=stylesheet href=hello.css />"
                       "</head></html>"},
         };
         responses["hax://example.com/hello.css"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 301},
                 .headers = {{"Location", "hax://example.com/redirected.css"}},
         };
         responses["hax://example.com/redirected.css"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"p { color: green; }"},
         };
         engine::Engine e{std::make_unique<FakeProtocolHandler>(std::move(responses))};
         auto page = e.navigate(uri::Uri::parse("hax://example.com").value()).value();
-        expect_eq(page->response.err, protocol::ErrorCode::Ok);
         expect(contains(page->stylesheet.rules, {.selectors{"p"}, .declarations{{css::PropertyId::Color, "green"}}}));
     });
 
     etest::test("redirect loop", [] {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 301},
                 .headers = {{"Location", "hax://example.com"}},
         };
@@ -413,14 +390,12 @@ int main() {
     });
 
     etest::test("load", [] {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 301},
                 .headers = {{"Location", "hax://example.com/redirected"}},
         };
         responses["hax://example.com/redirected"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{"<html><body>hello!</body></html>"},
         };
@@ -433,14 +408,13 @@ int main() {
     etest::test("IType accessor, you get what you give", [] {
         auto naive = std::make_unique<type::NaiveType>();
         type::IType const *saved = naive.get();
-        engine::Engine e{std::make_unique<FakeProtocolHandler>(std::map<std::string, Response>{}), std::move(naive)};
+        engine::Engine e{std::make_unique<FakeProtocolHandler>(Responses{}), std::move(naive)};
         expect_eq(&e.font_system(), saved);
     });
 
     etest::test("bad uri in redirect", [] {
-        std::map<std::string, Response> responses;
+        Responses responses;
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 301},
                 .headers = {{"Location", ""}},
         };
@@ -450,18 +424,17 @@ int main() {
     });
 
     etest::test("bad uri in style href", [] {
-        std::map<std::string, Response> responses;
+        Responses responses;
         std::string body = "<html><head><link rel=stylesheet href=";
         body += std::string(1025, 'a');
         body += " /></head></html>";
         responses["hax://example.com"s] = Response{
-                .err = ErrorCode::Ok,
                 .status_line = {.status_code = 200},
                 .body{std::move(body)},
         };
         engine::Engine e{std::make_unique<FakeProtocolHandler>(std::move(responses))};
-        auto page = e.navigate(uri::Uri::parse("hax://example.com").value()).value();
-        expect_eq(page->response.err, protocol::ErrorCode::Ok);
+        auto page = e.navigate(uri::Uri::parse("hax://example.com").value());
+        expect(page.has_value());
     });
 
     return etest::run_all_tests();

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -15,6 +15,7 @@ cc_library(
         "//net",
         "//uri",
         "//util:string",
+        "@expected",
         "@fmt",
     ],
 )
@@ -37,6 +38,7 @@ cc_library(
         ":protocol",
         "//etest",
         "//uri",
+        "@expected",
         "@fmt",
     ],
 ) for src in glob(

--- a/protocol/file_handler.cpp
+++ b/protocol/file_handler.cpp
@@ -9,6 +9,8 @@
 
 #include "uri/uri.h"
 
+#include <tl/expected.hpp>
+
 #include <filesystem>
 #include <fstream>
 #include <ios>
@@ -17,21 +19,21 @@
 
 namespace protocol {
 
-Response FileHandler::handle(uri::Uri const &uri) {
+tl::expected<Response, Error> FileHandler::handle(uri::Uri const &uri) {
     auto path = std::filesystem::path(uri.path);
     if (!exists(path)) {
-        return {ErrorCode::Unresolved};
+        return tl::unexpected{protocol::Error{ErrorCode::Unresolved}};
     }
 
     if (!is_regular_file(path)) {
-        return {ErrorCode::InvalidResponse};
+        return tl::unexpected{protocol::Error{ErrorCode::InvalidResponse}};
     }
 
     auto file = std::ifstream(path, std::ios::in | std::ios::binary);
     auto size = file_size(path);
     auto content = std::string(size, '\0');
     file.read(content.data(), size);
-    return {ErrorCode::Ok, {}, {}, std::move(content)};
+    return Response{{}, {}, std::move(content)};
 }
 
 } // namespace protocol

--- a/protocol/file_handler.cpp
+++ b/protocol/file_handler.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -20,18 +20,18 @@ namespace protocol {
 Response FileHandler::handle(uri::Uri const &uri) {
     auto path = std::filesystem::path(uri.path);
     if (!exists(path)) {
-        return {Error::Unresolved};
+        return {ErrorCode::Unresolved};
     }
 
     if (!is_regular_file(path)) {
-        return {Error::InvalidResponse};
+        return {ErrorCode::InvalidResponse};
     }
 
     auto file = std::ifstream(path, std::ios::in | std::ios::binary);
     auto size = file_size(path);
     auto content = std::string(size, '\0');
     file.read(content.data(), size);
-    return {Error::Ok, {}, {}, std::move(content)};
+    return {ErrorCode::Ok, {}, {}, std::move(content)};
 }
 
 } // namespace protocol

--- a/protocol/file_handler.h
+++ b/protocol/file_handler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -11,11 +11,13 @@
 
 #include "uri/uri.h"
 
+#include <tl/expected.hpp>
+
 namespace protocol {
 
 class FileHandler final : public IProtocolHandler {
 public:
-    [[nodiscard]] Response handle(uri::Uri const &uri) override;
+    [[nodiscard]] tl::expected<Response, Error> handle(uri::Uri const &uri) override;
 };
 
 } // namespace protocol

--- a/protocol/file_handler_test.cpp
+++ b/protocol/file_handler_test.cpp
@@ -63,7 +63,7 @@ int main() {
     etest::test("uri pointing to non-existent file", [] {
         protocol::FileHandler handler;
         auto res = handler.handle(uri::Uri::parse("file:///this/file/does/definitely/not/exist.hastur").value());
-        expect_eq(res, protocol::Response{protocol::Error::Unresolved});
+        expect_eq(res, protocol::Response{protocol::ErrorCode::Unresolved});
     });
 
     etest::test("uri pointing to a folder", [] {
@@ -71,7 +71,7 @@ int main() {
 
         protocol::FileHandler handler;
         auto res = handler.handle(uri::Uri::parse(fmt::format("file://{}", tmp_dir.generic_string())).value());
-        expect_eq(res, protocol::Response{protocol::Error::InvalidResponse});
+        expect_eq(res, protocol::Response{protocol::ErrorCode::InvalidResponse});
     });
 
     etest::test("uri pointing to a regular file", [] {
@@ -84,7 +84,7 @@ int main() {
 
         protocol::FileHandler handler;
         auto res = handler.handle(uri::Uri::parse(fmt::format("file://{}", tmp_file->path().generic_string())).value());
-        expect_eq(res, protocol::Response{protocol::Error::Ok, {}, {}, "hello!"});
+        expect_eq(res, protocol::Response{protocol::ErrorCode::Ok, {}, {}, "hello!"});
     });
 
     return etest::run_all_tests();

--- a/protocol/file_handler_test.cpp
+++ b/protocol/file_handler_test.cpp
@@ -63,7 +63,7 @@ int main() {
     etest::test("uri pointing to non-existent file", [] {
         protocol::FileHandler handler;
         auto res = handler.handle(uri::Uri::parse("file:///this/file/does/definitely/not/exist.hastur").value());
-        expect_eq(res, protocol::Response{protocol::ErrorCode::Unresolved});
+        expect_eq(res.error(), protocol::Error{protocol::ErrorCode::Unresolved});
     });
 
     etest::test("uri pointing to a folder", [] {
@@ -71,7 +71,7 @@ int main() {
 
         protocol::FileHandler handler;
         auto res = handler.handle(uri::Uri::parse(fmt::format("file://{}", tmp_dir.generic_string())).value());
-        expect_eq(res, protocol::Response{protocol::ErrorCode::InvalidResponse});
+        expect_eq(res.error(), protocol::Error{protocol::ErrorCode::InvalidResponse});
     });
 
     etest::test("uri pointing to a regular file", [] {
@@ -84,7 +84,7 @@ int main() {
 
         protocol::FileHandler handler;
         auto res = handler.handle(uri::Uri::parse(fmt::format("file://{}", tmp_file->path().generic_string())).value());
-        expect_eq(res, protocol::Response{protocol::ErrorCode::Ok, {}, {}, "hello!"});
+        expect_eq(res, protocol::Response{{}, {}, "hello!"});
     });
 
     return etest::run_all_tests();

--- a/protocol/http.h
+++ b/protocol/http.h
@@ -11,6 +11,8 @@
 #include "uri/uri.h"
 #include "util/string.h"
 
+#include <tl/expected.hpp>
+
 #include <charconv>
 #include <cstddef>
 #include <optional>
@@ -23,39 +25,40 @@ namespace protocol {
 
 class Http {
 public:
-    static Response get(auto &&socket, uri::Uri const &uri, std::optional<std::string_view> user_agent) {
+    static tl::expected<Response, Error> get(
+            auto &&socket, uri::Uri const &uri, std::optional<std::string_view> user_agent) {
         using namespace std::string_view_literals;
 
         if (!socket.connect(uri.authority.host, Http::use_port(uri) ? uri.authority.port : uri.scheme)) {
-            return {ErrorCode::Unresolved};
+            return tl::unexpected{Error{ErrorCode::Unresolved}};
         }
 
         socket.write(Http::create_get_request(uri, std::move(user_agent)));
         auto data = socket.read_until("\r\n"sv);
         if (data.empty()) {
-            return {ErrorCode::InvalidResponse};
+            return tl::unexpected{Error{ErrorCode::InvalidResponse}};
         }
 
         auto status_line = Http::parse_status_line(data.substr(0, data.size() - 2));
         if (!status_line) {
-            return {ErrorCode::InvalidResponse};
+            return tl::unexpected{Error{ErrorCode::InvalidResponse}};
         }
 
         data = socket.read_until("\r\n\r\n"sv);
         if (data.empty()) {
-            return {ErrorCode::InvalidResponse, std::move(*status_line)};
+            return tl::unexpected{Error{ErrorCode::InvalidResponse, std::move(status_line)}};
         }
 
         auto headers = Http::parse_headers(data.substr(0, data.size() - 4));
         if (headers.size() == 0) {
-            return {ErrorCode::InvalidResponse, std::move(*status_line)};
+            return tl::unexpected{Error{ErrorCode::InvalidResponse, std::move(status_line)}};
         }
 
         auto encoding = headers.get("transfer-encoding"sv);
         if (encoding == "chunked"sv) {
             auto body = Http::get_chunked_body(socket);
             if (!body) {
-                return {ErrorCode::InvalidResponse, std::move(*status_line)};
+                return tl::unexpected{Error{ErrorCode::InvalidResponse, std::move(status_line)}};
             }
 
             data = *body;
@@ -63,7 +66,7 @@ public:
             data = socket.read_all();
         }
 
-        return {ErrorCode::Ok, std::move(*status_line), std::move(headers), std::move(data)};
+        return Response{std::move(*status_line), std::move(headers), std::move(data)};
     }
 
 private:

--- a/protocol/http_handler.cpp
+++ b/protocol/http_handler.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -10,9 +10,11 @@
 #include "protocol/response.h"
 #include "uri/uri.h"
 
+#include <tl/expected.hpp>
+
 namespace protocol {
 
-Response HttpHandler::handle(uri::Uri const &uri) {
+tl::expected<Response, Error> HttpHandler::handle(uri::Uri const &uri) {
     return Http::get(net::Socket{}, uri, user_agent_);
 }
 

--- a/protocol/http_handler.h
+++ b/protocol/http_handler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -10,6 +10,8 @@
 
 #include "uri/uri.h"
 
+#include <tl/expected.hpp>
+
 #include <optional>
 #include <string>
 #include <utility>
@@ -20,7 +22,7 @@ class HttpHandler final : public IProtocolHandler {
 public:
     explicit HttpHandler(std::optional<std::string> user_agent) : user_agent_{std::move(user_agent)} {}
 
-    [[nodiscard]] Response handle(uri::Uri const &) override;
+    [[nodiscard]] tl::expected<Response, Error> handle(uri::Uri const &) override;
 
 private:
     std::optional<std::string> user_agent_;

--- a/protocol/http_test.cpp
+++ b/protocol/http_test.cpp
@@ -228,7 +228,7 @@ int main() {
 
         auto response = protocol::Http::get(socket, create_uri(), std::nullopt);
 
-        expect_eq(response.err, protocol::Error::InvalidResponse);
+        expect_eq(response.err, protocol::ErrorCode::InvalidResponse);
     });
 
     etest::test("transfer-encoding chunked, no separator between chunk", [] {
@@ -238,7 +238,7 @@ int main() {
 
         auto response = protocol::Http::get(socket, create_uri(), std::nullopt);
 
-        expect_eq(response.err, protocol::Error::InvalidResponse);
+        expect_eq(response.err, protocol::ErrorCode::InvalidResponse);
     });
 
     etest::test("transfer-encoding chunked, chunk too short", [] {
@@ -248,7 +248,7 @@ int main() {
 
         auto response = protocol::Http::get(socket, create_uri(), std::nullopt);
 
-        expect_eq(response.err, protocol::Error::InvalidResponse);
+        expect_eq(response.err, protocol::ErrorCode::InvalidResponse);
     });
 
     etest::test("transfer-encoding chunked, chunk too long", [] {
@@ -258,7 +258,7 @@ int main() {
 
         auto response = protocol::Http::get(socket, create_uri(), std::nullopt);
 
-        expect_eq(response.err, protocol::Error::InvalidResponse);
+        expect_eq(response.err, protocol::ErrorCode::InvalidResponse);
     });
 
     etest::test("404 no headers no body", [] {
@@ -275,26 +275,26 @@ int main() {
     etest::test("connect failure", [] {
         FakeSocket socket{.connect_result = false};
         auto response = protocol::Http::get(socket, create_uri(), std::nullopt);
-        expect_eq(response, protocol::Response{.err = protocol::Error::Unresolved});
+        expect_eq(response, protocol::Response{.err = protocol::ErrorCode::Unresolved});
     });
 
     etest::test("empty response", [] {
         FakeSocket socket{};
         auto response = protocol::Http::get(socket, create_uri(), std::nullopt);
-        expect_eq(response, protocol::Response{.err = protocol::Error::InvalidResponse});
+        expect_eq(response, protocol::Response{.err = protocol::ErrorCode::InvalidResponse});
     });
 
     etest::test("empty status line", [] {
         FakeSocket socket{.read_data = "\r\n"};
         auto response = protocol::Http::get(socket, create_uri(), std::nullopt);
-        expect_eq(response, protocol::Response{.err = protocol::Error::InvalidResponse});
+        expect_eq(response, protocol::Response{.err = protocol::ErrorCode::InvalidResponse});
     });
 
     etest::test("no headers", [] {
         FakeSocket socket{.read_data = "HTTP/1.1 200 OK\r\n \r\n\r\n"};
         auto response = protocol::Http::get(socket, create_uri(), std::nullopt);
         expect_eq(response,
-                protocol::Response{.err = protocol::Error::InvalidResponse, .status_line{"HTTP/1.1", 200, "OK"}});
+                protocol::Response{.err = protocol::ErrorCode::InvalidResponse, .status_line{"HTTP/1.1", 200, "OK"}});
     });
 
     etest::test("mixed valid and invalid headers", [] {
@@ -302,7 +302,7 @@ int main() {
         auto response = protocol::Http::get(socket, create_uri(), std::nullopt);
         expect_eq(response,
                 protocol::Response{
-                        .err = protocol::Error::Ok,
+                        .err = protocol::ErrorCode::Ok,
                         .status_line{"HTTP/1.1", 200, "OK"},
                         .headers{{"one", "1"}, {"two", "2"}},
                 });

--- a/protocol/https_handler.cpp
+++ b/protocol/https_handler.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -10,9 +10,11 @@
 #include "protocol/response.h"
 #include "uri/uri.h"
 
+#include <tl/expected.hpp>
+
 namespace protocol {
 
-Response HttpsHandler::handle(uri::Uri const &uri) {
+tl::expected<Response, Error> HttpsHandler::handle(uri::Uri const &uri) {
     return Http::get(net::SecureSocket{}, uri, user_agent_);
 }
 

--- a/protocol/https_handler.h
+++ b/protocol/https_handler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -10,6 +10,8 @@
 
 #include "uri/uri.h"
 
+#include <tl/expected.hpp>
+
 #include <optional>
 #include <string>
 #include <utility>
@@ -20,7 +22,7 @@ class HttpsHandler final : public IProtocolHandler {
 public:
     explicit HttpsHandler(std::optional<std::string> user_agent) : user_agent_{std::move(user_agent)} {}
 
-    [[nodiscard]] Response handle(uri::Uri const &) override;
+    [[nodiscard]] tl::expected<Response, Error> handle(uri::Uri const &) override;
 
 private:
     std::optional<std::string> user_agent_;

--- a/protocol/iprotocol_handler.h
+++ b/protocol/iprotocol_handler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -9,12 +9,14 @@
 
 #include "uri/uri.h"
 
+#include <tl/expected.hpp>
+
 namespace protocol {
 
 class IProtocolHandler {
 public:
     virtual ~IProtocolHandler() = default;
-    [[nodiscard]] virtual Response handle(uri::Uri const &) = 0;
+    [[nodiscard]] virtual tl::expected<Response, Error> handle(uri::Uri const &) = 0;
 };
 
 } // namespace protocol

--- a/protocol/multi_protocol_handler.h
+++ b/protocol/multi_protocol_handler.h
@@ -8,6 +8,8 @@
 
 #include "uri/uri.h"
 
+#include <tl/expected.hpp>
+
 #include <functional>
 #include <map>
 #include <memory>
@@ -22,12 +24,12 @@ public:
         handlers_[std::move(protocol)] = std::move(handler);
     }
 
-    [[nodiscard]] Response handle(uri::Uri const &uri) override {
+    [[nodiscard]] tl::expected<Response, Error> handle(uri::Uri const &uri) override {
         if (auto it = handlers_.find(uri.scheme); it != handlers_.end()) {
             return it->second->handle(uri);
         }
 
-        return {ErrorCode::Unhandled};
+        return tl::unexpected{Error{ErrorCode::Unhandled}};
     }
 
 private:

--- a/protocol/multi_protocol_handler.h
+++ b/protocol/multi_protocol_handler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -27,7 +27,7 @@ public:
             return it->second->handle(uri);
         }
 
-        return {Error::Unhandled};
+        return {ErrorCode::Unhandled};
     }
 
 private:

--- a/protocol/multi_protocol_handler_test.cpp
+++ b/protocol/multi_protocol_handler_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -32,10 +32,10 @@ private:
 int main() {
     etest::test("added protocols are handled", [] {
         MultiProtocolHandler handler;
-        expect_eq(handler.handle(uri::Uri{.scheme = "hax"}).err, protocol::Error::Unhandled);
+        expect_eq(handler.handle(uri::Uri{.scheme = "hax"}).err, protocol::ErrorCode::Unhandled);
 
-        handler.add("hax", std::make_unique<FakeProtocolHandler>(protocol::Response{protocol::Error::Ok}));
-        expect_eq(handler.handle(uri::Uri{.scheme = "hax"}).err, protocol::Error::Ok);
+        handler.add("hax", std::make_unique<FakeProtocolHandler>(protocol::Response{protocol::ErrorCode::Ok}));
+        expect_eq(handler.handle(uri::Uri{.scheme = "hax"}).err, protocol::ErrorCode::Ok);
     });
 
     return etest::run_all_tests();

--- a/protocol/multi_protocol_handler_test.cpp
+++ b/protocol/multi_protocol_handler_test.cpp
@@ -10,6 +10,8 @@
 #include "etest/etest.h"
 #include "uri/uri.h"
 
+#include <tl/expected.hpp>
+
 #include <memory>
 #include <utility>
 
@@ -21,10 +23,12 @@ namespace {
 class FakeProtocolHandler final : public protocol::IProtocolHandler {
 public:
     explicit FakeProtocolHandler(protocol::Response response) : response_{std::move(response)} {}
-    [[nodiscard]] protocol::Response handle(uri::Uri const &) override { return response_; }
+    [[nodiscard]] tl::expected<protocol::Response, protocol::Error> handle(uri::Uri const &) override {
+        return response_;
+    }
 
 private:
-    protocol::Response response_;
+    tl::expected<protocol::Response, protocol::Error> response_;
 };
 
 } // namespace
@@ -32,10 +36,11 @@ private:
 int main() {
     etest::test("added protocols are handled", [] {
         MultiProtocolHandler handler;
-        expect_eq(handler.handle(uri::Uri{.scheme = "hax"}).err, protocol::ErrorCode::Unhandled);
+        expect_eq(handler.handle(uri::Uri{.scheme = "hax"}),
+                tl::unexpected{protocol::Error{protocol::ErrorCode::Unhandled}});
 
-        handler.add("hax", std::make_unique<FakeProtocolHandler>(protocol::Response{protocol::ErrorCode::Ok}));
-        expect_eq(handler.handle(uri::Uri{.scheme = "hax"}).err, protocol::ErrorCode::Ok);
+        handler.add("hax", std::make_unique<FakeProtocolHandler>(protocol::Response{}));
+        expect_eq(handler.handle(uri::Uri{.scheme = "hax"}), protocol::Response{});
     });
 
     return etest::run_all_tests();

--- a/protocol/response.cpp
+++ b/protocol/response.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -17,17 +17,17 @@
 
 namespace protocol {
 
-std::string_view to_string(Error e) {
+std::string_view to_string(ErrorCode e) {
     switch (e) {
-        case Error::Ok:
+        case ErrorCode::Ok:
             return "Ok";
-        case Error::Unresolved:
+        case ErrorCode::Unresolved:
             return "Unresolved";
-        case Error::Unhandled:
+        case ErrorCode::Unhandled:
             return "Unhandled";
-        case Error::InvalidResponse:
+        case ErrorCode::InvalidResponse:
             return "InvalidResponse";
-        case Error::RedirectLimit:
+        case ErrorCode::RedirectLimit:
             return "RedirectLimit";
     }
     return "Unknown";

--- a/protocol/response.cpp
+++ b/protocol/response.cpp
@@ -19,8 +19,6 @@ namespace protocol {
 
 std::string_view to_string(ErrorCode e) {
     switch (e) {
-        case ErrorCode::Ok:
-            return "Ok";
         case ErrorCode::Unresolved:
             return "Unresolved";
         case ErrorCode::Unhandled:

--- a/protocol/response.h
+++ b/protocol/response.h
@@ -56,12 +56,18 @@ private:
 };
 
 struct Response {
-    ErrorCode err{};
     StatusLine status_line;
     Headers headers;
     std::string body;
 
     [[nodiscard]] bool operator==(Response const &) const = default;
+};
+
+struct Error {
+    ErrorCode err{};
+    std::optional<StatusLine> status_line;
+
+    [[nodiscard]] bool operator==(Error const &) const = default;
 };
 
 } // namespace protocol

--- a/protocol/response.h
+++ b/protocol/response.h
@@ -18,7 +18,6 @@
 namespace protocol {
 
 enum class ErrorCode : std::uint8_t {
-    Ok,
     Unresolved,
     Unhandled,
     InvalidResponse,

--- a/protocol/response.h
+++ b/protocol/response.h
@@ -17,7 +17,7 @@
 
 namespace protocol {
 
-enum class Error : std::uint8_t {
+enum class ErrorCode : std::uint8_t {
     Ok,
     Unresolved,
     Unhandled,
@@ -25,7 +25,7 @@ enum class Error : std::uint8_t {
     RedirectLimit,
 };
 
-std::string_view to_string(Error);
+std::string_view to_string(ErrorCode);
 
 struct StatusLine {
     std::string version;
@@ -56,7 +56,7 @@ private:
 };
 
 struct Response {
-    Error err{};
+    ErrorCode err{};
     StatusLine status_line;
     Headers headers;
     std::string body;

--- a/protocol/response_test.cpp
+++ b/protocol/response_test.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2021-2022 Mikael Larsson <c.mikael.larsson@gmail.com>
-// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -37,15 +37,15 @@ int main() {
         expect_eq(headers.get("cOnTeNt-TyPe"sv).value(), "text/html");
     });
 
-    etest::test("error, to_string", [] {
-        using protocol::Error;
-        expect_eq(to_string(Error::Ok), "Ok"sv);
-        expect_eq(to_string(Error::Unresolved), "Unresolved"sv);
-        expect_eq(to_string(Error::Unhandled), "Unhandled"sv);
-        expect_eq(to_string(Error::InvalidResponse), "InvalidResponse"sv);
-        expect_eq(to_string(Error::RedirectLimit), "RedirectLimit"sv);
+    etest::test("ErrorCode, to_string", [] {
+        using protocol::ErrorCode;
+        expect_eq(to_string(ErrorCode::Ok), "Ok"sv);
+        expect_eq(to_string(ErrorCode::Unresolved), "Unresolved"sv);
+        expect_eq(to_string(ErrorCode::Unhandled), "Unhandled"sv);
+        expect_eq(to_string(ErrorCode::InvalidResponse), "InvalidResponse"sv);
+        expect_eq(to_string(ErrorCode::RedirectLimit), "RedirectLimit"sv);
         // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
-        expect_eq(to_string(static_cast<Error>(std::underlying_type_t<Error>{20})), "Unknown"sv);
+        expect_eq(to_string(static_cast<ErrorCode>(std::underlying_type_t<ErrorCode>{20})), "Unknown"sv);
     });
 
     return etest::run_all_tests();

--- a/protocol/response_test.cpp
+++ b/protocol/response_test.cpp
@@ -39,7 +39,6 @@ int main() {
 
     etest::test("ErrorCode, to_string", [] {
         using protocol::ErrorCode;
-        expect_eq(to_string(ErrorCode::Ok), "Ok"sv);
         expect_eq(to_string(ErrorCode::Unresolved), "Unresolved"sv);
         expect_eq(to_string(ErrorCode::Unhandled), "Unhandled"sv);
         expect_eq(to_string(ErrorCode::InvalidResponse), "InvalidResponse"sv);


### PR DESCRIPTION
Previously, we'd return a `Reponse` w/ `ErrorCode::Ok` for success and a `Response` w/ a non-`Ok` error code and no headers or body for an error. Now `Response` has no error code, and we have a separate `Error` struct with only an error code and an optional status line, which was what you really got in the error case before.