### PR TITLE
css: Support the 'only {all,print,screen}' media type syntax

### DIFF
--- a/css/media_query.h
+++ b/css/media_query.h
@@ -92,15 +92,15 @@ public:
 
     // https://drafts.csswg.org/mediaqueries/#mq-syntax
     static constexpr std::optional<MediaQuery> parse(std::string_view s) {
-        if (s == "all") {
+        if (s == "all" || s == "only all") {
             return MediaQuery{True{}};
         }
 
-        if (s == "print") {
+        if (s == "print" || s == "only print") {
             return MediaQuery{Type{.type = MediaType::Print}};
         }
 
-        if (s == "screen") {
+        if (s == "screen" || s == "only screen") {
             return MediaQuery{Type{.type = MediaType::Screen}};
         }
 

--- a/css/media_query_test.cpp
+++ b/css/media_query_test.cpp
@@ -119,6 +119,14 @@ void type_tests(etest::Suite &s) {
         a.expect_eq(css::MediaQuery::parse("screen"),
                 css::MediaQuery{css::MediaQuery::Type{.type = css::MediaType::Screen}} //
         );
+        a.expect_eq(css::MediaQuery::parse("only all"), css::MediaQuery{css::MediaQuery::True{}});
+
+        a.expect_eq(css::MediaQuery::parse("only print"),
+                css::MediaQuery{css::MediaQuery::Type{.type = css::MediaType::Print}} //
+        );
+        a.expect_eq(css::MediaQuery::parse("only screen"),
+                css::MediaQuery{css::MediaQuery::Type{.type = css::MediaType::Screen}} //
+        );
 
         a.expect_eq(css::MediaQuery::parse("asdf"), std::nullopt);
 


### PR DESCRIPTION
Technically, 'only' means "only applies if the entire query matches", but that's also the only way we interpret queries right now.