### PR TITLE
css2: Fix assertion failures and set up fuzz testing

### DIFF
--- a/css2/BUILD
+++ b/css2/BUILD
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-load("//bzl:copts.bzl", "HASTUR_COPTS")
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+load("//bzl:copts.bzl", "HASTUR_COPTS", "HASTUR_FUZZ_PLATFORMS")
 
 cc_library(
     name = "css2",
@@ -26,4 +27,17 @@ cc_library(
         ":css2",
         "//etest",
     ],
-) for src in glob(["*_test.cpp"])]
+) for src in glob(
+    include = ["*_test.cpp"],
+    exclude = ["*_fuzz_test.cpp"],
+)]
+
+[cc_fuzz_test(
+    name = src[:-4],
+    size = "small",
+    testonly = True,
+    srcs = [src],
+    copts = HASTUR_COPTS,
+    target_compatible_with = HASTUR_FUZZ_PLATFORMS,
+    deps = [":css2"],
+) for src in glob(["*_fuzz_test.cpp"])]

--- a/css2/token.h
+++ b/css2/token.h
@@ -61,7 +61,7 @@ struct DelimToken {
 };
 
 struct NumberToken {
-    std::variant<int, double> data;
+    std::variant<std::int32_t, double> data;
     [[nodiscard]] bool operator==(NumberToken const &) const = default;
 
     [[nodiscard]] constexpr bool is_integer() const { return std::holds_alternative<int>(data); }

--- a/css2/tokenizer.cpp
+++ b/css2/tokenizer.cpp
@@ -410,7 +410,8 @@ std::variant<int, double> Tokenizer::consume_number(char first_byte) {
         consume_next_input_character();
     }
 
-    if (peek_input(0) == '.' && util::is_digit(peek_input(1).value_or('Q'))) {
+    if (!std::holds_alternative<double>(result) && peek_input(0) == '.'
+            && util::is_digit(peek_input(1).value_or('Q'))) {
         std::ignore = consume_next_input_character(); // '.'
         auto v = consume_next_input_character();
         assert(v.has_value());

--- a/css2/tokenizer.cpp
+++ b/css2/tokenizer.cpp
@@ -362,7 +362,7 @@ bool Tokenizer::inputs_starts_ident_sequence(char first_character) const {
     return result;
 }
 
-bool Tokenizer::inputs_starts_number(char first_character) const {
+bool Tokenizer::inputs_starts_number([[maybe_unused]] char first_character) const {
     assert(first_character == '-' || first_character == '+');
 
     auto next_input = peek_input(0);

--- a/css2/tokenizer.h
+++ b/css2/tokenizer.h
@@ -68,7 +68,7 @@ private:
     bool is_eof() const;
     void reconsume_in(State);
 
-    std::variant<int, double> consume_number(char first_byte);
+    std::variant<std::int32_t, double> consume_number(char first_byte);
     std::string consume_an_escaped_code_point();
 };
 

--- a/css2/tokenizer_fuzz_test.cpp
+++ b/css2/tokenizer_fuzz_test.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "css2/tokenizer.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *data, std::size_t size);
+
+extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *data, std::size_t size) {
+    auto input = std::string_view{reinterpret_cast<char const *>(data), size};
+    css2::Tokenizer{input,
+            [](auto &&) {},
+            [](auto) {
+            }}
+            .run();
+    return 0;
+}

--- a/css2/tokenizer_test.cpp
+++ b/css2/tokenizer_test.cpp
@@ -9,6 +9,8 @@
 
 #include "etest/etest2.h"
 
+#include <cstdint>
+#include <limits>
 #include <source_location>
 #include <string>
 #include <string_view>
@@ -377,6 +379,16 @@ int main() {
         expect_token(output, CloseParenToken{});
     });
 
+    s.add_test("integer: large", [](etest::IActions &a) {
+        auto output = run_tokenizer(a, "12147483647");
+        expect_token(output, NumberToken{std::numeric_limits<std::int32_t>::max()});
+    });
+
+    s.add_test("integer: large negative", [](etest::IActions &a) {
+        auto output = run_tokenizer(a, "-12147483648");
+        expect_token(output, NumberToken{std::numeric_limits<std::int32_t>::min()});
+    });
+
     s.add_test("integer: leading 0", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "00000001");
         expect_token(output, NumberToken{.data = 1});
@@ -450,6 +462,16 @@ int main() {
         auto output = run_tokenizer(a, "-.");
         expect_token(output, DelimToken{'-'});
         expect_token(output, DelimToken{'.'});
+    });
+
+    s.add_test("number: large", [](etest::IActions &a) {
+        auto output = run_tokenizer(a, "12147483647.0");
+        expect_token(output, NumberToken{static_cast<double>(std::numeric_limits<std::int32_t>::max())});
+    });
+
+    s.add_test("number: large negative", [](etest::IActions &a) {
+        auto output = run_tokenizer(a, "-12147483648.0");
+        expect_token(output, NumberToken{static_cast<double>(std::numeric_limits<std::int32_t>::min())});
     });
 
     s.add_test("number: no digits before decimal point", [](etest::IActions &a) {

--- a/css2/tokenizer_test.cpp
+++ b/css2/tokenizer_test.cpp
@@ -457,6 +457,13 @@ int main() {
         expect_token(output, NumberToken{.25});
     });
 
+    // TODO(robinlinden): Look into what this is meant to parse as.
+    s.add_test("number: dots and digits shouldn't crash", [](etest::IActions &a) {
+        auto output = run_tokenizer(a, ".25.25");
+        expect_token(output, NumberToken{.25});
+        expect_token(output, NumberToken{.25});
+    });
+
     s.add_test("full stop", [](etest::IActions &a) {
         auto output = run_tokenizer(a, ".");
         expect_token(output, DelimToken{'.'});


### PR DESCRIPTION
The consume_number code has become quite janky and should be updated to more closely match the spec, but this fixes all issues fuzzing found.