### PR TITLE
style: Support parts of attribute matching

### DIFF
--- a/style/style.cpp
+++ b/style/style.cpp
@@ -155,6 +155,23 @@ bool is_match(style::StyledNode const &node, std::string_view selector) {
         return it != element.attributes.end() && it->second == selector_;
     }
 
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors
+    if (selector_.starts_with('[') && selector_.contains(']')) {
+        selector_.remove_prefix(1);
+        auto [attr, rest] = util::split_once(selector_, "]");
+        if (!rest.empty() && !is_match(node, rest)) {
+            return false;
+        }
+
+        auto [key, value] = util::split_once(attr, "=");
+        if (value.empty()) {
+            return element.attributes.contains(key);
+        }
+
+        auto it = element.attributes.find(key);
+        return it != element.attributes.end() && it->second == value;
+    }
+
     return false;
 }
 

--- a/style/style_test.cpp
+++ b/style/style_test.cpp
@@ -10,7 +10,7 @@
 #include "css/rule.h"
 #include "css/style_sheet.h"
 #include "dom/dom.h"
-#include "etest/etest.h"
+#include "etest/etest2.h"
 
 #include <algorithm>
 #include <array>
@@ -22,9 +22,6 @@
 #include <vector>
 
 using namespace std::literals;
-using etest::expect;
-using etest::expect_eq;
-using etest::require;
 
 namespace {
 bool is_match(dom::Element const &e, std::string_view selector) {
@@ -48,31 +45,31 @@ bool check_parents(style::StyledNode const &a, style::StyledNode const &b) {
     return *a.parent == *b.parent;
 }
 
-void inline_css_tests() {
-    etest::test("inline css: is applied", [] {
+void inline_css_tests(etest::Suite &s) {
+    s.add_test("inline css: is applied", [](etest::IActions &a) {
         dom::Node dom = dom::Element{"div", {{"style", {"font-size:2px"}}}};
         auto styled = style::style_tree(dom, {}, {});
-        expect_eq(styled->properties, std::vector{std::pair{css::PropertyId::FontSize, "2px"s}});
+        a.expect_eq(styled->properties, std::vector{std::pair{css::PropertyId::FontSize, "2px"s}});
     });
 
-    etest::test("inline css: doesn't explode", [] {
+    s.add_test("inline css: doesn't explode", [](etest::IActions &) {
         dom::Node dom = dom::Element{"div", {{"style", {"aaa"}}}};
         std::ignore = style::style_tree(dom, {}, {});
     });
 
-    etest::test("inline css: overrides the stylesheet", [] {
+    s.add_test("inline css: overrides the stylesheet", [](etest::IActions &a) {
         dom::Node dom = dom::Element{"div", {{"style", {"font-size:2px"}}}};
         auto styled = style::style_tree(dom, {{css::Rule{{"div"}, {{css::PropertyId::FontSize, "2000px"}}}}}, {});
 
         // The last property is the one that's applied.
-        expect_eq(styled->properties,
+        a.expect_eq(styled->properties,
                 std::vector{
                         std::pair{css::PropertyId::FontSize, "2000px"s}, std::pair{css::PropertyId::FontSize, "2px"s}});
     });
 }
 
-void important_declarations_tests() {
-    etest::test("!important: has higher priority", [] {
+void important_declarations_tests(etest::Suite &s) {
+    s.add_test("!important: has higher priority", [](etest::IActions &a) {
         dom::Node dom = dom::Element{"div"};
         css::StyleSheet css{.rules{{
                 .selectors = {"div"},
@@ -82,7 +79,7 @@ void important_declarations_tests() {
         auto styled = style::style_tree(dom, css);
 
         // The last property is the one that's applied.
-        expect_eq(styled->properties,
+        a.expect_eq(styled->properties,
                 std::vector{
                         std::pair{css::PropertyId::FontSize, "2px"s},
                         std::pair{css::PropertyId::FontSize, "20px"s},
@@ -92,86 +89,88 @@ void important_declarations_tests() {
 } // namespace
 
 int main() {
-    etest::test("is_match: universal selector", [] {
-        expect(is_match(dom::Element{"div"}, "*"sv));
-        expect(is_match(dom::Element{"span"}, "*"sv));
+    etest::Suite s;
+
+    s.add_test("is_match: universal selector", [](etest::IActions &a) {
+        a.expect(is_match(dom::Element{"div"}, "*"sv));
+        a.expect(is_match(dom::Element{"span"}, "*"sv));
     });
 
-    etest::test("is_match: simple names", [] {
-        expect(is_match(dom::Element{"div"}, "div"sv));
-        expect(!is_match(dom::Element{"div"}, "span"sv));
+    s.add_test("is_match: simple names", [](etest::IActions &a) {
+        a.expect(is_match(dom::Element{"div"}, "div"sv));
+        a.expect(!is_match(dom::Element{"div"}, "span"sv));
     });
 
-    etest::test("is_match: class", [] {
-        expect(!is_match(dom::Element{"div"}, ".myclass"sv));
-        expect(!is_match(dom::Element{"div", {{"id", "myclass"}}}, ".myclass"sv));
-        expect(is_match(dom::Element{"div", {{"class", "myclass"}}}, ".myclass"sv));
-        expect(is_match(dom::Element{"div", {{"class", "first second"}}}, ".first"sv));
-        expect(is_match(dom::Element{"div", {{"class", "first second"}}}, ".second"sv));
+    s.add_test("is_match: class", [](etest::IActions &a) {
+        a.expect(!is_match(dom::Element{"div"}, ".myclass"sv));
+        a.expect(!is_match(dom::Element{"div", {{"id", "myclass"}}}, ".myclass"sv));
+        a.expect(is_match(dom::Element{"div", {{"class", "myclass"}}}, ".myclass"sv));
+        a.expect(is_match(dom::Element{"div", {{"class", "first second"}}}, ".first"sv));
+        a.expect(is_match(dom::Element{"div", {{"class", "first second"}}}, ".second"sv));
 
-        expect(is_match(dom::Element{"div", {{"class", "first second"}}}, ".first.second"sv));
-        expect(!is_match(dom::Element{"div", {{"class", "first second"}}}, ".first.third"sv));
+        a.expect(is_match(dom::Element{"div", {{"class", "first second"}}}, ".first.second"sv));
+        a.expect(!is_match(dom::Element{"div", {{"class", "first second"}}}, ".first.third"sv));
 
-        expect(is_match(dom::Element{"div", {{"class", "first second"}}}, "div.first"sv));
-        expect(is_match(dom::Element{"div", {{"class", "first second"}}}, "div.second"sv));
-        expect(is_match(dom::Element{"div", {{"class", "first second"}}}, "div.second.first"sv));
-        expect(!is_match(dom::Element{"div", {{"class", "first second"}}}, "div.third"sv));
-        expect(!is_match(dom::Element{"div", {{"class", "first second"}}}, "p.first"sv));
+        a.expect(is_match(dom::Element{"div", {{"class", "first second"}}}, "div.first"sv));
+        a.expect(is_match(dom::Element{"div", {{"class", "first second"}}}, "div.second"sv));
+        a.expect(is_match(dom::Element{"div", {{"class", "first second"}}}, "div.second.first"sv));
+        a.expect(!is_match(dom::Element{"div", {{"class", "first second"}}}, "div.third"sv));
+        a.expect(!is_match(dom::Element{"div", {{"class", "first second"}}}, "p.first"sv));
     });
 
-    etest::test("is_match: id", [] {
-        expect(!is_match(dom::Element{"div"}, "#myid"sv));
-        expect(is_match(dom::Element{"div", {{"class", "myid"}}}, ".myid"sv));
-        expect(!is_match(dom::Element{"div", {{"id", "myid"}}}, ".myid"sv));
+    s.add_test("is_match: id", [](etest::IActions &a) {
+        a.expect(!is_match(dom::Element{"div"}, "#myid"sv));
+        a.expect(is_match(dom::Element{"div", {{"class", "myid"}}}, ".myid"sv));
+        a.expect(!is_match(dom::Element{"div", {{"id", "myid"}}}, ".myid"sv));
     });
 
-    etest::test("is_match: psuedo-class, unhandled", [] {
-        expect(!is_match(dom::Element{"div"}, ":hi"sv));
-        expect(!is_match(dom::Element{"div"}, "div:hi"sv));
+    s.add_test("is_match: psuedo-class, unhandled", [](etest::IActions &a) {
+        a.expect(!is_match(dom::Element{"div"}, ":hi"sv));
+        a.expect(!is_match(dom::Element{"div"}, "div:hi"sv));
     });
 
     // These are 100% identical right now as we treat all links as unvisited links.
     for (auto const *pc : std::array{"link", "any-link"}) {
-        etest::test(std::format("is_match: psuedo-class, {}", pc), [pc] {
-            expect(is_match(dom::Element{"a", {{"href", ""}}}, std::format(":{}", pc)));
+        s.add_test(std::format("is_match: psuedo-class, {}", pc), [pc](etest::IActions &a) {
+            a.expect(is_match(dom::Element{"a", {{"href", ""}}}, std::format(":{}", pc)));
 
-            expect(is_match(dom::Element{"a", {{"href", ""}}}, std::format("a:{}", pc)));
-            expect(is_match(dom::Element{"area", {{"href", ""}}}, std::format("area:{}", pc)));
+            a.expect(is_match(dom::Element{"a", {{"href", ""}}}, std::format("a:{}", pc)));
+            a.expect(is_match(dom::Element{"area", {{"href", ""}}}, std::format("area:{}", pc)));
 
-            expect(is_match(dom::Element{"a", {{"href", ""}, {"class", "hi"}}}, std::format(".hi:{}", pc)));
-            expect(is_match(dom::Element{"a", {{"href", ""}, {"id", "hi"}}}, std::format("#hi:{}", pc)));
+            a.expect(is_match(dom::Element{"a", {{"href", ""}, {"class", "hi"}}}, std::format(".hi:{}", pc)));
+            a.expect(is_match(dom::Element{"a", {{"href", ""}, {"id", "hi"}}}, std::format("#hi:{}", pc)));
 
-            expect(!is_match(dom::Element{"b"}, std::format(":{}", pc)));
-            expect(!is_match(dom::Element{"a"}, std::format("a:{}", pc)));
-            expect(!is_match(dom::Element{"a", {{"href", ""}}}, std::format("b:{}", pc)));
-            expect(!is_match(dom::Element{"b", {{"href", ""}}}, std::format("b:{}", pc)));
-            expect(!is_match(dom::Element{"a", {{"href", ""}, {"class", "hi2"}}}, std::format(".hi:{}", pc)));
-            expect(!is_match(dom::Element{"a", {{"href", ""}, {"id", "hi2"}}}, std::format("#hi:{}", pc)));
+            a.expect(!is_match(dom::Element{"b"}, std::format(":{}", pc)));
+            a.expect(!is_match(dom::Element{"a"}, std::format("a:{}", pc)));
+            a.expect(!is_match(dom::Element{"a", {{"href", ""}}}, std::format("b:{}", pc)));
+            a.expect(!is_match(dom::Element{"b", {{"href", ""}}}, std::format("b:{}", pc)));
+            a.expect(!is_match(dom::Element{"a", {{"href", ""}, {"class", "hi2"}}}, std::format(".hi:{}", pc)));
+            a.expect(!is_match(dom::Element{"a", {{"href", ""}, {"id", "hi2"}}}, std::format("#hi:{}", pc)));
         });
     }
 
-    etest::test("is_match: :root", [] {
+    s.add_test("is_match: :root", [](etest::IActions &a) {
         dom::Element dom = dom::Element{"html", {}, {dom::Element{"body"}}};
         style::StyledNode node{dom, {}, {style::StyledNode{dom.children[0]}}};
         node.children[0].parent = &node;
 
-        expect(style::is_match(node, ":root"));
-        expect(!style::is_match(node.children[0], ":root"));
+        a.expect(style::is_match(node, ":root"));
+        a.expect(!style::is_match(node.children[0], ":root"));
     });
 
-    etest::test("is_match: child", [] {
+    s.add_test("is_match: child", [](etest::IActions &a) {
         dom::Element dom = dom::Element{"div", {{"class", "logo"}}, {dom::Element{"span"}}};
         style::StyledNode node{dom, {}, {style::StyledNode{dom.children[0]}}};
         node.children[0].parent = &node;
-        expect(style::is_match(node.children[0], ".logo > span"sv));
-        expect(!style::is_match(node, ".logo > span"sv));
+        a.expect(style::is_match(node.children[0], ".logo > span"sv));
+        a.expect(!style::is_match(node, ".logo > span"sv));
 
         std::get<dom::Element>(dom.children[0]).attributes["class"] = "ohno";
-        expect(style::is_match(node.children[0], ".logo > .ohno"sv));
-        expect(style::is_match(node.children[0], ".logo > span"sv));
+        a.expect(style::is_match(node.children[0], ".logo > .ohno"sv));
+        a.expect(style::is_match(node.children[0], ".logo > span"sv));
     });
 
-    etest::test("is_match: descendant", [] {
+    s.add_test("is_match: descendant", [](etest::IActions &a) {
         using style::StyledNode;
         // DOM for div[.logo] { span { a } }
         dom::Element dom = dom::Element{"div", {{"class", "logo"}}, {dom::Element{"span", {}, {dom::Element{"a"}}}}};
@@ -179,86 +178,86 @@ int main() {
         node.children[0].parent = &node;
         node.children[0].children[0].parent = &node.children[0];
 
-        expect(style::is_match(node.children[0], ".logo span"sv));
-        expect(style::is_match(node.children[0], "div span"sv));
-        expect(!style::is_match(node, ".logo span"sv));
+        a.expect(style::is_match(node.children[0], ".logo span"sv));
+        a.expect(style::is_match(node.children[0], "div span"sv));
+        a.expect(!style::is_match(node, ".logo span"sv));
 
         std::get<dom::Element>(dom.children[0]).attributes["class"] = "ohno";
-        expect(style::is_match(node.children[0], ".logo .ohno"sv));
-        expect(style::is_match(node.children[0], ".logo span"sv));
+        a.expect(style::is_match(node.children[0], ".logo .ohno"sv));
+        a.expect(style::is_match(node.children[0], ".logo span"sv));
 
-        expect(style::is_match(node.children[0].children[0], "div a"sv));
-        expect(style::is_match(node.children[0].children[0], ".logo a"sv));
-        expect(style::is_match(node.children[0].children[0], "span a"sv));
-        expect(style::is_match(node.children[0].children[0], ".ohno a"sv));
-        expect(style::is_match(node.children[0].children[0], "div span a"sv));
-        expect(style::is_match(node.children[0].children[0], ".logo span a"sv));
-        expect(style::is_match(node.children[0].children[0], "div .ohno a"sv));
-        expect(style::is_match(node.children[0].children[0], ".logo .ohno a"sv));
+        a.expect(style::is_match(node.children[0].children[0], "div a"sv));
+        a.expect(style::is_match(node.children[0].children[0], ".logo a"sv));
+        a.expect(style::is_match(node.children[0].children[0], "span a"sv));
+        a.expect(style::is_match(node.children[0].children[0], ".ohno a"sv));
+        a.expect(style::is_match(node.children[0].children[0], "div span a"sv));
+        a.expect(style::is_match(node.children[0].children[0], ".logo span a"sv));
+        a.expect(style::is_match(node.children[0].children[0], "div .ohno a"sv));
+        a.expect(style::is_match(node.children[0].children[0], ".logo .ohno a"sv));
     });
 
-    etest::test("matching_rules: simple names", [] {
+    s.add_test("matching_rules: simple names", [](etest::IActions &a) {
         css::StyleSheet stylesheet;
-        expect(matching_rules(dom::Element{"div"}, stylesheet).empty());
+        a.expect(matching_rules(dom::Element{"div"}, stylesheet).empty());
 
         stylesheet.rules.push_back(
                 css::Rule{.selectors = {"span", "p"}, .declarations = {{css::PropertyId::Width, "80px"}}});
 
-        expect(matching_rules(dom::Element{"div"}, stylesheet).empty());
+        a.expect(matching_rules(dom::Element{"div"}, stylesheet).empty());
 
         {
             auto span_rules = matching_rules(dom::Element{"span"}, stylesheet);
-            require(span_rules.size() == 1);
-            expect(span_rules[0] == std::pair{css::PropertyId::Width, "80px"s});
+            a.require(span_rules.size() == 1);
+            a.expect(span_rules[0] == std::pair{css::PropertyId::Width, "80px"s});
         }
 
         {
             auto p_rules = matching_rules(dom::Element{"p"}, stylesheet);
-            require(p_rules.size() == 1);
-            expect(p_rules[0] == std::pair{css::PropertyId::Width, "80px"s});
+            a.require(p_rules.size() == 1);
+            a.expect(p_rules[0] == std::pair{css::PropertyId::Width, "80px"s});
         }
 
         stylesheet.rules.push_back(
                 css::Rule{.selectors = {"span", "hr"}, .declarations = {{css::PropertyId::Height, "auto"}}});
 
-        expect(matching_rules(dom::Element{"div"}, stylesheet).empty());
+        a.expect(matching_rules(dom::Element{"div"}, stylesheet).empty());
 
         {
             auto span_rules = matching_rules(dom::Element{"span"}, stylesheet);
-            require(span_rules.size() == 2);
-            expect(span_rules[0] == std::pair{css::PropertyId::Width, "80px"s});
-            expect(span_rules[1] == std::pair{css::PropertyId::Height, "auto"s});
+            a.require(span_rules.size() == 2);
+            a.expect(span_rules[0] == std::pair{css::PropertyId::Width, "80px"s});
+            a.expect(span_rules[1] == std::pair{css::PropertyId::Height, "auto"s});
         }
 
         {
             auto p_rules = matching_rules(dom::Element{"p"}, stylesheet);
-            require(p_rules.size() == 1);
-            expect(p_rules[0] == std::pair{css::PropertyId::Width, "80px"s});
+            a.require(p_rules.size() == 1);
+            a.expect(p_rules[0] == std::pair{css::PropertyId::Width, "80px"s});
         }
 
         {
             auto hr_rules = matching_rules(dom::Element{"hr"}, stylesheet);
-            require(hr_rules.size() == 1);
-            expect(hr_rules[0] == std::pair{css::PropertyId::Height, "auto"s});
+            a.require(hr_rules.size() == 1);
+            a.expect(hr_rules[0] == std::pair{css::PropertyId::Height, "auto"s});
         }
     });
 
-    etest::test("matching_rules: media query", [] {
+    s.add_test("matching_rules: media query", [](etest::IActions &a) {
         css::StyleSheet stylesheet{{
                 css::Rule{.selectors{"p"}, .declarations{{css::PropertyId::Color, "red"}}},
         }};
 
-        expect_eq(
+        a.expect_eq(
                 matching_rules(dom::Element{"p"}, stylesheet), std::vector{std::pair{css::PropertyId::Color, "red"s}});
 
         stylesheet.rules[0].media_query = css::MediaQuery::parse("(min-width: 700px)");
-        expect(matching_rules(dom::Element{"p"}, stylesheet).empty());
+        a.expect(matching_rules(dom::Element{"p"}, stylesheet).empty());
 
-        expect_eq(matching_rules(dom::Element{"p"}, stylesheet, {.window_width = 700}),
+        a.expect_eq(matching_rules(dom::Element{"p"}, stylesheet, {.window_width = 700}),
                 std::vector{std::pair{css::PropertyId::Color, "red"s}});
     });
 
-    etest::test("style_tree: structure", [] {
+    s.add_test("style_tree: structure", [](etest::IActions &a) {
         auto root = dom::Element{"html", {}, {}};
         root.children.emplace_back(dom::Element{"head"});
         root.children.emplace_back(dom::Element{"body", {}, {dom::Element{"p"}}});
@@ -270,11 +269,11 @@ int main() {
         auto &body = expected.children.back();
         body.children.push_back({std::get<dom::Element>(root.children[1]).children[0], {}, {}, &body});
 
-        expect(*style::style_tree(root, {}) == expected);
-        expect(check_parents(*style::style_tree(root, {}), expected));
+        a.expect(*style::style_tree(root, {}) == expected);
+        a.expect(check_parents(*style::style_tree(root, {}), expected));
     });
 
-    etest::test("style_tree: style is applied", [] {
+    s.add_test("style_tree: style is applied", [](etest::IActions &a) {
         auto root = dom::Element{"html", {}, {}};
         root.children.emplace_back(dom::Element{"head"});
         root.children.emplace_back(dom::Element{"body", {}, {dom::Element{"p"}}});
@@ -294,30 +293,30 @@ int main() {
                 {},
                 &body});
 
-        expect(*style::style_tree(root, stylesheet) == expected);
-        expect(check_parents(*style::style_tree(root, stylesheet), expected));
+        a.expect(*style::style_tree(root, stylesheet) == expected);
+        a.expect(check_parents(*style::style_tree(root, stylesheet), expected));
     });
 
-    etest::test("matching rules: custom properties", [] {
+    s.add_test("matching rules: custom properties", [](etest::IActions &a) {
         css::StyleSheet stylesheet{{
                 css::Rule{.selectors{"p"}, .custom_properties{{"--hello", "very yes"}}},
                 css::Rule{.selectors{"a"}, .custom_properties{{"--goodbye", "very no"}}},
         }};
 
         auto res = style::matching_properties({.node = dom::Element{"p"}}, stylesheet, {});
-        expect_eq(res.custom, std::vector{std::pair{"--hello"s, "very yes"s}});
-        expect(res.normal.empty());
+        a.expect_eq(res.custom, std::vector{std::pair{"--hello"s, "very yes"s}});
+        a.expect(res.normal.empty());
 
         res = style::matching_properties({.node = dom::Element{"a"}}, stylesheet, {});
-        expect_eq(res.custom, std::vector{std::pair{"--goodbye"s, "very no"s}});
-        expect(res.normal.empty());
+        a.expect_eq(res.custom, std::vector{std::pair{"--goodbye"s, "very no"s}});
+        a.expect(res.normal.empty());
 
         res = style::matching_properties({.node = dom::Element{"div"}}, stylesheet, {});
-        expect(res.custom.empty());
-        expect(res.normal.empty());
+        a.expect(res.custom.empty());
+        a.expect(res.normal.empty());
     });
 
-    etest::test("style_tree: custom variables", [] {
+    s.add_test("style_tree: custom variables", [](etest::IActions &a) {
         auto root = dom::Element{"html", {{"style", "--inline: 3px;"}}, {}};
         css::StyleSheet stylesheet{{
                 {.selectors = {"html"}, .custom_properties = {{"--stylesheet", "5px"}}},
@@ -331,10 +330,11 @@ int main() {
                 },
         };
 
-        expect_eq(*style::style_tree(root, stylesheet), expected);
+        a.expect_eq(*style::style_tree(root, stylesheet), expected);
     });
 
-    inline_css_tests();
-    important_declarations_tests();
-    return etest::run_all_tests();
+    inline_css_tests(s);
+    important_declarations_tests(s);
+
+    return s.run();
 }

--- a/style/style_test.cpp
+++ b/style/style_test.cpp
@@ -86,6 +86,24 @@ void important_declarations_tests(etest::Suite &s) {
                 });
     });
 }
+
+void attribute_selector_matching(etest::Suite &s) {
+    s.add_test("is_match: attribute selector", [](etest::IActions &a) {
+        a.expect(is_match(dom::Element{"p", {{"a", "b"}}}, "[a]"sv));
+        a.expect(!is_match(dom::Element{"p", {{"a", "b"}}}, "[a"sv));
+        a.expect(!is_match(dom::Element{"p"}, "[a]"sv));
+
+        a.expect(is_match(dom::Element{"p", {{"a", "b"}}}, "[a=b]"sv));
+        a.expect(!is_match(dom::Element{"p", {{"a", "b"}}}, "[a=c]"sv));
+
+        a.expect(is_match(dom::Element{"p", {{"a", "b"}, {"c", "d"}}}, "[a=b][c=d]"sv));
+        a.expect(is_match(dom::Element{"p", {{"a", "b"}, {"c", "d"}}}, "[a=b][c]"sv));
+        a.expect(is_match(dom::Element{"p", {{"a", "b"}, {"c", "d"}}}, "[a][c]"sv));
+        a.expect(!is_match(dom::Element{"p", {{"a", "b"}, {"c", "d"}}}, "[a=b][c=g]"sv));
+        a.expect(!is_match(dom::Element{"p", {{"a", "b"}, {"c", "d"}}}, "[a=b][d]"sv));
+        a.expect(!is_match(dom::Element{"p", {{"a", "b"}}}, "[a][c]"sv));
+    });
+}
 } // namespace
 
 int main() {
@@ -335,6 +353,7 @@ int main() {
 
     inline_css_tests(s);
     important_declarations_tests(s);
+    attribute_selector_matching(s);
 
     return s.run();
 }


### PR DESCRIPTION
This adds support for things like [a][b=c], but no exotic forms of
matching, and also not things like asdf[foo=bar] where the attribute
isn't relatively alone.

Resolves #943 