### PR TITLE
Calculate prefers-color-scheme media queries based on the OS dark mode preference

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -13,6 +13,7 @@
 #include "gfx/opengl_canvas.h"
 #include "gfx/sfml_canvas.h"
 #include "layout/layout_box.h"
+#include "os/system_info.h"
 #include "protocol/handler_factory.h"
 #include "protocol/response.h"
 #include "render/render.h"
@@ -776,7 +777,10 @@ void App::switch_canvas() {
 }
 
 engine::Options App::make_options() const {
-    return {.layout_width = static_cast<int>(window_.getSize().x / scale_)};
+    return {
+            .layout_width = static_cast<int>(window_.getSize().x / scale_),
+            .dark_mode = os::is_dark_mode(),
+    };
 }
 
 } // namespace browser::gui

--- a/browser/gui/app.h
+++ b/browser/gui/app.h
@@ -108,6 +108,8 @@ private:
     void show_render_surface();
 
     void switch_canvas();
+
+    engine::Options make_options() const;
 };
 
 } // namespace browser::gui

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -6,6 +6,7 @@
 
 #include "archive/zlib.h"
 #include "css/default.h"
+#include "css/media_query.h"
 #include "css/parser.h"
 #include "css/style_sheet.h"
 #include "dom/dom.h"
