### PR TITLE
css2: Support tokenizing floating point numbers

### DIFF
--- a/css2/BUILD
+++ b/css2/BUILD
@@ -12,6 +12,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//unicode:util",
+        "//util:from_chars",
         "//util:string",
     ],
 )

--- a/css2/token.h
+++ b/css2/token.h
@@ -60,28 +60,29 @@ struct DelimToken {
     [[nodiscard]] bool operator==(DelimToken const &) const = default;
 };
 
-enum class NumericType : std::uint8_t {
-    Integer,
-    Number,
-};
-
 struct NumberToken {
-    NumericType type{NumericType::Integer};
     std::variant<int, double> data;
     [[nodiscard]] bool operator==(NumberToken const &) const = default;
+
+    [[nodiscard]] constexpr bool is_integer() const { return std::holds_alternative<int>(data); }
+    [[nodiscard]] constexpr bool is_number() const { return !is_integer(); }
 };
 
 struct PercentageToken {
-    NumericType type{NumericType::Integer};
     std::variant<int, double> data{};
     [[nodiscard]] bool operator==(PercentageToken const &) const = default;
+
+    [[nodiscard]] constexpr bool is_integer() const { return std::holds_alternative<int>(data); }
+    [[nodiscard]] constexpr bool is_number() const { return !is_integer(); }
 };
 
 struct DimensionToken {
-    NumericType type{NumericType::Integer};
     std::variant<int, double> data{};
     std::string unit{};
     [[nodiscard]] bool operator==(DimensionToken const &) const = default;
+
+    [[nodiscard]] constexpr bool is_integer() const { return std::holds_alternative<int>(data); }
+    [[nodiscard]] constexpr bool is_number() const { return !is_integer(); }
 };
 
 struct WhitespaceToken {

--- a/css2/token_test.cpp
+++ b/css2/token_test.cpp
@@ -59,33 +59,45 @@ int main() {
         a.expect_eq("DelimToken ,", to_string(t));
     });
 
