### PR TITLE
layout: Drop completely empty text nodes

### DIFF
--- a/html/BUILD
+++ b/html/BUILD
@@ -13,7 +13,6 @@ cc_library(
     deps = [
         "//dom",
         "//html2",
-        "//util:string",
         "@spdlog",
     ],
 )

--- a/html/parser.cpp
+++ b/html/parser.cpp
@@ -8,7 +8,6 @@
 #include "html2/parser_states.h"
 #include "html2/token.h"
 #include "html2/tokenizer.h"
-#include "util/string.h"
 
 #include <spdlog/spdlog.h>
 
@@ -246,8 +245,7 @@ void Parser::operator()(html2::EndOfFileToken const &) {
 void Parser::generate_text_node_if_needed() {
     assert(!open_elements_.empty());
     auto text = std::exchange(current_text_, {}).str();
-    bool is_uninteresting = std::ranges::all_of(text, [](char c) { return util::is_whitespace(c); });
-    if (is_uninteresting) {
+    if (text.empty()) {
         return;
     }
 


### PR DESCRIPTION
The spec-compliant html parser in #994 emits whitespace nodes even if they're all whitespace, and that wasn't handled in the layout system as our old ad-hoc html parser dropped all whitespace-only nodes. Now it's handled in the layout system, and we can remove that hack from our ad-hoc parser.

This fixes a lot of minor whitespace issues on a lot of websites. E.g.
![before](https://github.com/robinlinden/hastur/assets/8304462/be9ee625-c0f6-40a5-82a6-6c2cbbc5b039)
turns into
![after](https://github.com/robinlinden/hastur/assets/8304462/4d449977-e269-4c2f-89e6-19454b29f394)
with this fix.