### PR TITLE
css: Fix IE hacks being parsed as nested rules

### DIFF
--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -463,6 +463,8 @@ std::optional<css::Rule> Parser::parse_rule() {
         auto [name, value] = *decl;
         if (name.starts_with("--")) {
             rule.custom_properties.insert_or_assign(std::string{name}, value);
+        } else if (!util::is_alpha(name.front())) {
+            spdlog::warn("Ignoring unknown property: '{}'", name);
         } else if (value.ends_with("!important")) {
             value.remove_suffix(std::strlen("!important"));
             add_declaration(rule.important_declarations, name, util::trim(value));

--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -441,7 +441,10 @@ std::optional<css::Rule> Parser::parse_rule() {
             return std::nullopt;
         }
 
-        if (peek() == '{') {
+        // If a name starts w/ any of these, it's likely a nested rule w/ : as
+        // part of the selector, e.g. &:hover { ... }. This isn't great, but
+        // we're dropping this parser in favour of the css2 one soon(tm).
+        if (peek() == '{' || std::string_view{".#>&[|+~:"}.contains(nested_rule_or_declaration_name->front())) {
             // TODO(robinlinden): Nested rule. Skip over it for now.
             pos_ -= nested_rule_or_declaration_name->size();
             if (auto nested_rule = parse_rule()) {

--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -441,9 +441,7 @@ std::optional<css::Rule> Parser::parse_rule() {
             return std::nullopt;
         }
 
-        if (peek() == '{'
-                || (!util::is_alpha(nested_rule_or_declaration_name->front())
-                        && nested_rule_or_declaration_name->front() != '-')) {
+        if (peek() == '{') {
             // TODO(robinlinden): Nested rule. Skip over it for now.
             pos_ -= nested_rule_or_declaration_name->size();
             if (auto nested_rule = parse_rule()) {

--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -434,7 +434,7 @@ std::optional<css::Rule> Parser::parse_rule() {
 
     while (peek() != '}') {
         // TODO(robinlinden): This doesn't get along with nested rules like
-        // `foo // { bar:baz { font-size: 3em; } }`
+        // `foo { bar:baz { font-size: 3em; } }`
         // due to the assumption that "ascii:" always is a CSS property name.
         auto nested_rule_or_declaration_name = consume_while([](char c) { return c != ':' && c != '{'; });
         if (!nested_rule_or_declaration_name || nested_rule_or_declaration_name->empty()) {

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -1238,6 +1238,19 @@ int main() {
                 });
     });
 
+    s.add_test("parser: nested rule, : in name", [](etest::IActions &a) {
+        a.expect_eq(css::parse("p { color: green; &:hover { font-size: 3px; } font-size: 5px; }").rules, //
+                std::vector{
+                        css::Rule{
+                                .selectors = {{"p"}},
+                                .declarations{
+                                        {css::PropertyId::Color, "green"},
+                                        {css::PropertyId::FontSize, "5px"},
+                                },
+                        },
+                });
+    });
+
     s.add_test("parser: eof in nested rule", [](etest::IActions &a) {
         a.expect(css::parse("p { color: green; a { font-size: 3px; ").rules.empty()); //
     });

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -1243,8 +1243,7 @@ int main() {
     });
 
     s.add_test("parser: -webkit-lol", [](etest::IActions &a) {
-        a.expect_eq(css::parse("p { -webkit-font-size: 3px; }").rules.at(0).declarations,
-                std::map<css::PropertyId, std::string>{{css::PropertyId::Unknown, "3px"}});
+        a.expect(css::parse("p { -webkit-font-size: 3px; }").rules.at(0).declarations.empty()); //
     });
 
     s.add_test("parser: @charset", [](etest::IActions &a) {

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -1260,5 +1260,14 @@ int main() {
                 css::Rule{{"p"}, {{css::PropertyId::FontSize, "3px"}}});
     });
 
+    s.add_test("parser: IE hacks don't break things", [](etest::IActions &a) {
+        auto rules = css::parse("p { font-size: 3px; *font-size: 5px; } a { color: green; }").rules;
+        a.expect_eq(rules,
+                std::vector{
+                        css::Rule{{"p"}, {{css::PropertyId::FontSize, "3px"}}},
+                        css::Rule{{"a"}, {{css::PropertyId::Color, "green"}}},
+                });
+    });
+
     return s.run();
 }


### PR DESCRIPTION
This improves e.g. https://www.iana.org/help/example-domains and https://srctree.gr.ht/repos

iana by correctly skipping over IE hacks, and grht by making the nested rule detection better.