-    s.add_test("to_string NumberToken integer", [](etest::IActions &a) {
-        NumberToken t{NumericType::Integer, 53};
+    s.add_test("NumberToken integer", [](etest::IActions &a) {
+        NumberToken t{53};
+        a.expect(t.is_integer());
+        a.expect(!t.is_number());
         a.expect_eq("NumberToken 53", to_string(t));
     });
 
-    s.add_test("to_string NumberToken number", [](etest::IActions &a) {
-        NumberToken t{NumericType::Number, 1.33};
+    s.add_test("NumberToken number", [](etest::IActions &a) {
+        NumberToken t{1.33};
+        a.expect(!t.is_integer());
+        a.expect(t.is_number());
         a.expect_eq("NumberToken 1.33", to_string(t));
     });
 
-    s.add_test("to_string PercentageToken integer", [](etest::IActions &a) {
-        PercentageToken t{NumericType::Integer, 923};
+    s.add_test("PercentageToken integer", [](etest::IActions &a) {
+        PercentageToken t{923};
+        a.expect(t.is_integer());
+        a.expect(!t.is_number());
         a.expect_eq("PercentageToken 923", to_string(t));
     });
 
-    s.add_test("to_string PercentageToken number", [](etest::IActions &a) {
-        PercentageToken t{NumericType::Number, 44.123};
+    s.add_test("PercentageToken number", [](etest::IActions &a) {
+        PercentageToken t{44.123};
+        a.expect(!t.is_integer());
+        a.expect(t.is_number());
         a.expect_eq("PercentageToken 44.123", to_string(t));
     });
 
-    s.add_test("to_string DimensionToken integer", [](etest::IActions &a) {
-        DimensionToken t{NumericType::Integer, 1, "px"};
+    s.add_test("DimensionToken integer", [](etest::IActions &a) {
+        DimensionToken t{1, "px"};
+        a.expect(t.is_integer());
+        a.expect(!t.is_number());
         a.expect_eq("DimensionToken 1px", to_string(t));
     });
 
-    s.add_test("to_string DimensionToken number", [](etest::IActions &a) {
-        DimensionToken t{NumericType::Number, 1.5, "em"};
+    s.add_test("DimensionToken number", [](etest::IActions &a) {
+        DimensionToken t{1.5, "em"};
+        a.expect(!t.is_integer());
+        a.expect(t.is_number());
         a.expect_eq("DimensionToken 1.5em", to_string(t));
     });
 

--- a/css2/tokenizer.cpp
+++ b/css2/tokenizer.cpp
@@ -395,15 +395,14 @@ std::variant<int, double> Tokenizer::consume_number(char first_byte) {
     // TODO(robinlinden): Step 5
 
     // The tokenizer will verify that this is a number before calling consume_number.
+    [[maybe_unused]] util::from_chars_result fc_res{};
     if (auto *int_res = std::get_if<int>(&result); int_res != nullptr) {
-        [[maybe_unused]] auto fc_res = util::from_chars(repr.data(), repr.data() + repr.size(), *int_res);
-        assert(fc_res.ec == std::errc{});
+        fc_res = util::from_chars(repr.data(), repr.data() + repr.size(), *int_res);
     } else {
-        [[maybe_unused]] auto fc_res =
-                util::from_chars(repr.data(), repr.data() + repr.size(), std::get<double>(result));
-        assert(fc_res.ec == std::errc{});
+        fc_res = util::from_chars(repr.data(), repr.data() + repr.size(), std::get<double>(result));
     }
 
+    assert(fc_res.ec == std::errc{} && fc_res.ptr == repr.data() + repr.size());
     return result;
 }
 

--- a/css2/tokenizer.h
+++ b/css2/tokenizer.h
@@ -67,7 +67,7 @@ private:
     bool is_eof() const;
     void reconsume_in(State);
 
-    std::pair<std::variant<int, double>, NumericType> consume_number(char first_byte);
+    std::variant<int, double> consume_number(char first_byte);
     std::string consume_an_escaped_code_point();
 };
 

--- a/css2/tokenizer_test.cpp
+++ b/css2/tokenizer_test.cpp
@@ -365,29 +365,29 @@ int main() {
         expect_token(output, CloseCurlyToken{});
     });
 
-    s.add_test("number: ez", [](etest::IActions &a) {
+    s.add_test("integer: ez", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "13");
         expect_token(output, NumberToken{.data = 13});
     });
 
-    s.add_test("number: less ez", [](etest::IActions &a) {
+    s.add_test("integer: less ez", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "(13)");
         expect_token(output, OpenParenToken{});
         expect_token(output, NumberToken{.data = 13});
         expect_token(output, CloseParenToken{});
     });
 
-    s.add_test("number: leading 0", [](etest::IActions &a) {
+    s.add_test("integer: leading 0", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "00000001");
         expect_token(output, NumberToken{.data = 1});
     });
 
-    s.add_test("plus: number", [](etest::IActions &a) {
+    s.add_test("plus: integer", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "+13");
         expect_token(output, NumberToken{.data = 13});
     });
 
-    s.add_test("plus: number w/ leading 0", [](etest::IActions &a) {
+    s.add_test("plus: integer w/ leading 0", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "+00000001");
         expect_token(output, NumberToken{.data = 1});
     });
@@ -398,12 +398,12 @@ int main() {
         expect_token(output, IdentToken{"hello"});
     });
 
-    s.add_test("hyphen: negative number", [](etest::IActions &a) {
+    s.add_test("hyphen: negative integer", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "-13");
         expect_token(output, NumberToken{.data = -13});
     });
 
-    s.add_test("hyphen: negative number w/ leading 0", [](etest::IActions &a) {
+    s.add_test("hyphen: negative integer w/ leading 0", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "-00000001");
         expect_token(output, NumberToken{.data = -1});
     });

--- a/css2/tokenizer_test.cpp
+++ b/css2/tokenizer_test.cpp
@@ -414,5 +414,27 @@ int main() {
         expect_token(output, IdentToken{"lol"});
     });
 
+    s.add_test("number: ez", [](etest::IActions &a) {
+        auto output = run_tokenizer(a, "0.25");
+        expect_token(output, NumberToken{.type = css2::NumericType::Number, .data = 0.25});
+    });
+
+    s.add_test("number: and other things", [](etest::IActions &a) {
+        auto output = run_tokenizer(a, "(0.375)");
+        expect_token(output, OpenParenToken{});
+        expect_token(output, NumberToken{.type = css2::NumericType::Number, .data = 0.375});
+        expect_token(output, CloseParenToken{});
+    });
+
+    s.add_test("number: negative", [](etest::IActions &a) {
+        auto output = run_tokenizer(a, "-42.25");
+        expect_token(output, NumberToken{.type = css2::NumericType::Number, .data = -42.25});
+    });
+
+    s.add_test("number: with +", [](etest::IActions &a) {
+        auto output = run_tokenizer(a, "+13.25");
+        expect_token(output, NumberToken{.type = css2::NumericType::Number, .data = 13.25});
+    });
+
     return s.run();
 }

--- a/css2/tokenizer_test.cpp
+++ b/css2/tokenizer_test.cpp
@@ -416,24 +416,24 @@ int main() {
 
     s.add_test("number: ez", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "0.25");
-        expect_token(output, NumberToken{.type = css2::NumericType::Number, .data = 0.25});
+        expect_token(output, NumberToken{0.25});
     });
 
     s.add_test("number: and other things", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "(0.375)");
         expect_token(output, OpenParenToken{});
-        expect_token(output, NumberToken{.type = css2::NumericType::Number, .data = 0.375});
+        expect_token(output, NumberToken{0.375});
         expect_token(output, CloseParenToken{});
     });
 
     s.add_test("number: negative", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "-42.25");
-        expect_token(output, NumberToken{.type = css2::NumericType::Number, .data = -42.25});
+        expect_token(output, NumberToken{-42.25});
     });
 
     s.add_test("number: with +", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "+13.25");
-        expect_token(output, NumberToken{.type = css2::NumericType::Number, .data = 13.25});
+        expect_token(output, NumberToken{13.25});
     });
 
     return s.run();

