### PR TITLE
ci: Make the code coverage status required again

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,17 +7,3 @@ codecov:
 
 # https://docs.codecov.com/docs/pull-request-comments#disable-comment
 comment: false
-
-# TODO(robinlinden): We don't want to manually have to check that tests cover new code.
-#
-# The coverage CI status check is only informational for now due to Bazel 7
-# switching to branch coverage with gcc and gcc appearing to not generate
-# reliable coverage reports when run in branch-coverage mode.
-coverage:
-  status:
-    project:
-      default:
-        informational: true
-    patch:
-      default:
-        informational: true


### PR DESCRIPTION
Looks like something shifted in codecov or the compilers we use as the project code coverage jumped 3% the other day and has stopped randomly fluctuating, meaning this should be fine again.

#1043 looks like the first PR where the code coverage was back to what we should expect.