### PR TITLE
browser/gui: Fix crash on favicon image data load failure

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -583,8 +583,13 @@ void App::on_page_loaded() {
 
         auto icon = engine_.load(*uri).response;
         sf::Image favicon;
-        if (!icon.has_value() || !favicon.loadFromMemory(icon->body.data(), icon->body.size())) {
+        if (!icon.has_value()) {
             spdlog::warn("Error loading favicon from '{}': {}", uri->uri, to_string(icon.error().err));
+            continue;
+        }
+
+        if (!favicon.loadFromMemory(icon->body.data(), icon->body.size())) {
+            spdlog::warn("Error parsing favicon data from '{}'", uri->uri);
             continue;
         }
 


### PR DESCRIPTION
We were accessing error() of a tl::expected when downloading the favicon worked but SFML failed to load it as an image.

Introduced in 7622d7444a095980cad794658e5b888ceeacdb58.