@@ -28,6 +29,16 @@
 using namespace std::literals;
 
 namespace engine {
+namespace {
+
+css::MediaQuery::Context to_media_context(Options opts) {
+    return {
+            .window_width = opts.layout_width,
+            .color_scheme = opts.dark_mode ? css::ColorScheme::Dark : css::ColorScheme::Light,
+    };
+}
+
+} // namespace
 
 tl::expected<std::unique_ptr<PageState>, NavigationError> Engine::navigate(uri::Uri uri, Options opts) {
     auto result = load(std::move(uri));
@@ -126,7 +137,7 @@ tl::expected<std::unique_ptr<PageState>, NavigationError> Engine::navigate(uri::
 
     spdlog::info("Styling dom w/ {} rules", state->stylesheet.rules.size());
     state->layout_width = opts.layout_width;
-    state->styled = style::style_tree(state->dom.html_node, state->stylesheet, {.window_width = state->layout_width});
+    state->styled = style::style_tree(state->dom.html_node, state->stylesheet, to_media_context(opts));
     state->layout = layout::create_layout(*state->styled, state->layout_width, *type_);
 
     return state;
@@ -134,7 +145,7 @@ tl::expected<std::unique_ptr<PageState>, NavigationError> Engine::navigate(uri::
 
 void Engine::relayout(PageState &state, Options opts) {
     state.layout_width = opts.layout_width;
-    state.styled = style::style_tree(state.dom.html_node, state.stylesheet, {.window_width = state.layout_width});
+    state.styled = style::style_tree(state.dom.html_node, state.stylesheet, to_media_context(opts));
     state.layout = layout::create_layout(*state.styled, state.layout_width, *type_);
 }
 

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -29,7 +29,7 @@ using namespace std::literals;
 
 namespace engine {
 
-tl::expected<std::unique_ptr<PageState>, NavigationError> Engine::navigate(uri::Uri uri) {
+tl::expected<std::unique_ptr<PageState>, NavigationError> Engine::navigate(uri::Uri uri, Options opts) {
     auto result = load(std::move(uri));
 
     if (!result.response.has_value()) {
@@ -125,15 +125,15 @@ tl::expected<std::unique_ptr<PageState>, NavigationError> Engine::navigate(uri::
     }
 
     spdlog::info("Styling dom w/ {} rules", state->stylesheet.rules.size());
-    state->layout_width = layout_width_;
+    state->layout_width = opts.layout_width;
     state->styled = style::style_tree(state->dom.html_node, state->stylesheet, {.window_width = state->layout_width});
     state->layout = layout::create_layout(*state->styled, state->layout_width, *type_);
 
     return state;
 }
 
-void Engine::relayout(PageState &state, int width) {
-    state.layout_width = width;
+void Engine::relayout(PageState &state, Options opts) {
+    state.layout_width = opts.layout_width;
     state.styled = style::style_tree(state.dom.html_node, state.stylesheet, {.window_width = state.layout_width});
     state.layout = layout::create_layout(*state.styled, state.layout_width, *type_);
 }

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -27,6 +27,7 @@ namespace engine {
 struct Options {
     // Default chosen by rolling 1d600.
     int layout_width{600};
+    bool dark_mode{false};
 };
 
 struct PageState {

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -24,6 +24,11 @@
 
 namespace engine {
 
+struct Options {
+    // Default chosen by rolling 1d600.
+    int layout_width{600};
+};
+
 struct PageState {
     uri::Uri uri{};
     protocol::Response response{};
@@ -45,11 +50,9 @@ public:
             std::unique_ptr<type::IType> type = std::make_unique<type::NaiveType>())
         : protocol_handler_{std::move(protocol_handler)}, type_{std::move(type)} {}
 
-    void set_layout_width(int layout_width) { layout_width_ = layout_width; }
+    [[nodiscard]] tl::expected<std::unique_ptr<PageState>, NavigationError> navigate(uri::Uri, Options = {});
 
-    [[nodiscard]] tl::expected<std::unique_ptr<PageState>, NavigationError> navigate(uri::Uri);
-
-    void relayout(PageState &, int layout_width);
+    void relayout(PageState &, Options);
 
     struct [[nodiscard]] LoadResult {
         tl::expected<protocol::Response, protocol::Error> response;
@@ -62,7 +65,6 @@ public:
 private:
     std::unique_ptr<protocol::IProtocolHandler> protocol_handler_{};
     std::unique_ptr<type::IType> type_{};
-    int layout_width_{600}; // Default chosen by rolling 1d600.
 };
 
 } // namespace engine

--- a/engine/engine_test.cpp
+++ b/engine/engine_test.cpp
@@ -94,12 +94,11 @@ int main() {
         engine::Engine e{std::make_unique<FakeProtocolHandler>(Responses{
                 std::pair{"hax://example.com"s, Response{}},
         })};
-        e.set_layout_width(123);
 
-        auto page = e.navigate(uri::Uri::parse("hax://example.com").value()).value();
+        auto page = e.navigate(uri::Uri::parse("hax://example.com").value(), {.layout_width = 123}).value();
         expect_eq(page->layout_width, 123);
 
-        e.relayout(*page, 100);
+        e.relayout(*page, {.layout_width = 100});
         expect_eq(page->layout_width, 100);
     });
 

--- a/os/BUILD
+++ b/os/BUILD
@@ -64,6 +64,7 @@ cc_library(
         "@platforms//os:linux": [],
         "@platforms//os:macos": [],
         "@platforms//os:windows": [
+            "-DEFAULTLIB:Advapi32",
             "-DEFAULTLIB:Shcore",
             "-DEFAULTLIB:User32",
         ],

--- a/os/memory_windows.cpp
+++ b/os/memory_windows.cpp
@@ -4,7 +4,7 @@
 
 #include "os/memory.h"
 
-#include "os/windows_setup.h"
+#include "os/windows_setup.h" // IWYU pragma: keep
 
 #include <Memoryapi.h>
 

--- a/os/system_info.h
+++ b/os/system_info.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -7,6 +7,7 @@
 
 namespace os {
 unsigned active_window_scale_factor();
+bool is_dark_mode();
 } // namespace os
 
 #endif

--- a/os/system_info_linux.cpp
+++ b/os/system_info_linux.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -28,6 +28,14 @@ unsigned active_window_scale_factor() {
     }
 
     return 1;
+}
+
+bool is_dark_mode() {
+    if (auto const *env_var = std::getenv("HST_DARK_MODE")) {
+        return std::strcmp(env_var, "1") == 0;
+    }
+
+    return false;
 }
 
 // NOLINTEND(concurrency-mt-unsafe)

--- a/os/system_info_linux_test.cpp
+++ b/os/system_info_linux_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -28,6 +28,8 @@ int main() {
     unsetenv("GDK_SCALE");
     unsetenv("ELM_SCALE");
 
+    unsetenv("HST_DARK_MODE");
+
     s.add_test("active_window_scale_factor", [](etest::IActions &a) {
         static constexpr int kOnlyIfUnset = 0;
 
@@ -45,6 +47,19 @@ int main() {
 
         setenv("HST_SCALE", "50", kOnlyIfUnset);
         a.expect_eq(os::active_window_scale_factor(), 50u);
+    });
+
+    s.add_test("is_dark_mode", [](etest::IActions &a) {
+        static constexpr int kOverwrite = 1;
+
+        // We default to false.
+        a.expect_eq(os::is_dark_mode(), false);
+
+        setenv("HST_DARK_MODE", "0", kOverwrite);
+        a.expect_eq(os::is_dark_mode(), false);
+
+        setenv("HST_DARK_MODE", "1", kOverwrite);
+        a.expect_eq(os::is_dark_mode(), true);
     });
 
     return s.run();

--- a/os/system_info_windows.cpp
+++ b/os/system_info_windows.cpp
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "os/system_info.h"
 
-#include "os/windows_setup.h"
+#include "os/windows_setup.h" // IWYU pragma: keep
 
 #include <shellscalingapi.h>
 

--- a/os/system_info_windows.cpp
+++ b/os/system_info_windows.cpp
@@ -8,14 +8,17 @@
 
 #include <shellscalingapi.h>
 
+#include <array>
 #include <charconv>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
+#include <iostream>
 
 namespace os {
+// NOLINTBEGIN(concurrency-mt-unsafe): We never modify the environment variables.
 
 unsigned active_window_scale_factor() {
-    // NOLINTNEXTLINE(concurrency-mt-unsafe): We never modify the environment variables.
     if (auto const *env_var = std::getenv("HST_SCALE")) {
         if (int result{}; std::from_chars(env_var, env_var + std::strlen(env_var), result).ec == std::errc{}) {
             return result;
@@ -31,4 +34,23 @@ unsigned active_window_scale_factor() {
     return static_cast<unsigned>(std::lround(static_cast<float>(scale_factor) / 100.f));
 }
 
+bool is_dark_mode() {
+    if (auto const *env_var = std::getenv("HST_DARK_MODE")) {
+        return std::strcmp(env_var, "1") == 0;
+    }
+
+    std::array<std::uint8_t, sizeof(DWORD)> value{};
+    auto size = static_cast<DWORD>(value.size());
+    static constexpr auto *kPath = R"(Software\Microsoft\Windows\CurrentVersion\Themes\Personalize)";
+    if (auto ret = RegGetValueA(
+                HKEY_CURRENT_USER, kPath, "AppsUseLightTheme", RRF_RT_REG_DWORD, nullptr, value.data(), &size);
+            ret != ERROR_SUCCESS) {
+        std::cerr << "Unable to read system dark mode preference: '" << ret << "'\n";
+        return false;
+    }
+
+    return value[0] == 0;
+}
+
+// NOLINTEND(concurrency-mt-unsafe)
 } // namespace os

--- a/os/xdg_windows.cpp
+++ b/os/xdg_windows.cpp
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "os/xdg.h"
 
-#include "os/windows_setup.h"
+#include "os/windows_setup.h" // IWYU pragma: keep
 
 #include <Knownfolders.h>
 #include <Objbase.h>


### PR DESCRIPTION
The default is light mode, but you can force it to dark mode by setting the `HST_DARK_MODE` env var to `1`.

Working out if the user wants dark mode or not on Linux is a bunch of work, so that's a todo for someone in the future.