### PR TITLE
ci: Update the Clang coverage job to Clang 19

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -107,10 +107,6 @@ build:clang-coverage
 build:clang-coverage --action_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
 build:clang-coverage --experimental_generate_llvm_lcov
 
-build:clang16-coverage --config=clang-coverage
-build:clang16-coverage --action_env=BAZEL_LLVM_COV=llvm-cov-16
-build:clang16-coverage --action_env=GCOV=llvm-profdata-16
-
 build:clang18-coverage --config=clang-coverage
 build:clang18-coverage --action_env=BAZEL_LLVM_COV=llvm-cov-18
 build:clang18-coverage --action_env=GCOV=llvm-profdata-18

--- a/.bazelrc
+++ b/.bazelrc
@@ -115,6 +115,10 @@ build:clang18-coverage --config=clang-coverage
 build:clang18-coverage --action_env=BAZEL_LLVM_COV=llvm-cov-18
 build:clang18-coverage --action_env=GCOV=llvm-profdata-18
 
+build:clang19-coverage --config=clang-coverage
+build:clang19-coverage --action_env=BAZEL_LLVM_COV=llvm-cov-19
+build:clang19-coverage --action_env=GCOV=llvm-profdata-19
+
 build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
 build:clang-tidy --output_groups=report
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,8 +99,8 @@ jobs:
           - compiler: gcc
             version: 13
           - compiler: clang
-            version: 18
-            bazel: --config=clang18-coverage
+            version: 19
+            bazel: --config=clang19-coverage
     steps:
       - uses: actions/checkout@v4
         with:
@@ -120,15 +120,18 @@ jobs:
       - name: Setup (clang)
         if: startsWith(matrix.compiler, 'clang')
         run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-add-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main"
           sudo apt-get update
           sudo apt-get install --no-install-recommends lcov clang-${{ matrix.version }} libclang-rt-${{ matrix.version }}-dev llvm-${{ matrix.version }}
-          echo "CC=clang-18" >> $GITHUB_ENV
-          echo "CXX=clang++-18" >> $GITHUB_ENV
+          echo "CC=clang-19" >> $GITHUB_ENV
+          echo "CXX=clang++-19" >> $GITHUB_ENV
       - run: sudo apt-get install libx11-dev libxi-dev
       - name: Coverage
         run: bazel coverage ... ${{ matrix.bazel }}
-      - name: Summary
-        run: lcov --summary bazel-out/_coverage/_coverage_report.dat
+      # clang 19 coverage has a lot of problems w/ boringssl:
+      # lcov: ERROR: "external/boringssl/crypto/conf/internal.h":30:  function conf.c:lh_CONF_VALUE_insert found on line but no corresponding 'line' coverage data point.  Cannot derive function end line.
+      - run: lcov --ignore-errors inconsistent --summary bazel-out/_coverage/_coverage_report.dat
       - name: Upload
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This also means we're now testing Clang 19 w/ libstdc++. Clang 18 w/
libstdc++ is still tested in the various sanitizer jobs, so no need for
an additional job for that.