### PR TITLE
etest: Add support for compile-time tests

### DIFF
--- a/idna/punycode_test.cpp
+++ b/idna/punycode_test.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 namespace {
-std::string unicode_as_utf8_string(std::vector<int> const &code_points) {
+constexpr std::string unicode_as_utf8_string(std::vector<int> const &code_points) {
     std::string result{};
     for (auto const code_point : code_points) {
         result += unicode::to_utf8(code_point);
@@ -25,7 +25,7 @@ int main() {
     etest::Suite s{};
 
     // https://datatracker.ietf.org/doc/html/rfc3492#section-7
-    s.add_test("(A) Arabic (Egyptian)", [](etest::IActions &a) {
+    s.constexpr_test("(A) Arabic (Egyptian)", [](etest::IActions &a) {
         // u+0644 u+064A u+0647 u+0645 u+0627 u+0628 u+062A u+0643 u+0644
         // u+0645 u+0648 u+0634 u+0639 u+0631 u+0628 u+064A u+061F
         // Punycode: egbpdaj6bu4bxfgehfvwxn
@@ -49,7 +49,7 @@ int main() {
         a.expect_eq(idna::Punycode::to_utf8("egbpdaj6bu4bxfgehfvwxn").value(), expected);
     });
 
-    s.add_test("(M) <amuro><namie>-with-SUPER-MONKEYS", [](etest::IActions &a) {
+    s.constexpr_test("(M) <amuro><namie>-with-SUPER-MONKEYS", [](etest::IActions &a) {
         // u+5B89 u+5BA4 u+5948 u+7F8E u+6075 u+002D u+0077 u+0069 u+0074
         // u+0068 u+002D U+0053 U+0055 U+0050 U+0045 U+0052 u+002D U+004D
         // U+004F U+004E U+004B U+0045 U+0059 U+0053
@@ -81,7 +81,7 @@ int main() {
         a.expect_eq(idna::Punycode::to_utf8("-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n").value(), expected);
     });
 
-    s.add_test("(P) Maji<de>Koi<suru>5<byou><mae>", [](etest::IActions &a) {
+    s.constexpr_test("(P) Maji<de>Koi<suru>5<byou><mae>", [](etest::IActions &a) {
         // U+004D u+0061 u+006A u+0069 u+3067 U+004B u+006F u+0069 u+3059
         // u+308B u+0035 u+79D2 u+524D
         // Punycode: MajiKoi5-783gue6qz075azm5e
@@ -91,20 +91,20 @@ int main() {
     });
 
     // Error handling.
-    s.add_test("non-ascii before separator", [](etest::IActions &a) {
+    s.constexpr_test("non-ascii before separator", [](etest::IActions &a) {
         a.expect_eq(idna::Punycode::to_utf8("\xF0-").has_value(), false); //
     });
 
-    s.add_test("out of data", [](etest::IActions &a) {
+    s.constexpr_test("out of data", [](etest::IActions &a) {
         a.expect_eq(idna::Punycode::to_utf8("-3").has_value(), false); //
     });
 
-    s.add_test("non-ascii after separator", [](etest::IActions &a) {
+    s.constexpr_test("non-ascii after separator", [](etest::IActions &a) {
         a.expect_eq(idna::Punycode::to_utf8("-\xF0").has_value(), false); //
     });
 
     // Other functionality.
-    s.add_test("uppercase punycode", [](etest::IActions &a) {
+    s.constexpr_test("uppercase punycode", [](etest::IActions &a) {
         // Same as (P) Maji<de>Koi<suru>5<byou><mae>, but with the punycode capitalized.
         std::string expected = unicode_as_utf8_string(
                 {'M', 'a', 'j', 'i', 0x3067, 'K', 'o', 'i', 0x3059, 0x308B, '5', 0x79D2, 0x524D});


### PR DESCRIPTION
These tests are both evaluated in static-asserts and run like normal
tests in order to allow measuring code coverage and things like that.