### PR TITLE
etest: Run tests in a randomized order

### DIFF
--- a/etest/etest2.cpp
+++ b/etest/etest2.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <iterator>
 #include <optional>
+#include <random>
 #include <source_location>
 #include <sstream>
 #include <string_view>
@@ -85,6 +86,20 @@ int Suite::run(RunOptions const &opts) {
     if (tests_to_run.empty()) {
         return 1;
     }
+
+    unsigned const seed = [&] {
+        if (opts.rng_seed) {
+            return *opts.rng_seed;
+        }
+
+        return std::random_device{}();
+    }();
+    std::mt19937 rng{seed};
+
+    // Shuffle tests to avoid dependencies between them.
+    std::ranges::shuffle(tests_to_run, rng);
+
+    std::cout << "Running " << tests_to_run.size() << " tests with the seed " << seed << ".\n";
 
     auto const longest_name = std::ranges::max_element(
             tests_to_run, [](auto const &a, auto const &b) { return a.size() < b.size(); }, &Test::name);

--- a/etest/etest2.h
+++ b/etest/etest2.h
@@ -27,6 +27,7 @@ concept Printable = requires(std::ostream &os, T t) {
 
 struct RunOptions {
     bool run_disabled_tests{false};
+    std::optional<unsigned> rng_seed;
 };
 
 class IActions {

--- a/etest/shuffled_tests_test.cpp
+++ b/etest/shuffled_tests_test.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "etest/etest2.h"
+
+#include <iostream>
+#include <random>
+#include <tuple>
+
+int main() {
+    unsigned seed = std::random_device{}();
+    etest::Suite s;
+
+    int last_run_test{};
+    s.add_test("1", [&](auto &) { last_run_test = 1; });
+    s.add_test("2", [&](auto &) { last_run_test = 2; });
+
+    std::ignore = s.run({.rng_seed = seed});
+    auto after_first_run = last_run_test;
+
+    std::ignore = s.run({.rng_seed = seed});
+    if (last_run_test != after_first_run) {
+        std::cerr << "Tests didn't run in the same order with the same seed\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
We don't want dependencies between tests.

This finds the `errno` issue in `util::from_chars` resolved in #1054:

```
$ bazel test ... --runs_per_test=10
<...>
//util:from_chars_test  FAILED in 7 out of 10 in 0.2s
```