### PR TITLE
Replace all fmt::format-bits w/ std::format

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -29,7 +29,6 @@
 #include <SFML/Window/Keyboard.hpp>
 #include <SFML/Window/Mouse.hpp>
 #include <SFML/Window/VideoMode.hpp>
-#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <imgui-SFML.h>
 #include <imgui.h>
@@ -44,6 +43,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <format>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -82,7 +82,7 @@ std::optional<std::string_view> try_get_text_content(dom::Document const &doc, s
 void ensure_has_scheme(std::string &url) {
     if (!url.contains("://")) {
         spdlog::info("Url missing scheme, assuming https");
-        url = fmt::format("https://{}", url);
+        url = std::format("https://{}", url);
     }
 }
 
@@ -356,7 +356,7 @@ void App::step() {
             auto document_position = to_document_position(std::move(window_position));
             auto const *hovered = get_hovered_node(document_position);
             nav_widget_extra_info_ =
-                    fmt::format("{},{}: {}", document_position.x, document_position.y, element_text(hovered));
+                    std::format("{},{}: {}", document_position.x, document_position.y, element_text(hovered));
 
             // If imgui is dealing with the mouse, we do nothing and let imgui change the cursor.
             if (ImGui::GetIO().WantCaptureMouse) {
@@ -497,22 +497,22 @@ void App::reload() {
 void App::on_navigation_failure(protocol::ErrorCode err) {
     switch (err) {
         case protocol::ErrorCode::Unresolved: {
-            nav_widget_extra_info_ = fmt::format("Unable to resolve endpoint for '{}'", url_buf_);
+            nav_widget_extra_info_ = std::format("Unable to resolve endpoint for '{}'", url_buf_);
             spdlog::error(nav_widget_extra_info_);
             break;
         }
         case protocol::ErrorCode::Unhandled: {
-            nav_widget_extra_info_ = fmt::format("Unhandled protocol for '{}'", url_buf_);
+            nav_widget_extra_info_ = std::format("Unhandled protocol for '{}'", url_buf_);
             spdlog::error(nav_widget_extra_info_);
             break;
         }
         case protocol::ErrorCode::InvalidResponse: {
-            nav_widget_extra_info_ = fmt::format("Invalid response from '{}'", url_buf_);
+            nav_widget_extra_info_ = std::format("Invalid response from '{}'", url_buf_);
             spdlog::error(nav_widget_extra_info_);
             break;
         }
         case protocol::ErrorCode::RedirectLimit: {
-            nav_widget_extra_info_ = fmt::format("Redirect limit hit while loading '{}'", url_buf_);
+            nav_widget_extra_info_ = std::format("Redirect limit hit while loading '{}'", url_buf_);
             spdlog::error(nav_widget_extra_info_);
             break;
         }
@@ -521,7 +521,7 @@ void App::on_navigation_failure(protocol::ErrorCode err) {
 
 void App::on_page_loaded() {
     if (auto page_title = try_get_text_content(page().dom, "/html/head/title"sv)) {
-        auto title = fmt::format("{} - {}", *page_title, browser_title_);
+        auto title = std::format("{} - {}", *page_title, browser_title_);
         window_.setTitle(sf::String::fromUtf8(title.begin(), title.end()));
     } else {
         window_.setTitle(browser_title_);
@@ -662,7 +662,7 @@ void App::run_debug_widget() const {
         }();
 
         std::cout << "\nStatus line:\n"
-                  << fmt::format("{} {} {}", status.version, status.status_code, status.reason) << '\n';
+                  << std::format("{} {} {}", status.version, status.status_code, status.reason) << '\n';
     }
 
     if (ImGui::Button("Response headers")) {

--- a/browser/tui/BUILD
+++ b/browser/tui/BUILD
@@ -12,7 +12,6 @@ cc_binary(
         "//protocol",
         "//tui",
         "//uri",
-        "@fmt",
         "@spdlog",
     ],
 )

--- a/browser/tui/tui.cpp
+++ b/browser/tui/tui.cpp
@@ -9,7 +9,6 @@
 #include "protocol/response.h"
 #include "uri/uri.h"
 
-#include <fmt/format.h>
 #include <spdlog/cfg/env.h>
 #include <spdlog/logger.h>
 #include <spdlog/sinks/dup_filter_sink.h>
@@ -17,6 +16,7 @@
 #include <spdlog/spdlog.h>
 
 #include <chrono>
+#include <format>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -30,7 +30,7 @@ constexpr char const *kDefaultUri = "http://www.example.com";
 void ensure_has_scheme(std::string &url) {
     if (!url.contains("://")) {
         spdlog::info("Url missing scheme, assuming https");
-        url = fmt::format("https://{}", url);
+        url = std::format("https://{}", url);
     }
 }
 } // namespace

--- a/css/BUILD
+++ b/css/BUILD
@@ -21,7 +21,6 @@ cc_library(
     deps = [
         "//util:from_chars",
         "//util:string",
-        "@fmt",
         "@spdlog",
     ],
 )
@@ -43,7 +42,6 @@ cc_fuzz_test(
     deps = [
         ":css",
         "//etest",
-        "@fmt",
     ],
 ) for src in glob(
     include = ["*_test.cpp"],

--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -12,7 +12,6 @@
 
 #include "util/string.h"
 
-#include <fmt/format.h>
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
@@ -22,6 +21,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <format>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -665,34 +665,34 @@ void Parser::expand_border_radius_values(Declarations &declarations, std::string
         switch (tokenizer.size()) {
             case 1: {
                 auto v_radius{unchecked_get(tokenizer)};
-                top_left += fmt::format(" / {}", v_radius);
-                top_right += fmt::format(" / {}", v_radius);
-                bottom_right += fmt::format(" / {}", v_radius);
-                bottom_left += fmt::format(" / {}", v_radius);
+                top_left += std::format(" / {}", v_radius);
+                top_right += std::format(" / {}", v_radius);
+                bottom_right += std::format(" / {}", v_radius);
+                bottom_left += std::format(" / {}", v_radius);
                 break;
             }
             case 2: {
                 auto v1_radius{unchecked_get(tokenizer)};
-                top_left += fmt::format(" / {}", v1_radius);
-                bottom_right += fmt::format(" / {}", v1_radius);
+                top_left += std::format(" / {}", v1_radius);
+                bottom_right += std::format(" / {}", v1_radius);
                 auto v2_radius{unchecked_get(tokenizer.next())};
-                top_right += fmt::format(" / {}", v2_radius);
-                bottom_left += fmt::format(" / {}", v2_radius);
+                top_right += std::format(" / {}", v2_radius);
+                bottom_left += std::format(" / {}", v2_radius);
                 break;
             }
             case 3: {
-                top_left += fmt::format(" / {}", unchecked_get(tokenizer));
+                top_left += std::format(" / {}", unchecked_get(tokenizer));
                 auto v_radius = unchecked_get(tokenizer.next());
-                top_right += fmt::format(" / {}", v_radius);
-                bottom_left += fmt::format(" / {}", v_radius);
-                bottom_right += fmt::format(" / {}", unchecked_get(tokenizer.next()));
+                top_right += std::format(" / {}", v_radius);
+                bottom_left += std::format(" / {}", v_radius);
+                bottom_right += std::format(" / {}", unchecked_get(tokenizer.next()));
                 break;
             }
             case 4: {
-                top_left += fmt::format(" / {}", unchecked_get(tokenizer));
-                top_right += fmt::format(" / {}", unchecked_get(tokenizer.next()));
-                bottom_right += fmt::format(" / {}", unchecked_get(tokenizer.next()));
-                bottom_left += fmt::format(" / {}", unchecked_get(tokenizer.next()));
+                top_left += std::format(" / {}", unchecked_get(tokenizer));
+                top_right += std::format(" / {}", unchecked_get(tokenizer.next()));
+                bottom_right += std::format(" / {}", unchecked_get(tokenizer.next()));
+                bottom_left += std::format(" / {}", unchecked_get(tokenizer.next()));
                 break;
             }
             default:
@@ -853,10 +853,10 @@ void Parser::expand_edge_values(Declarations &declarations, std::string_view pro
         post_fix = "-color";
     }
 
-    declarations.insert_or_assign(property_id_from_string(fmt::format("{}-top{}", property, post_fix)), top);
-    declarations.insert_or_assign(property_id_from_string(fmt::format("{}-bottom{}", property, post_fix)), bottom);
-    declarations.insert_or_assign(property_id_from_string(fmt::format("{}-left{}", property, post_fix)), left);
-    declarations.insert_or_assign(property_id_from_string(fmt::format("{}-right{}", property, post_fix)), right);
+    declarations.insert_or_assign(property_id_from_string(std::format("{}-top{}", property, post_fix)), top);
+    declarations.insert_or_assign(property_id_from_string(std::format("{}-bottom{}", property, post_fix)), bottom);
+    declarations.insert_or_assign(property_id_from_string(std::format("{}-left{}", property, post_fix)), left);
+    declarations.insert_or_assign(property_id_from_string(std::format("{}-right{}", property, post_fix)), right);
 }
 
 void Parser::expand_font(Declarations &declarations, std::string_view value) {

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -11,11 +11,10 @@
 
 #include "etest/etest2.h"
 
-#include <fmt/format.h>
-
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <format>
 #include <iterator>
 #include <map>
 #include <source_location>
@@ -445,7 +444,7 @@ int main() {
 
     auto box_shorthand_one_value = [](std::string property, std::string value, std::string post_fix = "") {
         return [=](etest::IActions &a) mutable {
-            auto rules = css::parse(fmt::format("p {{ {}: {}; }}"sv, property, value)).rules;
+            auto rules = css::parse(std::format("p {{ {}: {}; }}"sv, property, value)).rules;
             a.require(rules.size() == 1);
 
             if (property == "border-style" || property == "border-color" || property == "border-width") {
@@ -454,13 +453,13 @@ int main() {
 
             auto const &body = rules[0];
             a.expect(body.declarations.size() == 4);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-top{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-top{}", property, post_fix)))
                     == value);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-bottom{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-bottom{}", property, post_fix)))
                     == value);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-left{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-left{}", property, post_fix)))
                     == value);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-right{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-right{}", property, post_fix)))
                     == value);
         };
     };
@@ -485,7 +484,7 @@ int main() {
                                             std::array<std::string, 2> values,
                                             std::string post_fix = "") {
         return [=](etest::IActions &a) mutable {
-            auto rules = css::parse(fmt::format("p {{ {}: {} {}; }}"sv, property, values[0], values[1])).rules;
+            auto rules = css::parse(std::format("p {{ {}: {} {}; }}"sv, property, values[0], values[1])).rules;
             a.require(rules.size() == 1);
 
             if (property == "border-style") {
@@ -494,13 +493,13 @@ int main() {
 
             auto const &body = rules[0];
             a.expect(body.declarations.size() == 4);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-top{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-top{}", property, post_fix)))
                     == values[0]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-bottom{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-bottom{}", property, post_fix)))
                     == values[0]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-left{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-left{}", property, post_fix)))
                     == values[1]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-right{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-right{}", property, post_fix)))
                     == values[1]);
         };
     };
@@ -520,7 +519,7 @@ int main() {
                                               std::string post_fix = "") {
         return [=](etest::IActions &a) mutable {
             auto rules =
-                    css::parse(fmt::format("p {{ {}: {} {} {}; }}"sv, property, values[0], values[1], values[2])).rules;
+                    css::parse(std::format("p {{ {}: {} {} {}; }}"sv, property, values[0], values[1], values[2])).rules;
             a.require(rules.size() == 1);
 
             if (property == "border-style") {
@@ -529,13 +528,13 @@ int main() {
 
             auto const &body = rules[0];
             a.expect(body.declarations.size() == 4);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-top{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-top{}", property, post_fix)))
                     == values[0]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-bottom{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-bottom{}", property, post_fix)))
                     == values[2]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-left{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-left{}", property, post_fix)))
                     == values[1]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-right{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-right{}", property, post_fix)))
                     == values[1]);
         };
     };
@@ -555,7 +554,7 @@ int main() {
                                              std::string post_fix = "") {
         return [=](etest::IActions &a) mutable {
             auto rules = css::parse(
-                    fmt::format("p {{ {}: {} {} {} {}; }}"sv, property, values[0], values[1], values[2], values[3]))
+                    std::format("p {{ {}: {} {} {} {}; }}"sv, property, values[0], values[1], values[2], values[3]))
                                  .rules;
             a.require(rules.size() == 1);
 
@@ -565,13 +564,13 @@ int main() {
 
             auto const &body = rules[0];
             a.expect(body.declarations.size() == 4);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-top{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-top{}", property, post_fix)))
                     == values[0]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-bottom{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-bottom{}", property, post_fix)))
                     == values[2]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-left{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-left{}", property, post_fix)))
                     == values[3]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-right{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-right{}", property, post_fix)))
                     == values[1]);
         };
     };
@@ -597,7 +596,7 @@ int main() {
                                             std::string post_fix = "") {
         return [=](etest::IActions &a) mutable {
             std::string workaround_for_border_style = property == "border-style" ? "border" : property;
-            auto rules = css::parse(fmt::format(R"(
+            auto rules = css::parse(std::format(R"(
                             p {{
                                {0}: {2};
                                {5}-top{1}: {3};
@@ -618,13 +617,13 @@ int main() {
 
             auto const &body = rules[0];
             a.expect(body.declarations.size() == 4);
-            a.expect_eq(body.declarations.at(css::property_id_from_string(fmt::format("{}-top{}", property, post_fix))),
+            a.expect_eq(body.declarations.at(css::property_id_from_string(std::format("{}-top{}", property, post_fix))),
                     values[1]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-bottom{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-bottom{}", property, post_fix)))
                     == values[0]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-left{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-left{}", property, post_fix)))
                     == values[2]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-right{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-right{}", property, post_fix)))
                     == values[0]);
         };
     };
@@ -644,7 +643,7 @@ int main() {
                                                std::string post_fix = "") {
         return [=](etest::IActions &a) mutable {
             std::string workaround_for_border_style = property == "border-style" ? "border" : property;
-            auto rules = css::parse(fmt::format(R"(
+            auto rules = css::parse(std::format(R"(
                             p {{
                                {6}-bottom{1}: {2};
                                {6}-left{1}: {3};
@@ -666,13 +665,13 @@ int main() {
 
             auto const &body = rules[0];
             a.expect(body.declarations.size() == 4);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-top{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-top{}", property, post_fix)))
                     == values[2]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-bottom{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-bottom{}", property, post_fix)))
                     == values[2]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-left{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-left{}", property, post_fix)))
                     == values[3]);
-            a.expect(body.declarations.at(css::property_id_from_string(fmt::format("{}-right{}", property, post_fix)))
+            a.expect(body.declarations.at(css::property_id_from_string(std::format("{}-right{}", property, post_fix)))
                     == values[3]);
         };
     };

--- a/css/property_id_test.cpp
+++ b/css/property_id_test.cpp
@@ -6,8 +6,7 @@
 
 #include "etest/etest2.h"
 
-#include <fmt/format.h>
-
+#include <format>
 #include <string_view>
 
 using namespace std::literals;
@@ -30,7 +29,7 @@ int main() {
         // Requires a manual update every time we add something last in the enum.
         while (id <= static_cast<int>(css::PropertyId::WordSpacing)) {
             a.expect(css::to_string(static_cast<css::PropertyId>(id)) != "unknown"sv,
-                    fmt::format("Property {} is missing a string mapping", id));
+                    std::format("Property {} is missing a string mapping", id));
             id += 1;
         }
     });

--- a/style/BUILD
+++ b/style/BUILD
@@ -31,6 +31,5 @@ cc_library(
         "//dom",
         "//etest",
         "//gfx",
-        "@fmt",
     ],
 ) for src in glob(["*_test.cpp"])]

--- a/style/style_test.cpp
+++ b/style/style_test.cpp
@@ -12,10 +12,9 @@
 #include "dom/dom.h"
 #include "etest/etest.h"
 
-#include <fmt/format.h>
-
 #include <algorithm>
 #include <array>
+#include <format>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -133,21 +132,21 @@ int main() {
 
     // These are 100% identical right now as we treat all links as unvisited links.
     for (auto const *pc : std::array{"link", "any-link"}) {
-        etest::test(fmt::format("is_match: psuedo-class, {}", pc), [pc] {
-            expect(is_match(dom::Element{"a", {{"href", ""}}}, fmt::format(":{}", pc)));
+        etest::test(std::format("is_match: psuedo-class, {}", pc), [pc] {
+            expect(is_match(dom::Element{"a", {{"href", ""}}}, std::format(":{}", pc)));
 
-            expect(is_match(dom::Element{"a", {{"href", ""}}}, fmt::format("a:{}", pc)));
-            expect(is_match(dom::Element{"area", {{"href", ""}}}, fmt::format("area:{}", pc)));
+            expect(is_match(dom::Element{"a", {{"href", ""}}}, std::format("a:{}", pc)));
+            expect(is_match(dom::Element{"area", {{"href", ""}}}, std::format("area:{}", pc)));
 
-            expect(is_match(dom::Element{"a", {{"href", ""}, {"class", "hi"}}}, fmt::format(".hi:{}", pc)));
-            expect(is_match(dom::Element{"a", {{"href", ""}, {"id", "hi"}}}, fmt::format("#hi:{}", pc)));
+            expect(is_match(dom::Element{"a", {{"href", ""}, {"class", "hi"}}}, std::format(".hi:{}", pc)));
+            expect(is_match(dom::Element{"a", {{"href", ""}, {"id", "hi"}}}, std::format("#hi:{}", pc)));
 
-            expect(!is_match(dom::Element{"b"}, fmt::format(":{}", pc)));
-            expect(!is_match(dom::Element{"a"}, fmt::format("a:{}", pc)));
-            expect(!is_match(dom::Element{"a", {{"href", ""}}}, fmt::format("b:{}", pc)));
-            expect(!is_match(dom::Element{"b", {{"href", ""}}}, fmt::format("b:{}", pc)));
-            expect(!is_match(dom::Element{"a", {{"href", ""}, {"class", "hi2"}}}, fmt::format(".hi:{}", pc)));
-            expect(!is_match(dom::Element{"a", {{"href", ""}, {"id", "hi2"}}}, fmt::format("#hi:{}", pc)));
+            expect(!is_match(dom::Element{"b"}, std::format(":{}", pc)));
+            expect(!is_match(dom::Element{"a"}, std::format("a:{}", pc)));
+            expect(!is_match(dom::Element{"a", {{"href", ""}}}, std::format("b:{}", pc)));
+            expect(!is_match(dom::Element{"b", {{"href", ""}}}, std::format("b:{}", pc)));
+            expect(!is_match(dom::Element{"a", {{"href", ""}, {"class", "hi2"}}}, std::format(".hi:{}", pc)));
+            expect(!is_match(dom::Element{"a", {{"href", ""}, {"id", "hi2"}}}, std::format("#hi:{}", pc)));
         });
     }
 

--- a/third_party/spdlog.BUILD
+++ b/third_party/spdlog.BUILD
@@ -11,6 +11,8 @@ cc_library(
         "SPDLOG_COMPILED_LIB",
         "SPDLOG_FMT_EXTERNAL",
         "SPDLOG_NO_EXCEPTIONS",
+        # libc++18 doesn't set __cpp_lib_format >= 202207L which is required for this.
+        # "SPDLOG_USE_STD_FORMAT",
     ],
     includes = ["include/"],
     linkopts = select({


### PR DESCRIPTION
`fmt::join` was left in a few places as there's no good well-supported
alternative in the stdlib yet, and we're still depending on fmtlib via
spdlog anyway.

