### PR TITLE
css: Ignore `@import` at-rules

### DIFF
--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -314,6 +314,14 @@ StyleSheet Parser::parse_rules() {
                 return style;
             }
 
+            if (kind == "@import") {
+                std::ignore = consume_while([](char c) { return c != ';'; });
+                consume_char(); // ;
+                skip_whitespace_and_comments();
+                spdlog::warn("Encountered unhandled import at-rule", *kind);
+                continue;
+            }
+
             spdlog::warn("Encountered unhandled {} at-rule", *kind);
 
             skip_whitespace_and_comments();

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -1257,5 +1257,10 @@ int main() {
         a.expect(css::parse("@charset 'shi").rules.empty()); //
     });
 
+    s.add_test("parser: @import", [](etest::IActions &a) {
+        a.expect_eq(css::parse("@import 'test.css'; p { font-size: 3px; }").rules.at(0),
+                css::Rule{{"p"}, {{css::PropertyId::FontSize, "3px"}}});
+    });
+
     return s.run();
 }


### PR DESCRIPTION
Without this, any `@import` at-rules are likely to kill parsing of the rest of the document.

---

This makes https://owickstrom.github.io/the-monospace-web/ look like

![after](https://github.com/user-attachments/assets/86c7e3bb-4039-42e0-85e5-e9c0afcdcade)


instead of

![before](https://github.com/user-attachments/assets/7a149b46-8793-4f30-bc20-ff17f913776a)

, so while it's still broken, it's a lot better.