### PR TITLE
archive: Use `std::byte` as the input type in the API

### DIFF
--- a/archive/gzip_fuzz_test.cpp
+++ b/archive/gzip_fuzz_test.cpp
@@ -1,18 +1,17 @@
-// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "archive/zlib.h"
 
+#include <cstddef>
 #include <stddef.h> // NOLINT
 #include <stdint.h> // NOLINT
-#include <string_view>
 #include <tuple>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size); // NOLINT
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size) {
-    std::string_view input{reinterpret_cast<char const *>(data), size};
-    std::ignore = archive::zlib_decode(input, archive::ZlibMode::Gzip);
+    std::ignore = archive::zlib_decode({reinterpret_cast<std::byte const *>(data), size}, archive::ZlibMode::Gzip);
     return 0;
 }

--- a/archive/zlib.h
+++ b/archive/zlib.h
@@ -7,9 +7,11 @@
 
 #include <tl/expected.hpp>
 
+#include <cstddef>
 #include <cstdint>
+#include <span>
 #include <string>
-#include <string_view>
+#include <vector>
 
 namespace archive {
 
@@ -23,7 +25,7 @@ enum class ZlibMode : std::uint8_t {
     Gzip,
 };
 
-tl::expected<std::string, ZlibError> zlib_decode(std::string_view, ZlibMode);
+tl::expected<std::vector<std::byte>, ZlibError> zlib_decode(std::span<std::byte const>, ZlibMode);
 
 } // namespace archive
 

--- a/archive/zlib_fuzz_test.cpp
+++ b/archive/zlib_fuzz_test.cpp
@@ -1,18 +1,17 @@
-// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "archive/zlib.h"
 
+#include <cstddef>
 #include <stddef.h> // NOLINT
 #include <stdint.h> // NOLINT
-#include <string_view>
 #include <tuple>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size); // NOLINT
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size) {
-    std::string_view input{reinterpret_cast<char const *>(data), size};
-    std::ignore = archive::zlib_decode(input, archive::ZlibMode::Zlib);
+    std::ignore = archive::zlib_decode({reinterpret_cast<std::byte const *>(data), size}, archive::ZlibMode::Zlib);
     return 0;
 }

--- a/archive/zstd.cpp
+++ b/archive/zstd.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 David Zero <zero-one@zer0-one.net>
+// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -7,8 +8,8 @@
 #include <tl/expected.hpp>
 #include <zstd.h>
 
+#include <climits>
 #include <cstddef>
-#include <cstdint>
 #include <cstdlib>
 #include <memory>
 #include <span>
@@ -34,7 +35,7 @@ std::string_view to_string(ZstdError err) {
     return "Unknown error";
 }
 
-tl::expected<std::vector<std::uint8_t>, ZstdError> zstd_decode(std::span<uint8_t const> const input) {
+tl::expected<std::vector<std::byte>, ZstdError> zstd_decode(std::span<std::byte const> const input) {
     if (input.empty()) {
         return tl::unexpected{ZstdError::InputEmpty};
     }
@@ -51,8 +52,9 @@ tl::expected<std::vector<std::uint8_t>, ZstdError> zstd_decode(std::span<uint8_t
 
     std::size_t const chunk_size = ZSTD_DStreamOutSize();
 
-    std::vector<std::uint8_t> out;
+    std::vector<std::byte> out;
 
+    static_assert(CHAR_BIT == 8, "zstd requires 8-bit input");
     ZSTD_inBuffer in_buf = {input.data(), input.size_bytes(), 0};
 
     std::size_t count = 0;

--- a/archive/zstd.h
+++ b/archive/zstd.h
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 David Zero <zero-one@zer0-one.net>
+// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -25,7 +26,7 @@ enum class ZstdError : std::uint8_t {
 
 std::string_view to_string(ZstdError);
 
-tl::expected<std::vector<std::uint8_t>, ZstdError> zstd_decode(std::span<std::uint8_t const>);
+tl::expected<std::vector<std::byte>, ZstdError> zstd_decode(std::span<std::byte const>);
 
 } // namespace archive
 

--- a/archive/zstd_fuzz_test.cpp
+++ b/archive/zstd_fuzz_test.cpp
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: 2024 David Zero <zero-one@zer0-one.net>
+// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "archive/zstd.h"
 
+#include <cstddef>
 #include <span>
 #include <stddef.h> // NOLINT
 #include <stdint.h> // NOLINT
@@ -11,6 +13,6 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size); // NOLINT
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, size_t size) {
-    std::ignore = archive::zstd_decode({data, size});
+    std::ignore = archive::zstd_decode({reinterpret_cast<std::byte const *>(data), size});
     return 0;
 }

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -67,7 +67,7 @@ namespace {
             return false;
         }
 
-        response.body = std::string(reinterpret_cast<char const *>(decoded->data()), decoded->size());
+        response.body.assign(reinterpret_cast<char const *>(decoded->data()), decoded->size());
         return true;
     }
 

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -21,13 +21,12 @@
 #include <spdlog/spdlog.h>
 #include <tl/expected.hpp>
 
-#include <cstdint>
+#include <cstddef>
 #include <future>
 #include <memory>
 #include <span>
 #include <string>
 #include <string_view>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -57,9 +56,8 @@ namespace {
     }
 
     if (encoding == "zstd") {
-        static_assert(std::is_same_v<char, std::uint8_t> || std::is_same_v<unsigned char, std::uint8_t>);
-        std::span<std::uint8_t const> body_view{
-                reinterpret_cast<std::uint8_t const *>(response.body.data()), response.body.size()};
+        std::span<std::byte const> body_view{
+                reinterpret_cast<std::byte const *>(response.body.data()), response.body.size()};
         auto decoded = archive::zstd_decode(body_view);
         if (!decoded) {
             auto const &err = decoded.error();


### PR DESCRIPTION
std::byte is like the char types in that it's allowed to alias anything.

std::uint8_t doesn't have this magic, so when using it we also have to
static_assert that it's an alias of one of the blessed character types
that can alias anything.

The zlib-decoding used char types, so it didn't have this issue, but it
was also updated for consistency.