### PR TITLE
ci: Drop the macos-14 job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,7 +188,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14
           - os: macos-15
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30


### PR DESCRIPTION
This means the oldest macOS toolchain we test with now is whatever Xcode 16 provides, so we get access to 'Parenthesized initialization of aggregates' (p0960) and can use things like emplace_back and make_unique w/ our structs w/o having to add c-tors to them.