--- a/util/from_chars.h
+++ b/util/from_chars.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -29,6 +29,7 @@ inline from_chars_result from_chars(char const *first, char const *last, float &
     // Produce a null-terminated string that we can safely pass to std::strtof.
     std::string to_parse{first, last};
     char *end{};
+    errno = 0;
     float result = std::strtof(to_parse.c_str(), &end);
     if (end == to_parse.c_str()) {
         // No conversion could be performed.

--- a/util/from_chars_test.cpp
+++ b/util/from_chars_test.cpp
@@ -14,22 +14,6 @@ using namespace std::literals;
 int main() {
     etest::Suite s;
 
-    s.add_test("success", [](etest::IActions &a) {
-        auto from = "100.5"sv;
-        float v{};
-        auto res = util::from_chars(from.data(), from.data() + from.size(), v);
-        a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
-        a.expect_eq(v, 100.5f);
-    });
-
-    s.add_test("success, negative", [](etest::IActions &a) {
-        auto from = "-100.5"sv;
-        float v{};
-        auto res = util::from_chars(from.data(), from.data() + from.size(), v);
-        a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
-        a.expect_eq(v, -100.5f);
-    });
-
     s.add_test("failure, out of range", [](etest::IActions &a) {
         auto from = "1e100000"sv;
         float v{};
@@ -48,6 +32,22 @@ int main() {
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
         a.expect_eq(res, util::from_chars_result{from.data(), std::errc::invalid_argument});
         a.expect_eq(v, 0.f);
+    });
+
+    s.add_test("success", [](etest::IActions &a) {
+        auto from = "100.5"sv;
+        float v{};
+        auto res = util::from_chars(from.data(), from.data() + from.size(), v);
+        a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
+        a.expect_eq(v, 100.5f);
+    });
+
+    s.add_test("success, negative", [](etest::IActions &a) {
+        auto from = "-100.5"sv;
+        float v{};
+        auto res = util::from_chars(from.data(), from.data() + from.size(), v);
+        a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
+        a.expect_eq(v, -100.5f);
     });
 
     return s.run();

--- a/util/from_chars_test.cpp
+++ b/util/from_chars_test.cpp
@@ -20,7 +20,9 @@ void add_tests(etest::Suite &s, std::string_view name_prefix) {
         auto from = "1e100000"sv;
         T v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
-        a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc::result_out_of_range});
+        a.expect_eq(res,
+                util::from_chars_result{from.data() + from.size(), std::errc::result_out_of_range},
+                std::make_error_code(res.ec).message());
 #ifndef _MSC_VER
         // Microsoft's STL sets v to HUGE_VALF when ERANGE occurs.
         // See: https://en.cppreference.com/w/cpp/utility/from_chars#Return_value
@@ -32,7 +34,9 @@ void add_tests(etest::Suite &s, std::string_view name_prefix) {
         auto from = "abcd"sv;
         T v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
-        a.expect_eq(res, util::from_chars_result{from.data(), std::errc::invalid_argument});
+        a.expect_eq(res,
+                util::from_chars_result{from.data(), std::errc::invalid_argument},
+                std::make_error_code(res.ec).message());
         a.expect_eq(v, T{0.});
     });
 
@@ -40,7 +44,9 @@ void add_tests(etest::Suite &s, std::string_view name_prefix) {
         auto from = "100.5"sv;
         T v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
-        a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
+        a.expect_eq(res,
+                util::from_chars_result{from.data() + from.size(), std::errc{}},
+                std::make_error_code(res.ec).message());
         a.expect_eq(v, T{100.5});
     });
 
@@ -48,7 +54,9 @@ void add_tests(etest::Suite &s, std::string_view name_prefix) {
         auto from = "-100.5"sv;
         T v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
-        a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
+        a.expect_eq(res,
+                util::from_chars_result{from.data() + from.size(), std::errc{}},
+                std::make_error_code(res.ec).message());
         a.expect_eq(v, T{-100.5});
     });
 }

