### PR TITLE
ci: Drop support for setups that don't support std::format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,17 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: gcc-12
-            os: ubuntu-24.04
-            compiler: gcc
-            version: 12
-            bazel: -c dbg --test_timeout=120 --run_under="valgrind --leak-check=full --errors-for-leak-kinds=all --error-exitcode=1 --track-origins=yes --show-leak-kinds=all --num-callers=32" --test_tag_filters=-no-valgrind
-            apt: g++-12 valgrind
-
           - name: gcc-14
             os: ubuntu-24.04
             compiler: gcc
             version: 14
+            bazel: -c dbg --test_timeout=120 --run_under="valgrind --leak-check=full --errors-for-leak-kinds=all --error-exitcode=1 --track-origins=yes --show-leak-kinds=all --num-callers=32" --test_tag_filters=-no-valgrind
+            apt: valgrind
 
           - name: clang-18-tsan
             os: ubuntu-24.04
@@ -44,13 +39,6 @@ jobs:
             bazel: -c dbg --config asan --config ubsan --test_env=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 --config libfuzzer
             apt: libclang-rt-18-dev llvm-18
             fuzz: true
-
-          - name: clang-16-libc++
-            os: ubuntu-24.04
-            compiler: clang
-            version: 16
-            bazel: --config libc++
-            apt: libc++abi-16-dev libc++-16-dev
 
           - name: clang-17-libc++
             os: ubuntu-24.04
@@ -197,7 +185,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13
           - os: macos-14
           - os: macos-15
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### Compiler
 
-Right now GCC 12, Clang 16, and MSVC are tested against. The project makes use
+Right now GCC 13, Clang 17, and MSVC are tested against. The project makes use
 of C++23 features, so a reasonably recent compiler is required.
 
 #### Build system

--- a/html2/BUILD
+++ b/html2/BUILD
@@ -14,7 +14,6 @@ cc_library(
     deps = [
         "//unicode:util",
         "//util:string",
-        "@fmt",
     ],
 )
 
