### PR TITLE
html2: Fix assertion failure when parsing <body><template>

### DIFF
--- a/html2/parser_states.cpp
+++ b/html2/parser_states.cpp
@@ -410,7 +410,6 @@ std::optional<InsertionMode> BeforeHead::process(IActions &a, html2::Token const
 
 // https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhead
 // Incomplete.
-// TODO(robinlinden): Template nonsense.
 // NOLINTNEXTLINE(misc-no-recursion)
 std::optional<InsertionMode> InHead::process(IActions &a, html2::Token const &token) {
     if (is_boring_whitespace(token)) {
@@ -469,6 +468,11 @@ std::optional<InsertionMode> InHead::process(IActions &a, html2::Token const &to
             a.set_tokenizer_state(html2::State::ScriptData);
             a.store_original_insertion_mode(a.current_insertion_mode());
             return Text{};
+        }
+
+        if (name == "template") {
+            // TODO(robinlinden): Template nonsense.
+            return {};
         }
     } else if (auto const *end = std::get_if<html2::EndTagToken>(&token)) {
         if (end->tag_name == "head") {

--- a/html2/parser_states.cpp
+++ b/html2/parser_states.cpp
@@ -409,7 +409,6 @@ std::optional<InsertionMode> BeforeHead::process(IActions &a, html2::Token const
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhead
-// Incomplete.
 // NOLINTNEXTLINE(misc-no-recursion)
 std::optional<InsertionMode> InHead::process(IActions &a, html2::Token const &token) {
     if (is_boring_whitespace(token)) {
@@ -491,7 +490,12 @@ std::optional<InsertionMode> InHead::process(IActions &a, html2::Token const &to
         return {};
     }
 
-    if (end != nullptr && !end_tag_as_anything_else) {
+    if (end != nullptr && end->tag_name == "template") {
+        // TODO(robinlinden): Template nonsense.
+        return {};
+    }
+
+    if ((start != nullptr && start->tag_name == "head") || (end != nullptr && !end_tag_as_anything_else)) {
         // Parse error.
         return {};
     }

--- a/html2/parser_states_test.cpp
+++ b/html2/parser_states_test.cpp
@@ -270,6 +270,16 @@ void in_head_tests() {
         auto res = parse("</head>", {});
         expect_eq(res.document.html(), dom::Element{"html", {}, {dom::Element{"head"}, dom::Element{"body"}}});
     });
+
+    etest::test("InHead: headhead", [] {
+        auto res = parse("<head><head>", {});
+        expect_eq(res.document.html(), dom::Element{"html", {}, {dom::Element{"head"}, dom::Element{"body"}}});
+    });
+
+    etest::test("InHead: </template>", [] {
+        auto res = parse("<head></template>", {});
+        expect_eq(res.document.html(), dom::Element{"html", {}, {dom::Element{"head"}, dom::Element{"body"}}});
+    });
 }
 
 void in_head_noscript_tests() {

--- a/html2/parser_states_test.cpp
+++ b/html2/parser_states_test.cpp
@@ -12,6 +12,7 @@
 #include "html/parser_actions.h"
 
 #include <string_view>
+#include <tuple>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -477,6 +478,10 @@ void in_body_tests() {
         auto res = parse("<body><p><hr>", {});
         auto const &body = std::get<dom::Element>(res.document.html().children.at(1));
         expect_eq(body, dom::Element{"body", {}, {dom::Element{"p"}, dom::Element{"hr"}}});
+    });
+
+    etest::test("InBody: <template> doesn't crash", [] {
+        std::ignore = parse("<body><template>", {}); //
     });
 }
 


### PR DESCRIPTION
There are a bunch of elements that InBody handles using InHead's rules
and all of them need to be handled as <head> won't be the topmost
element when this happens.

This makes arstechnica.com once again make a dom tree even if you're running in debug mode.