--- a/util/from_chars_test.cpp
+++ b/util/from_chars_test.cpp
@@ -6,49 +6,58 @@
 
 #include "etest/etest2.h"
 
+#include <string>
 #include <string_view>
 #include <system_error>
 
 using namespace std::literals;
 
-int main() {
-    etest::Suite s;
+namespace {
 
-    s.add_test("failure, out of range", [](etest::IActions &a) {
+template<typename T>
+void add_tests(etest::Suite &s, std::string_view name_prefix) {
+    s.add_test(std::string{name_prefix} + ": failure, out of range", [](etest::IActions &a) {
         auto from = "1e100000"sv;
-        float v{};
+        T v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
         a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc::result_out_of_range});
 #ifndef _MSC_VER
         // Microsoft's STL sets v to HUGE_VALF when ERANGE occurs.
         // See: https://en.cppreference.com/w/cpp/utility/from_chars#Return_value
-        a.expect_eq(v, 0.f);
+        a.expect_eq(v, T{0.});
 #endif
     });
 
-    s.add_test("failure, not a float", [](etest::IActions &a) {
+    s.add_test(std::string{name_prefix} + ": failure, not a number", [](etest::IActions &a) {
         auto from = "abcd"sv;
-        float v{};
+        T v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
         a.expect_eq(res, util::from_chars_result{from.data(), std::errc::invalid_argument});
-        a.expect_eq(v, 0.f);
+        a.expect_eq(v, T{0.});
     });
 
-    s.add_test("success", [](etest::IActions &a) {
+    s.add_test(std::string{name_prefix} + ": success", [](etest::IActions &a) {
         auto from = "100.5"sv;
-        float v{};
+        T v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
         a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
-        a.expect_eq(v, 100.5f);
+        a.expect_eq(v, T{100.5});
     });
 
-    s.add_test("success, negative", [](etest::IActions &a) {
+    s.add_test(std::string{name_prefix} + ": success, negative", [](etest::IActions &a) {
         auto from = "-100.5"sv;
-        float v{};
+        T v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
         a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
-        a.expect_eq(v, -100.5f);
+        a.expect_eq(v, T{-100.5});
     });
+}
 
+} // namespace
+
+int main() {
+    etest::Suite s;
+    add_tests<float>(s, "float");
+    add_tests<double>(s, "double");
     return s.run();
 }

--- a/util/from_chars_test.cpp
+++ b/util/from_chars_test.cpp
@@ -1,53 +1,54 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "util/from_chars.h"
 
-#include "etest/etest.h"
+#include "etest/etest2.h"
 
 #include <string_view>
 #include <system_error>
 
 using namespace std::literals;
-using etest::expect_eq;
 
 int main() {
-    etest::test("success", [] {
+    etest::Suite s;
+
+    s.add_test("success", [](etest::IActions &a) {
         auto from = "100.5"sv;
         float v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
-        expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
-        expect_eq(v, 100.5f);
+        a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
+        a.expect_eq(v, 100.5f);
     });
 
-    etest::test("success, negative", [] {
+    s.add_test("success, negative", [](etest::IActions &a) {
         auto from = "-100.5"sv;
         float v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
-        expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
-        expect_eq(v, -100.5f);
+        a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc{}});
+        a.expect_eq(v, -100.5f);
     });
 
-    etest::test("failure, out of range", [] {
+    s.add_test("failure, out of range", [](etest::IActions &a) {
         auto from = "1e100000"sv;
         float v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
-        expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc::result_out_of_range});
+        a.expect_eq(res, util::from_chars_result{from.data() + from.size(), std::errc::result_out_of_range});
 #ifndef _MSC_VER
         // Microsoft's STL sets v to HUGE_VALF when ERANGE occurs.
         // See: https://en.cppreference.com/w/cpp/utility/from_chars#Return_value
-        expect_eq(v, 0.f);
+        a.expect_eq(v, 0.f);
 #endif
     });
 
-    etest::test("failure, not a float", [] {
+    s.add_test("failure, not a float", [](etest::IActions &a) {
         auto from = "abcd"sv;
         float v{};
         auto res = util::from_chars(from.data(), from.data() + from.size(), v);
-        expect_eq(res, util::from_chars_result{from.data(), std::errc::invalid_argument});
-        expect_eq(v, 0.f);
+        a.expect_eq(res, util::from_chars_result{from.data(), std::errc::invalid_argument});
+        a.expect_eq(v, 0.f);
     });
 
-    return etest::run_all_tests();
+    return s.run();
 }


### PR DESCRIPTION
There's still no support for things like `.25`, `-.25`, or `+.25`, but I'll set that up soon.