### PR TITLE
Fix compile command generation on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following assumes that you either have Bazel or Bazelisk under the name
 
 #### Generate json compilation database
 
-`bazel run refresh_compile_commands`
+`bazel run refresh_compile_commands --@rules_python//python/config_settings:bootstrap_impl=system_python`
 
 ### Misc
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,13 +69,13 @@ http_archive(
 # Misc tools
 # =========================================================
 
-# HEAD as of 2022-12-17.
+# HEAD as of 2024-10-28.
 # https://github.com/hedronvision/bazel-compile-commands-extractor
 http_archive(
     name = "hedron_compile_commands",
-    sha256 = "9b5683e6e0d764585f41639076f0be421a4c495c8f993c186e4449977ce03e5e",
-    strip_prefix = "bazel-compile-commands-extractor-c6cd079bef5836293ca18e55aac6ef05134c3a9d",
-    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/c6cd079bef5836293ca18e55aac6ef05134c3a9d.tar.gz",
+    integrity = "sha256-ZYEiz7HyW+duohKwD16wR9jirci8+SO5GEYfKx43zfI=",
+    strip_prefix = "bazel-compile-commands-extractor-4f28899228fb3ad0126897876f147ca15026151e",
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/4f28899228fb3ad0126897876f147ca15026151e.tar.gz",
 )
 
 # HEAD as of 2024-02-07.


### PR DESCRIPTION
Generating compile commands for Linux is still pretty broken due to
missing support for the parse_headers-feature some of our dependencies
use, but I'll look into that more later.

Also, trying to generate compile commands w/o forcing system_python bootstrapping fails w/:
```
$ bazel run refresh_compile_commands
INFO: Invocation ID: f85c2e11-6972-4caa-8e54-161a9275d097
INFO: Analyzed target //:refresh_compile_commands (61 packages loaded, 3436 targets configured).
INFO: Found 1 target...
Target //:refresh_compile_commands up-to-date:
  bazel-bin/refresh_compile_commands.zip
  bazel-bin/refresh_compile_commands.exe
  bazel-bin/refresh_compile_commands.check_python_version.py
  bazel-bin/refresh_compile_commands.py
INFO: Elapsed time: 7.820s, Critical Path: 4.05s
INFO: 4 processes: 3 internal, 1 local.
INFO: Build completed successfully, 4 total actions
INFO: Running command line: bazel-bin/refresh_compile_commands.exe
Traceback (most recent call last):
  File "<frozen runpy>", line 191, in _run_module_as_main
  File "<frozen runpy>", line 240, in _get_main_module_details
  File "<frozen runpy>", line 131, in _get_module_details
  File "<frozen importlib.util>", line 101, in find_spec
  File "<frozen importlib._bootstrap>", line 1262, in _find_spec
  File "<frozen importlib._bootstrap_external>", line 1528, in find_spec
  File "<frozen importlib._bootstrap_external>", line 1502, in _get_spec
  File "<frozen zipimport>", line 111, in find_spec
  File "<frozen importlib._bootstrap>", line 675, in spec_from_loader
  File "<frozen importlib._bootstrap_external>", line 822, in spec_from_file_location
  File "<frozen zipimport>", line 170, in get_filename
  File "<frozen zipimport>", line 708, in _get_module_code
  File "<frozen zipimport>", line 637, in _compile_source
  File "<...>\execroot\__main__\bazel-out\x64_windows-dbg\bin\refresh_compile_commands.zip\__main__.py", line 5
    if [[ -n "${RULES_PYTHON_BOOTSTRAP_VERBOSE:-}" ]]; then
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```