### PR TITLE
etest: Print the test name even if the test crashes

### DIFF
--- a/etest/etest2.cpp
+++ b/etest/etest2.cpp
@@ -91,7 +91,7 @@ int Suite::run(RunOptions const &opts) {
 
     bool failure = false;
     for (auto const &test : tests_to_run) {
-        std::cout << std::left << std::setw(longest_name->name.size()) << test.name << ": ";
+        std::cout << std::left << std::setw(longest_name->name.size()) << test.name << ": " << std::flush;
 
         Actions a{};
 #ifdef ETEST_EXCEPTIONS


### PR DESCRIPTION
`std::cout` is buffered, so if the test body hits e.g. an assert, it's likely that the crashing test's name won't show up in the output.

Before:
```
good test : PASSED
Assertion failed: false, file etest/meme_test.cpp, line 5
```

After:
```
good test : PASSED
bad test  : Assertion failed: false, file etest/meme_test.cpp, line 5
```