### PR TITLE
layout: Treat invalid width properties as 'auto'

### DIFF
--- a/layout/box_model_test.cpp
+++ b/layout/box_model_test.cpp
@@ -1,17 +1,16 @@
-// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "layout/box_model.h"
 
-#include "etest/etest.h"
+#include "etest/etest2.h"
 #include "geom/geom.h"
 
-using etest::expect;
-
 int main() {
-    etest::test("BoxModel box models", [] {
+    etest::Suite s{};
+    s.add_test("BoxModel box models", [](etest::IActions &a) {
         layout::BoxModel box{
                 .content{.x = 400, .y = 400, .width = 100, .height = 100}, // x: 400-500, y: 400-500
                 .padding{.left = 100, .right = 100, .top = 100, .bottom = 100}, // x: 300-600, y: 300-600
@@ -19,12 +18,12 @@ int main() {
                 .margin{.left = 100, .right = 100, .top = 100, .bottom = 100}, // x: 100-800, y: 100-800
         };
 
-        expect(box.padding_box() == geom::Rect{300, 300, 300, 300});
-        expect(box.border_box() == geom::Rect{200, 200, 500, 500});
-        expect(box.margin_box() == geom::Rect{100, 100, 700, 700});
+        a.expect(box.padding_box() == geom::Rect{300, 300, 300, 300});
+        a.expect(box.border_box() == geom::Rect{200, 200, 500, 500});
+        a.expect(box.margin_box() == geom::Rect{100, 100, 700, 700});
     });
 
-    etest::test("BoxModel::contains", [] {
+    s.add_test("BoxModel box models", [](etest::IActions &a) {
         layout::BoxModel box{
                 .content{.x = 400, .y = 400, .width = 100, .height = 100}, // x: 400-500, y: 400-500
                 .padding{.left = 100, .right = 100, .top = 100, .bottom = 100}, // x: 300-600, y: 300-600
@@ -32,12 +31,12 @@ int main() {
                 .margin{.left = 100, .right = 100, .top = 100, .bottom = 100}, // x: 100-800, y: 100-800
         };
 
-        expect(box.contains({450, 450})); // Inside content.
-        expect(box.contains({300, 300})); // Inside padding.
-        expect(box.contains({650, 250})); // Inside border.
-        expect(!box.contains({150, 150})); // Inside margin.
-        expect(!box.contains({90, 90})); // Outside margin.
+        a.expect(box.contains({450, 450})); // Inside content.
+        a.expect(box.contains({300, 300})); // Inside padding.
+        a.expect(box.contains({650, 250})); // Inside border.
+        a.expect(!box.contains({150, 150})); // Inside margin.
+        a.expect(!box.contains({90, 90})); // Outside margin.
     });
 
-    return etest::run_all_tests();
+    return s.run();
 }

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -448,8 +448,14 @@ void Layouter::calculate_width_and_margin(LayoutBox &box, geom::Rect const &pare
 
     auto margin_left = box.get_property<css::PropertyId::MarginLeft>();
     auto margin_right = box.get_property<css::PropertyId::MarginRight>();
-    if (auto width = box.get_property<css::PropertyId::Width>(); !width.is_auto()) {
-        box.dimensions.content.width = width.resolve(font_size, root_font_size_, parent.width);
+    auto width = box.get_property<css::PropertyId::Width>();
+    std::optional<int> resolved_width;
+    if (!width.is_auto()) {
+        resolved_width = width.try_resolve(font_size, root_font_size_, parent.width);
+    }
+
+    if (resolved_width) {
+        box.dimensions.content.width = *resolved_width;
         calculate_left_and_right_margin(box, parent, margin_left, margin_right, font_size);
     } else {
         if (margin_left != "auto") {

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -475,10 +475,15 @@ void Layouter::calculate_width_and_margin(LayoutBox &box, geom::Rect const &pare
         }
     }
 
-    if (auto max = box.get_property<css::PropertyId::MaxWidth>(); !max.is_none()) {
-        auto resolved = max.resolve(font_size, root_font_size_, parent.width);
-        if (box.dimensions.content.width > resolved) {
-            box.dimensions.content.width = resolved;
+    auto max = box.get_property<css::PropertyId::MaxWidth>();
+    std::optional<int> resolved_max;
+    if (!max.is_none()) {
+        resolved_max = max.try_resolve(font_size, root_font_size_, parent.width);
+    }
+
+    if (resolved_max) {
+        if (box.dimensions.content.width > *resolved_max) {
+            box.dimensions.content.width = *resolved_max;
             calculate_left_and_right_margin(box, parent, margin_left, margin_right, font_size);
         }
     }

--- a/layout/layout_box.cpp
+++ b/layout/layout_box.cpp
@@ -135,7 +135,7 @@ std::string to_string(LayoutBox const &box) {
     return std::move(ss).str();
 }
 
-int to_px(std::string_view property,
+std::optional<int> try_to_px(std::string_view property,
         int const font_size,
         int const root_font_size,
         std::optional<int> parent_property_value) {
@@ -148,7 +148,7 @@ int to_px(std::string_view property,
     auto parse_result = util::from_chars(property.data(), property.data() + property.size(), res);
     if (parse_result.ec != std::errc{}) {
         spdlog::warn("Unable to parse property '{}' in to_px", property);
-        return 0;
+        return std::nullopt;
     }
 
     auto const parsed_length = std::distance(property.data(), parse_result.ptr);
@@ -157,7 +157,7 @@ int to_px(std::string_view property,
     if (unit == "%") {
         if (!parent_property_value.has_value()) {
             spdlog::warn("Missing parent-value for property w/ '%' unit");
-            return 0;
+            return std::nullopt;
         }
 
         return static_cast<int>(res / 100.f * (*parent_property_value));
@@ -188,7 +188,7 @@ int to_px(std::string_view property,
     }
 
     spdlog::warn("Bad property '{}' w/ unit '{}' in to_px", property, unit);
-    return static_cast<int>(res);
+    return std::nullopt;
 }
 
 } // namespace layout

--- a/layout/layout_box.h
+++ b/layout/layout_box.h
@@ -92,10 +92,17 @@ inline std::vector<LayoutBox const *> dom_children(LayoutBox const &node) {
 }
 
 // TODO(robinlinden): This should be internal.
-int to_px(std::string_view property,
+std::optional<int> try_to_px(std::string_view property,
         int font_size,
         int root_font_size,
         std::optional<int> parent_property_value = std::nullopt);
+
+inline int to_px(std::string_view property,
+        int font_size,
+        int root_font_size,
+        std::optional<int> parent_property_value = std::nullopt) {
+    return try_to_px(property, font_size, root_font_size, parent_property_value).value_or(0);
+}
 
 } // namespace layout
 

--- a/layout/layout_property_test.cpp
+++ b/layout/layout_property_test.cpp
@@ -6,7 +6,7 @@
 
 #include "css/property_id.h"
 #include "dom/dom.h"
-#include "etest/etest.h"
+#include "etest/etest2.h"
 #include "gfx/color.h"
 #include "layout/unresolved_value.h"
 #include "style/styled_node.h"
@@ -18,11 +18,11 @@
 #include <vector>
 
 using namespace std::literals;
-using etest::expect_eq;
 
 namespace {
 template<css::PropertyId IdT>
-void expect_property_eq(std::optional<std::string> value,
+void expect_property_eq(etest::IActions &a,
+        std::optional<std::string> value,
         auto expected,
         std::vector<std::pair<css::PropertyId, std::string>> extra_properties = {},
         std::source_location const &loc = std::source_location::current()) {
@@ -39,42 +39,44 @@ void expect_property_eq(std::optional<std::string> value,
 
     auto layout = layout::create_layout(styled_node, 123);
     if (!layout) {
-        etest::expect(false, std::nullopt, loc);
+        a.expect(false, std::nullopt, loc);
         return;
     }
 
-    etest::expect_eq(layout->get_property<IdT>(), expected, std::nullopt, loc);
+    a.expect_eq(layout->get_property<IdT>(), expected, std::nullopt, loc);
 };
 } // namespace
 
 int main() {
-    etest::test("get_property", [] {
+    etest::Suite s{};
+
+    s.add_test("get_property", [](etest::IActions &a) {
         dom::Node dom_root = dom::Element{.name{"html"}};
         auto style_root = style::StyledNode{.node = dom_root, .properties = {{css::PropertyId::Color, "green"}}};
 
         auto layout = layout::create_layout(style_root, 0).value();
-        expect_eq(layout.get_property<css::PropertyId::Color>(), gfx::Color::from_css_name("green"));
-        expect_eq(layout.get_property<css::PropertyId::BackgroundColor>(), gfx::Color::from_css_name("transparent"));
+        a.expect_eq(layout.get_property<css::PropertyId::Color>(), gfx::Color::from_css_name("green"));
+        a.expect_eq(layout.get_property<css::PropertyId::BackgroundColor>(), gfx::Color::from_css_name("transparent"));
     });
 
     using enum css::PropertyId;
-    etest::test("border radius", [] {
-        expect_property_eq<BorderTopLeftRadius>("2em", std::pair{60, 60}, {{FontSize, "30px"}});
-        expect_property_eq<BorderTopRightRadius>(std::nullopt, std::pair{0, 0});
-        expect_property_eq<BorderBottomLeftRadius>(std::nullopt, std::pair{0, 0});
-        expect_property_eq<BorderBottomRightRadius>("10px/3em", std::pair{10, 90}, {{FontSize, "30px"}});
+    s.add_test("border radius", [](etest::IActions &a) {
+        expect_property_eq<BorderTopLeftRadius>(a, "2em", std::pair{60, 60}, {{FontSize, "30px"}});
+        expect_property_eq<BorderTopRightRadius>(a, std::nullopt, std::pair{0, 0});
+        expect_property_eq<BorderBottomLeftRadius>(a, std::nullopt, std::pair{0, 0});
+        expect_property_eq<BorderBottomRightRadius>(a, "10px/3em", std::pair{10, 90}, {{FontSize, "30px"}});
     });
 
-    etest::test("width", [] {
-        expect_property_eq<MinWidth>("13px", layout::UnresolvedValue{"13px"});
-        expect_property_eq<MinWidth>("auto", layout::UnresolvedValue{"auto"});
+    s.add_test("width", [](etest::IActions &a) {
+        expect_property_eq<MinWidth>(a, "13px", layout::UnresolvedValue{"13px"});
+        expect_property_eq<MinWidth>(a, "auto", layout::UnresolvedValue{"auto"});
 
-        expect_property_eq<Width>("42px", layout::UnresolvedValue{"42px"});
-        expect_property_eq<Width>("auto", layout::UnresolvedValue{"auto"});
+        expect_property_eq<Width>(a, "42px", layout::UnresolvedValue{"42px"});
+        expect_property_eq<Width>(a, "auto", layout::UnresolvedValue{"auto"});
 
-        expect_property_eq<MaxWidth>("420px", layout::UnresolvedValue{"420px"});
-        expect_property_eq<MaxWidth>("none", layout::UnresolvedValue{"none"});
+        expect_property_eq<MaxWidth>(a, "420px", layout::UnresolvedValue{"420px"});
+        expect_property_eq<MaxWidth>(a, "none", layout::UnresolvedValue{"none"});
     });
 
-    return etest::run_all_tests();
+    return s.run();
 }

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -1914,6 +1914,26 @@ int main() {
         expect_eq(layout.children.at(0).dimensions.border_box().width, 50);
     });
 
+    etest::test("invalid width", [] {
+        dom::Node dom = dom::Element{"html", {}, {dom::Element{"div"}}};
+        auto const &div = std::get<dom::Element>(dom).children[0];
+        style::StyledNode style{
+                .node{dom},
+                .properties{{css::PropertyId::Width, "asdf"}, {css::PropertyId::Display, "block"}},
+                .children{
+                        style::StyledNode{
+                                .node{div},
+                                .properties{{css::PropertyId::Width, "100px"}, {css::PropertyId::Display, "block"}},
+                        },
+                },
+        };
+        set_up_parent_ptrs(style);
+
+        auto layout = layout::create_layout(style, 1000).value();
+        expect_eq(layout.dimensions.border_box().width, 1000);
+        expect_eq(layout.children.at(0).dimensions.border_box().width, 100);
+    });
+
     whitespace_collapsing_tests();
     text_transform_tests();
     img_tests();

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -1914,7 +1914,7 @@ int main() {
         expect_eq(layout.children.at(0).dimensions.border_box().width, 50);
     });
 
-    etest::test("invalid width", [] {
+    etest::test("invalid width properties", [] {
         dom::Node dom = dom::Element{"html", {}, {dom::Element{"div"}}};
         auto const &div = std::get<dom::Element>(dom).children[0];
         style::StyledNode style{
@@ -1930,6 +1930,11 @@ int main() {
         set_up_parent_ptrs(style);
 
         auto layout = layout::create_layout(style, 1000).value();
+        expect_eq(layout.dimensions.border_box().width, 1000);
+        expect_eq(layout.children.at(0).dimensions.border_box().width, 100);
+
+        style.properties.push_back({css::PropertyId::MaxWidth, "asdf"});
+        layout = layout::create_layout(style, 1000).value();
         expect_eq(layout.dimensions.border_box().width, 1000);
         expect_eq(layout.children.at(0).dimensions.border_box().width, 100);
     });

--- a/layout/unresolved_value.cpp
+++ b/layout/unresolved_value.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -9,7 +9,14 @@
 #include <optional>
 
 namespace layout {
+
 int UnresolvedValue::resolve(int font_size, int root_font_size, std::optional<int> percent_relative_to) const {
     return to_px(raw, font_size, root_font_size, percent_relative_to);
 }
+
+std::optional<int> UnresolvedValue::try_resolve(
+        int font_size, int root_font_size, std::optional<int> percent_relative_to) const {
+    return try_to_px(raw, font_size, root_font_size, percent_relative_to);
+}
+
 } // namespace layout

--- a/layout/unresolved_value.h
+++ b/layout/unresolved_value.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -17,6 +17,8 @@ struct UnresolvedValue {
     constexpr bool is_auto() const { return raw == "auto"; }
     constexpr bool is_none() const { return raw == "none"; }
     int resolve(int font_size, int root_font_size, std::optional<int> percent_relative_to = std::nullopt) const;
+    std::optional<int> try_resolve(
+            int font_size, int root_font_size, std::optional<int> percent_relative_to = std::nullopt) const;
 };
 
 } // namespace layout

--- a/layout/unresolved_value_test.cpp
+++ b/layout/unresolved_value_test.cpp
@@ -1,10 +1,12 @@
-// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "layout/unresolved_value.h"
 
 #include "etest/etest2.h"
+
+#include <optional>
 
 int main() {
     etest::Suite s{"UnresolvedValue"};
@@ -59,6 +61,17 @@ int main() {
 
         // If the third argument is not provided, you get nothing.
         a.expect_eq(uv.resolve(123, 456), 0);
+    });
+
+    s.add_test("try_resolve", [](etest::IActions &a) {
+        // %, no parent provided.
+        auto const percent = layout::UnresolvedValue{.raw = "50%"};
+        a.expect_eq(percent.try_resolve(100, 100), std::nullopt);
+        a.expect_eq(percent.try_resolve(100, 100, 100), 50);
+
+        // Nonsense.
+        auto const nonsense = layout::UnresolvedValue{.raw = "foo"};
+        a.expect_eq(nonsense.try_resolve(100, 100, 100), std::nullopt);
     });
 
     return s.run();


### PR DESCRIPTION
This matches what other browsers do, but they also do it for all properties. These two were resulting in culling not rendering anything, so more important than other properties. I'll set something more general for this later.

Note that invalid in our case often is things like unsupported units or calc()'d values, so logging the values we couldn't resolve is still useful until we support more things.