### PR TITLE
 layout: Apply text-transform transforms 

### DIFF
--- a/css/property_id.cpp
+++ b/css/property_id.cpp
@@ -160,6 +160,9 @@ std::map<css::PropertyId, std::string_view> const initial_values{
         {css::PropertyId::TextDecorationLine, "none"sv},
         {css::PropertyId::TextDecorationStyle, "solid"sv},
 
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#formal_definition
+        {css::PropertyId::TextTransform, "none"sv},
+
         // https://developer.mozilla.org/en-US/docs/Web/CSS/border-color#formal_definition
         {css::PropertyId::BorderBottomColor, "currentcolor"sv},
         {css::PropertyId::BorderLeftColor, "currentcolor"sv},

--- a/layout/BUILD
+++ b/layout/BUILD
@@ -28,6 +28,7 @@ cc_library(
     name = src[:-4],
     size = "small",
     srcs = [src],
+    copts = HASTUR_COPTS,
     deps = [
         ":layout",
         "//css",

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -333,6 +333,152 @@ void whitespace_collapsing_tests() {
     });
 }
 
+void text_transform_tests() {
+    etest::test("text-transform: uppercase", [] {
+        constexpr auto kText = "hello   goodbye"sv;
+        constexpr auto kExpectedText = "HELLO GOODBYE"sv;
+        constexpr auto kTextWidth = kExpectedText.length() * 5;
+
+        dom::Element p{.name{"p"}, .children{dom::Text{std::string{kText}}}};
+        dom::Node html = dom::Element{.name{"html"}, .children{std::move(p)}};
+        dom::Element const &html_element = std::get<dom::Element>(html);
+
+        style::StyledNode p_style{
+                .node{html_element.children[0]},
+                .properties{{css::PropertyId::Display, "inline"}, {css::PropertyId::TextTransform, "uppercase"}},
+                .children{style::StyledNode{std::get<dom::Element>(html_element.children.at(0)).children.at(0)}},
+        };
+        style::StyledNode style{
+                .node{html},
+                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .children{std::move(p_style)},
+        };
+        set_up_parent_ptrs(style);
+
+        layout::LayoutBox p_layout{
+                .node = &style.children.at(0),
+                .type = LayoutType::Inline,
+                .dimensions{{0, 0, kTextWidth, 10}},
+                .children{layout::LayoutBox{
+                        .node = &style.children.at(0).children.at(0),
+                        .type = LayoutType::Inline,
+                        .dimensions{{0, 0, kTextWidth, 10}},
+                        .layout_text{std::string{kExpectedText}},
+                }},
+        };
+        layout::LayoutBox expected_layout{
+                .node = &style,
+                .type = LayoutType::Block,
+                .dimensions{{0, 0, 1234, 10}},
+                .children{layout::LayoutBox{
+                        .node = nullptr,
+                        .type = LayoutType::AnonymousBlock,
+                        .dimensions{{0, 0, kTextWidth, 10}},
+                        .children{std::move(p_layout)},
+                }},
+        };
+
+        auto actual = layout::create_layout(style, 1234);
+        expect_eq(actual, expected_layout);
+    });
+
+    etest::test("text-transform: lowercase", [] {
+        constexpr auto kText = "HELLO   GOODBYE"sv;
+        constexpr auto kExpectedText = "hello goodbye"sv;
+        constexpr auto kTextWidth = kExpectedText.length() * 5;
+
+        dom::Element p{.name{"p"}, .children{dom::Text{std::string{kText}}}};
+        dom::Node html = dom::Element{.name{"html"}, .children{std::move(p)}};
+        dom::Element const &html_element = std::get<dom::Element>(html);
+
+        style::StyledNode p_style{
+                .node{html_element.children[0]},
+                .properties{{css::PropertyId::Display, "inline"}, {css::PropertyId::TextTransform, "lowercase"}},
+                .children{style::StyledNode{std::get<dom::Element>(html_element.children.at(0)).children.at(0)}},
+        };
+        style::StyledNode style{
+                .node{html},
+                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .children{std::move(p_style)},
+        };
+        set_up_parent_ptrs(style);
+
+        layout::LayoutBox p_layout{
+                .node = &style.children.at(0),
+                .type = LayoutType::Inline,
+                .dimensions{{0, 0, kTextWidth, 10}},
+                .children{layout::LayoutBox{
+                        .node = &style.children.at(0).children.at(0),
+                        .type = LayoutType::Inline,
+                        .dimensions{{0, 0, kTextWidth, 10}},
+                        .layout_text{std::string{kExpectedText}},
+                }},
+        };
+        layout::LayoutBox expected_layout{
+                .node = &style,
+                .type = LayoutType::Block,
+                .dimensions{{0, 0, 1234, 10}},
+                .children{layout::LayoutBox{
+                        .node = nullptr,
+                        .type = LayoutType::AnonymousBlock,
+                        .dimensions{{0, 0, kTextWidth, 10}},
+                        .children{std::move(p_layout)},
+                }},
+        };
+
+        auto actual = layout::create_layout(style, 1234);
+        expect_eq(actual, expected_layout);
+    });
+
+    etest::test("text-transform: capitalize", [] {
+        constexpr auto kText = "HE?LO   GOODBYE!"sv;
+        constexpr auto kExpectedText = "He?Lo Goodbye!"sv;
+        constexpr auto kTextWidth = kExpectedText.length() * 5;
+
+        dom::Element p{.name{"p"}, .children{dom::Text{std::string{kText}}}};
+        dom::Node html = dom::Element{.name{"html"}, .children{std::move(p)}};
+        dom::Element const &html_element = std::get<dom::Element>(html);
+
+        style::StyledNode p_style{
+                .node{html_element.children[0]},
+                .properties{{css::PropertyId::Display, "inline"}, {css::PropertyId::TextTransform, "capitalize"}},
+                .children{style::StyledNode{std::get<dom::Element>(html_element.children.at(0)).children.at(0)}},
+        };
+        style::StyledNode style{
+                .node{html},
+                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .children{std::move(p_style)},
+        };
+        set_up_parent_ptrs(style);
+
+        layout::LayoutBox p_layout{
+                .node = &style.children.at(0),
+                .type = LayoutType::Inline,
+                .dimensions{{0, 0, kTextWidth, 10}},
+                .children{layout::LayoutBox{
+                        .node = &style.children.at(0).children.at(0),
+                        .type = LayoutType::Inline,
+                        .dimensions{{0, 0, kTextWidth, 10}},
+                        .layout_text{std::string{kExpectedText}},
+                }},
+        };
+        layout::LayoutBox expected_layout{
+                .node = &style,
+                .type = LayoutType::Block,
+                .dimensions{{0, 0, 1234, 10}},
+                .children{layout::LayoutBox{
+                        .node = nullptr,
+                        .type = LayoutType::AnonymousBlock,
+                        .dimensions{{0, 0, kTextWidth, 10}},
+                        .children{std::move(p_layout)},
+                }},
+        };
+
+        auto actual = layout::create_layout(style, 1234);
+        expect_eq(actual, expected_layout);
+    });
+}
+
 void img_tests() {
     etest::test("img, no alt or src", [] {
         dom::Node dom = dom::Element{"body", {}, {dom::Element{"img"}}};
@@ -1707,6 +1853,7 @@ int main() {
     });
 
     whitespace_collapsing_tests();
+    text_transform_tests();
     img_tests();
 
     return etest::run_all_tests();

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -439,6 +439,36 @@ std::vector<TextDecorationLine> StyledNode::get_text_decoration_line_property() 
     return lines;
 }
 
+std::optional<TextTransform> StyledNode::get_text_transform_property() const {
+    auto raw = get_raw_property(css::PropertyId::TextTransform);
+    if (raw == "none") {
+        return TextTransform::None;
+    }
+
+    if (raw == "capitalize") {
+        return TextTransform::Capitalize;
+    }
+
+    if (raw == "uppercase") {
+        return TextTransform::Uppercase;
+    }
+
+    if (raw == "lowercase") {
+        return TextTransform::Lowercase;
+    }
+
+    if (raw == "full-width") {
+        return TextTransform::FullWidth;
+    }
+
+    if (raw == "full-size-kana") {
+        return TextTransform::FullSizeKana;
+    }
+
+    spdlog::warn("Unhandled text-transform value '{}'", raw);
+    return std::nullopt;
+}
+
 static constexpr int kDefaultFontSize{16};
 // https://drafts.csswg.org/css-fonts-4/#absolute-size-mapping
 constexpr int kMediumFontSize = kDefaultFontSize;

--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -73,6 +73,15 @@ enum class TextDecorationLine : std::uint8_t {
     Blink,
 };
 
+enum class TextTransform : std::uint8_t {
+    None,
+    Capitalize,
+    Uppercase,
+    Lowercase,
+    FullWidth,
+    FullSizeKana,
+};
+
 enum class WhiteSpace : std::uint8_t {
     Normal,
     Pre,
@@ -131,6 +140,8 @@ struct StyledNode {
             return get_font_weight_property();
         } else if constexpr (T == css::PropertyId::TextDecorationLine) {
             return get_text_decoration_line_property();
+        } else if constexpr (T == css::PropertyId::TextTransform) {
+            return get_text_transform_property();
         } else if constexpr (T == css::PropertyId::WhiteSpace) {
             return get_white_space_property();
         } else {
@@ -150,6 +161,7 @@ private:
     int get_font_size_property() const;
     std::optional<FontWeight> get_font_weight_property() const;
     std::vector<TextDecorationLine> get_text_decoration_line_property() const;
+    std::optional<TextTransform> get_text_transform_property() const;
     std::optional<WhiteSpace> get_white_space_property() const;
 };
 

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -395,6 +395,18 @@ int main() {
         expect_property_eq<css::PropertyId::TextDecorationLine>("unhandled!", std::vector<style::TextDecorationLine>{});
     });
 
+    etest::test("get_property, text-transform", [] {
+        using enum style::TextTransform;
+        expect_property_eq<css::PropertyId::TextTransform>("none", None);
+        expect_property_eq<css::PropertyId::TextTransform>("capitalize", Capitalize);
+        expect_property_eq<css::PropertyId::TextTransform>("uppercase", Uppercase);
+        expect_property_eq<css::PropertyId::TextTransform>("lowercase", Lowercase);
+        expect_property_eq<css::PropertyId::TextTransform>("full-width", FullWidth);
+        expect_property_eq<css::PropertyId::TextTransform>("full-size-kana", FullSizeKana);
+
+        expect_property_eq<css::PropertyId::TextTransform>("unhandled!", std::nullopt);
+    });
+
     etest::test("get_property, white-space", [] {
         expect_property_eq<css::PropertyId::WhiteSpace>("normal", style::WhiteSpace::Normal);
         expect_property_eq<css::PropertyId::WhiteSpace>("pre", style::WhiteSpace::Pre);


### PR DESCRIPTION
This gives the `xn--[...]` labels on https://www.iana.org/domains/reserved the correct capitalization.