### PR TITLE
ci: Make the link-liveness job output easier to skim

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -359,7 +359,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - run: grep --recursive --no-filename --only-matching --exclude-dir="*corpus" --exclude=WORKSPACE --exclude=*test.cpp --exclude=ci.yaml 'https://[^)(}{",# ]*' | grep -v '^https://$' | sort | uniq | xargs wget --spider
+      - run: grep --recursive --no-filename --only-matching --exclude-dir="*corpus" --exclude=WORKSPACE --exclude=*test.cpp --exclude=ci.yaml 'https://[^)(}{",# ]*' | grep -v '^https://$' | sort | uniq | xargs wget --spider --no-verbose
 
   gitlint:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Before:
```
Spider mode enabled. Check if remote file exists.
--2024-05-13 23:26:46--  https://bazel.build/
Resolving bazel.build (bazel.build)... 216.58.211.14, 2a00:1450:400f:803::200e
Connecting to bazel.build (bazel.build)|216.58.211.14|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 77416 (76K) [text/html]
Remote file exists and could contain further links,
but recursion is disabled -- not retrieving.

Spider mode enabled. Check if remote file exists.
--2024-05-13 23:26:47--  https://broken-link.robinlinden.eu/
Resolving broken-link.robinlinden.eu (broken-link.robinlinden.eu)... failed: Name or service not known.
wget: unable to resolve host address ‘broken-link.robinlinden.eu’
```

After:
```
2024-05-13 23:26:55 URL: https://bazel.build/ 200 OK
wget: unable to resolve host address ‘broken-link.robinlinden.eu’
```