### PR TITLE
ci: Update to clang-format 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -298,10 +298,10 @@ jobs:
       - name: Set up the llvm repository
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
-      - run: sudo apt-get update && sudo apt-get install --no-install-recommends clang-format-17
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main"
+      - run: sudo apt-get update && sudo apt-get install --no-install-recommends clang-format-18
       - name: Format
-        run: find . -name "*.h" -o -name "*.cpp" | xargs clang-format-17 -style=file -i
+        run: find . -name "*.h" -o -name "*.cpp" | xargs clang-format-18 -style=file -i
       - name: Check
         run: git diff --exit-code
 

--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -228,7 +228,7 @@ std::unique_ptr<type::IType> create_font_system() {
 App::App(std::string browser_title, std::string start_page_hint, bool load_start_page)
     : engine_{protocol::HandlerFactory::create(
                       "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0"),
-            create_font_system()},
+              create_font_system()},
       browser_title_{std::move(browser_title)},
       window_{sf::VideoMode(kDefaultResolutionX, kDefaultResolutionY), browser_title_},
       url_buf_{std::move(start_page_hint)},
@@ -750,9 +750,9 @@ void App::render_layout() {
         render::render_layout(*canvas_,
                 *layout,
                 culling_enabled_ ? std::optional{geom::Rect{0,
-                        -scroll_offset_y_,
-                        static_cast<int>(window_.getSize().x),
-                        static_cast<int>(window_.getSize().y)}}
+                                           -scroll_offset_y_,
+                                           static_cast<int>(window_.getSize().x),
+                                           static_cast<int>(window_.getSize().y)}}
                                  : std::nullopt);
     }
 }

--- a/url/url_test.cpp
+++ b/url/url_test.cpp
@@ -304,7 +304,7 @@ int main() {
     etest::test("URL parsing: ipv6 and port", [] {
         url::UrlParser p;
 
-        const std::array<std::uint16_t, 8> addr{0x2001, 0xdb8, 0x85a3, 0, 0, 0x8a2e, 0x370, 0x7334};
+        std::array<std::uint16_t, 8> const addr{0x2001, 0xdb8, 0x85a3, 0, 0, 0x8a2e, 0x370, 0x7334};
 
         std::optional<url::Url> url = p.parse("https://[2001:db8:85a3::8a2e:370:7334]:631");
 
@@ -323,7 +323,7 @@ int main() {
     etest::test("URL parsing: ipv6 v4-mapped with port", [] {
         url::UrlParser p;
 
-        const std::array<std::uint16_t, 8> addr{0, 0, 0, 0, 0, 0xffff, 0x4ccb, 0x8c22};
+        std::array<std::uint16_t, 8> const addr{0, 0, 0, 0, 0, 0xffff, 0x4ccb, 0x8c22};
 
         std::optional<url::Url> url = p.parse("https://[0000:0000:0000:0000:0000:ffff:4ccb:8c22]:631");
 
@@ -342,7 +342,7 @@ int main() {
     etest::test("URL parsing: ipv6 v4-mapped compressed with dot-decimal", [] {
         url::UrlParser p;
 
-        const std::array<std::uint16_t, 8> addr{0, 0, 0, 0, 0, 0xffff, 0x4ccb, 0x8c22};
+        std::array<std::uint16_t, 8> const addr{0, 0, 0, 0, 0, 0xffff, 0x4ccb, 0x8c22};
 
         std::optional<url::Url> url = p.parse("https://[::ffff:76.203.140.34]:631");
 


### PR DESCRIPTION
Looks like 18 is better at west vs east const and deals with indentation differently somehow.