### PR TITLE
build: Fix detect_odr_violation not being enabled

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -89,7 +89,7 @@ build:asan --strip=never
 build:asan --features=asan
 build:asan --copt=-fsanitize-address-use-after-scope
 build:asan --copt=-fno-omit-frame-pointer
-build:asan --action_env=ASAN_OPTIONS=detect_odr_violations=2:detect_leaks=1:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
+build:asan --action_env=ASAN_OPTIONS=detect_odr_violation=2:detect_leaks=1:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
 build:asan --action_env=LSAN_OPTIONS=report_objects=1
 
 build:tsan --strip=never


### PR DESCRIPTION
This was incorrectly written as detect_odr_violation*s*, and there's no warning about unhandled arguments unless you turn up the verbosity of asan:

```
WARNING: found 1 unrecognized flag(s):
    detect_odr_violations
```

See: https://github.com/google/sanitizers/wiki/AddressSanitizerOneDefinitionRuleViolation