@@ -34,7 +33,6 @@ extra_deps = {
     deps = [
         ":html2",
         "//etest",
-        "@fmt",
     ] + extra_deps.get(
         src[:-9],
         [],

--- a/html2/token.cpp
+++ b/html2/token.cpp
@@ -4,8 +4,7 @@
 
 #include "html2/token.h"
 
-#include <fmt/format.h>
-
+#include <format>
 #include <string>
 #include <variant>
 
@@ -17,15 +16,15 @@ public:
     static std::string to_string(Token const &token) { return std::visit(TokenStringifier{}, token); }
 
     std::string operator()(DoctypeToken const &t) {
-        return fmt::format("Doctype {} {} {}",
+        return std::format("Doctype {} {} {}",
                 t.name.value_or(R"("")"),
                 t.public_identifier.value_or(R"("")"),
                 t.system_identifier.value_or(R"("")"));
     }
-    std::string operator()(StartTagToken const &t) { return fmt::format("StartTag {} {}", t.tag_name, t.self_closing); }
-    std::string operator()(EndTagToken const &t) { return fmt::format("EndTag {}", t.tag_name); }
-    std::string operator()(CommentToken const &t) { return fmt::format("Comment {}", t.data); }
-    std::string operator()(CharacterToken const &t) { return fmt::format("Character {}", t.data); }
+    std::string operator()(StartTagToken const &t) { return std::format("StartTag {} {}", t.tag_name, t.self_closing); }
+    std::string operator()(EndTagToken const &t) { return std::format("EndTag {}", t.tag_name); }
+    std::string operator()(CommentToken const &t) { return std::format("Comment {}", t.data); }
+    std::string operator()(CharacterToken const &t) { return std::format("Character {}", t.data); }
     std::string operator()(EndOfFileToken const &) { return "EndOfFile"; }
 };
 

--- a/html2/tokenizer_test.cpp
+++ b/html2/tokenizer_test.cpp
@@ -8,9 +8,8 @@
 
 #include "etest/etest.h"
 
-#include <fmt/format.h>
-
 #include <array>
+#include <format>
 #include <iterator>
 #include <optional>
 #include <source_location>
@@ -1378,50 +1377,50 @@ int main() {
     for (char quote : std::array{'\'', '"'}) {
         auto type = quote == '"' ? "double"sv : "single"sv;
 
-        etest::test(fmt::format("doctype, {}-quoted public identifier", type), [=] {
-            auto tokens = run_tokenizer(fmt::format("<!DOCTYPE HTML PUBLIC {0}great{0}>", quote));
+        etest::test(std::format("doctype, {}-quoted public identifier", type), [=] {
+            auto tokens = run_tokenizer(std::format("<!DOCTYPE HTML PUBLIC {0}great{0}>", quote));
             expect_token(tokens, DoctypeToken{.name = "html", .public_identifier = "great"});
             expect_token(tokens, EndOfFileToken{});
         });
 
-        etest::test(fmt::format("doctype, {}-quoted public identifier, missing whitespace", type), [=] {
-            auto tokens = run_tokenizer(fmt::format("<!DOCTYPE HTML PUBLIC{0}great{0}>", quote));
+        etest::test(std::format("doctype, {}-quoted public identifier, missing whitespace", type), [=] {
+            auto tokens = run_tokenizer(std::format("<!DOCTYPE HTML PUBLIC{0}great{0}>", quote));
             expect_error(tokens, ParseError::MissingWhitespaceAfterDoctypePublicKeyword);
             expect_token(tokens, DoctypeToken{.name = "html", .public_identifier = "great"});
             expect_token(tokens, EndOfFileToken{});
         });
 
-        etest::test(fmt::format("doctype, {}-quoted public identifier, eof", type), [=] {
-            auto tokens = run_tokenizer(fmt::format("<!DOCTYPE HTML PUBLIC {0}great", quote));
+        etest::test(std::format("doctype, {}-quoted public identifier, eof", type), [=] {
+            auto tokens = run_tokenizer(std::format("<!DOCTYPE HTML PUBLIC {0}great", quote));
             expect_error(tokens, ParseError::EofInDoctype);
             expect_token(tokens, DoctypeToken{.name = "html", .public_identifier = "great", .force_quirks = true});
             expect_token(tokens, EndOfFileToken{});
         });
 
-        etest::test(fmt::format("doctype, {}-quoted public identifier, abrupt end", type), [=] {
-            auto tokens = run_tokenizer(fmt::format("<!DOCTYPE HTML PUBLIC {0}great>", quote));
+        etest::test(std::format("doctype, {}-quoted public identifier, abrupt end", type), [=] {
+            auto tokens = run_tokenizer(std::format("<!DOCTYPE HTML PUBLIC {0}great>", quote));
             expect_error(tokens, ParseError::AbruptDoctypePublicIdentifier);
             expect_token(tokens, DoctypeToken{.name = "html", .public_identifier = "great", .force_quirks = true});
             expect_token(tokens, EndOfFileToken{});
         });
 
-        etest::test(fmt::format("doctype, {}-quoted public identifier, null", type), [=] {
-            auto tokens = run_tokenizer(fmt::format("<!DOCTYPE HTML PUBLIC {0}gre\0t{0}>"sv, quote));
+        etest::test(std::format("doctype, {}-quoted public identifier, null", type), [=] {
+            auto tokens = run_tokenizer(std::format("<!DOCTYPE HTML PUBLIC {0}gre\0t{0}>"sv, quote));
             expect_error(tokens, ParseError::UnexpectedNullCharacter);
             expect_token(
                     tokens, DoctypeToken{.name = "html", .public_identifier = "gre"s + kReplacementCharacter + "t"});
             expect_token(tokens, EndOfFileToken{});
         });
 
-        etest::test(fmt::format("doctype, {}-quoted system identifier", type), [=] {
-            auto tokens = run_tokenizer(fmt::format("<!DOCTYPE HTML PUBLIC 'great' {0}hello{0}>", quote));
+        etest::test(std::format("doctype, {}-quoted system identifier", type), [=] {
+            auto tokens = run_tokenizer(std::format("<!DOCTYPE HTML PUBLIC 'great' {0}hello{0}>", quote));
             expect_token(
                     tokens, DoctypeToken{.name = "html", .public_identifier = "great", .system_identifier = "hello"});
             expect_token(tokens, EndOfFileToken{});
         });
 
-        etest::test(fmt::format("doctype, {}-quoted system identifier, unexpected null", type), [=] {
-            auto tokens = run_tokenizer(fmt::format("<!DOCTYPE HTML PUBLIC 'great' {0}n\0{0}>"sv, quote));
+        etest::test(std::format("doctype, {}-quoted system identifier, unexpected null", type), [=] {
+            auto tokens = run_tokenizer(std::format("<!DOCTYPE HTML PUBLIC 'great' {0}n\0{0}>"sv, quote));
             expect_error(tokens, ParseError::UnexpectedNullCharacter);
             expect_token(tokens,
                     DoctypeToken{.name = "html",
@@ -1430,16 +1429,16 @@ int main() {
             expect_token(tokens, EndOfFileToken{});
         });
 
-        etest::test(fmt::format("doctype, {}-quoted system identifier, missing whitespace", type), [=] {
-            auto tokens = run_tokenizer(fmt::format("<!DOCTYPE HTML PUBLIC 'great'{0}hello{0}>", quote));
+        etest::test(std::format("doctype, {}-quoted system identifier, missing whitespace", type), [=] {
+            auto tokens = run_tokenizer(std::format("<!DOCTYPE HTML PUBLIC 'great'{0}hello{0}>", quote));
             expect_error(tokens, ParseError::MissingWhitespaceBetweenDoctypePublicAndSystemIdentifiers);
             expect_token(
                     tokens, DoctypeToken{.name = "html", .public_identifier = "great", .system_identifier = "hello"});
             expect_token(tokens, EndOfFileToken{});
         });
 
-        etest::test(fmt::format("doctype, {}-quoted system identifier, eof", type), [=] {
-            auto tokens = run_tokenizer(fmt::format("<!DOCTYPE HTML PUBLIC 'great' {0}hell", quote));
+        etest::test(std::format("doctype, {}-quoted system identifier, eof", type), [=] {
+            auto tokens = run_tokenizer(std::format("<!DOCTYPE HTML PUBLIC 'great' {0}hell", quote));
             expect_error(tokens, ParseError::EofInDoctype);
             expect_token(tokens,
                     DoctypeToken{.name = "html",
@@ -1449,8 +1448,8 @@ int main() {
             expect_token(tokens, EndOfFileToken{});
         });
 
-        etest::test(fmt::format("doctype, {}-quoted system identifier, abrupt end", type), [=] {
-            auto tokens = run_tokenizer(fmt::format("<!DOCTYPE HTML PUBLIC 'great' {0}hell>", quote));
+        etest::test(std::format("doctype, {}-quoted system identifier, abrupt end", type), [=] {
+            auto tokens = run_tokenizer(std::format("<!DOCTYPE HTML PUBLIC 'great' {0}hell>", quote));
             expect_error(tokens, ParseError::AbruptDoctypeSystemIdentifier);
             expect_token(tokens,
                     DoctypeToken{.name = "html",

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -16,7 +16,6 @@ cc_library(
         "//uri",
         "//util:string",
         "@expected",
-        "@fmt",
     ],
 )
 
@@ -44,7 +43,6 @@ cc_library(
         "//net:test",
         "//uri",
         "@expected",
-        "@fmt",
     ],
 ) for src in glob(
     include = ["*_test.cpp"],

--- a/protocol/file_handler_test.cpp
+++ b/protocol/file_handler_test.cpp
@@ -9,10 +9,9 @@
 #include "etest/etest.h"
 #include "uri/uri.h"
 
-#include <fmt/format.h>
-
 #include <cerrno>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <optional>
@@ -70,20 +69,20 @@ int main() {
         auto tmp_dir = fs::temp_directory_path();
 
         protocol::FileHandler handler;
-        auto res = handler.handle(uri::Uri::parse(fmt::format("file://{}", tmp_dir.generic_string())).value());
+        auto res = handler.handle(uri::Uri::parse(std::format("file://{}", tmp_dir.generic_string())).value());
         expect_eq(res.error(), protocol::Error{protocol::ErrorCode::InvalidResponse});
     });
 
     etest::test("uri pointing to a regular file", [] {
         std::random_device rng;
-        auto tmp_dst = fs::temp_directory_path() / fmt::format("hastur-uri-pointing-to-a-regular-file-test.{}", rng());
+        auto tmp_dst = fs::temp_directory_path() / std::format("hastur-uri-pointing-to-a-regular-file-test.{}", rng());
 
         auto tmp_file = TmpFile::create(std::move(tmp_dst));
         require(tmp_file.has_value());
         require(bool{tmp_file->fstream() << "hello!" << std::flush});
 
         protocol::FileHandler handler;
-        auto res = handler.handle(uri::Uri::parse(fmt::format("file://{}", tmp_file->path().generic_string())).value());
+        auto res = handler.handle(uri::Uri::parse(std::format("file://{}", tmp_file->path().generic_string())).value());
         expect_eq(res, protocol::Response{{}, {}, "hello!"});
     });
 

--- a/protocol/http.cpp
+++ b/protocol/http.cpp
@@ -10,9 +10,8 @@
 #include "uri/uri.h"
 #include "util/string.h"
 
-#include <fmt/format.h>
-
 #include <charconv>
+#include <format>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -43,7 +42,7 @@ bool Http::use_port(uri::Uri const &uri) {
 
 std::string Http::create_get_request(uri::Uri const &uri, std::optional<std::string_view> user_agent) {
     std::stringstream ss;
-    ss << fmt::format("GET {}", uri.path);
+    ss << std::format("GET {}", uri.path);
     if (!uri.query.empty()) {
         ss << '?' << uri.query;
     }
@@ -51,14 +50,14 @@ std::string Http::create_get_request(uri::Uri const &uri, std::optional<std::str
     ss << " HTTP/1.1\r\n";
 
     if (Http::use_port(uri)) {
-        ss << fmt::format("Host: {}:{}\r\n", uri.authority.host, uri.authority.port);
+        ss << std::format("Host: {}:{}\r\n", uri.authority.host, uri.authority.port);
     } else {
-        ss << fmt::format("Host: {}\r\n", uri.authority.host);
+        ss << std::format("Host: {}\r\n", uri.authority.host);
     }
     ss << "Accept: text/html\r\n";
     ss << "Connection: close\r\n";
     if (user_agent) {
-        ss << fmt::format("User-Agent: {}\r\n", *user_agent);
+        ss << std::format("User-Agent: {}\r\n", *user_agent);
     }
 
     ss << "\r\n";

--- a/uri/BUILD
+++ b/uri/BUILD
@@ -10,7 +10,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//util:string",
-        "@fmt",
     ],
 )
 

--- a/uri/uri.cpp
+++ b/uri/uri.cpp
@@ -7,8 +7,7 @@
 
 #include "util/string.h"
 
-#include <fmt/format.h>
-
+#include <format>
 #include <functional>
 #include <optional>
 #include <regex>
@@ -95,26 +94,26 @@ std::optional<Uri> parse_uri(std::string uristr) {
     std::optional<Uri> completed;
     if (uri.authority.host.empty() && uri.path.starts_with('/')) {
         // Origin-relative.
-        completed = parse_uri(fmt::format("{}://{}{}", base.scheme, base.authority.host, uri.uri));
+        completed = parse_uri(std::format("{}://{}{}", base.scheme, base.authority.host, uri.uri));
     } else if (uri.authority.host.empty() && !uri.path.empty()) {
         // https://url.spec.whatwg.org/#path-relative-url-string
         if (base.path == "/") {
-            completed = parse_uri(fmt::format("{}/{}", base.uri, uri.uri));
+            completed = parse_uri(std::format("{}/{}", base.uri, uri.uri));
         } else {
             auto end_of_last_path_segment = base.uri.find_last_of('/');
-            completed = parse_uri(fmt::format("{}/{}", base.uri.substr(0, end_of_last_path_segment), uri.uri));
+            completed = parse_uri(std::format("{}/{}", base.uri.substr(0, end_of_last_path_segment), uri.uri));
         }
     } else if (!uri.authority.host.empty() && uri.uri.starts_with("//")) {
         // Scheme-relative.
-        completed = parse_uri(fmt::format("{}:{}", base.scheme, uri.uri));
+        completed = parse_uri(std::format("{}:{}", base.scheme, uri.uri));
     } else if (uri.uri.starts_with('#')) {
         // Fragment-only.
         // Strip the old fragment if needed
         if (!base.fragment.empty()) {
             auto start_of_fragment = base.uri.find('#');
-            completed = parse_uri(fmt::format("{}{}", base.uri.substr(0, start_of_fragment), uri.uri));
+            completed = parse_uri(std::format("{}{}", base.uri.substr(0, start_of_fragment), uri.uri));
         } else {
-            completed = parse_uri(fmt::format("{}{}", base.uri, uri.uri));
+            completed = parse_uri(std::format("{}{}", base.uri, uri.uri));
         }
     } else {
         // No completion needed.


### PR DESCRIPTION
This drops gcc 12, Clang w/ lib++ 16, and whatever GitHub's macOS 13
runner uses.

The gcc 14 job was switched over to run tests under valgrind to cover
what gcc 12 was previously doing.