### PR TITLE
ci: Use libc++-19 in the clang-tidy job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,9 +288,7 @@ jobs:
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-add-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main"
-      # TODO(robinlinden): libc++-19 once we've done something about SFML having weird unsupported char_traits-stuff.
-      # See: https://releases.llvm.org/19.1.0/projects/libcxx/docs/ReleaseNotes.html#deprecations-and-removals
-      - run: sudo apt-get update && sudo apt-get install --no-install-recommends clang-tidy-19 libc++abi-18-dev libc++-18-dev
+      - run: sudo apt-get update && sudo apt-get install --no-install-recommends clang-tidy-19 libc++abi-19-dev libc++-19-dev
       - run: echo "CC=clang-19" >>$GITHUB_ENV && echo "CXX=clang++-19" >>$GITHUB_ENV
       - run: |
           sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-19 100

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,15 +154,6 @@ jobs:
           pipx install codecov-cli==0.6.0
           codecovcli upload-process --fail-on-error --file bazel-out/_coverage/_coverage_report.dat
 
-  linux-gcc-13-no-exceptions:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    container: gcc:13.3.0
-    steps:
-      - uses: actions/checkout@v4
-      - run: wget --no-verbose --output-document=bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64 && chmod +x bazelisk
-      - run: ./bazelisk test etest/... --copt=-fno-exceptions
-
   linux-aarch64-muslc:
     runs-on: ubuntu-24.04
     timeout-minutes: 30


### PR DESCRIPTION
This is possible now that we're on SFML 3.