### PR TITLE
Enable more of clang-tidy's modernize checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,9 +13,6 @@
 #
 # -misc-const-correctness: Consts some things that can't be const, and very very noisy.
 #
-# -modernize-use-emplace: Clang doesn't implement p0960 yet, and we're not
-# adding c-tors to all our structs.
-#
 # -modernize-use-nodiscard: Very noisy, and probably more meaningful if we only
 # add it where it matters.
 #
@@ -71,7 +68,6 @@ Checks: >
   -cppcoreguidelines-special-member-functions,
   -google-build-using-namespace,
   -misc-const-correctness,
-  -modernize-use-emplace,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -readability-container-data-pointer,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,8 +13,8 @@
 #
 # -misc-const-correctness: Consts some things that can't be const, and very very noisy.
 #
-# -modernize-make-unique, -modernize-use-emplace: Clang doesn't implement p0960
-# yet, and we're not adding c-tors to all our structs.
+# -modernize-use-emplace: Clang doesn't implement p0960 yet, and we're not
+# adding c-tors to all our structs.
 #
 # -modernize-use-nodiscard: Very noisy, and probably more meaningful if we only
 # add it where it matters.
@@ -71,7 +71,6 @@ Checks: >
   -cppcoreguidelines-special-member-functions,
   -google-build-using-namespace,
   -misc-const-correctness,
-  -modernize-make-unique,
   -modernize-use-emplace,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,

--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -424,7 +424,7 @@ std::optional<css::Rule> Parser::parse_rule() {
             return std::nullopt;
         }
 
-        rule.selectors.push_back(std::string{util::trim(*selector)});
+        rule.selectors.emplace_back(util::trim(*selector));
         skip_if_neq('{'); // ' ' or ','
         skip_whitespace_and_comments();
     }

--- a/js/tokenizer_test.cpp
+++ b/js/tokenizer_test.cpp
@@ -18,7 +18,7 @@ namespace {
 void expect_tokens(std::string_view input,
         std::vector<Token> tokens,
         std::source_location const &loc = std::source_location::current()) {
-    tokens.push_back(Eof{});
+    tokens.emplace_back(Eof{});
     etest::expect_eq(tokenize(input), tokens, std::nullopt, loc);
 }
 

--- a/layout/layout_property_test.cpp
+++ b/layout/layout_property_test.cpp
@@ -34,7 +34,7 @@ void expect_property_eq(etest::IActions &a,
     };
 
     if (value) {
-        styled_node.properties.push_back({IdT, *std::move(value)});
+        styled_node.properties.emplace_back(IdT, *std::move(value));
     }
 
     auto layout = layout::create_layout(styled_node, 123);

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -1934,7 +1934,7 @@ int main() {
         expect_eq(layout.dimensions.border_box().width, 1000);
         expect_eq(layout.children.at(0).dimensions.border_box().width, 100);
 
-        style.properties.push_back({css::PropertyId::MaxWidth, "asdf"});
+        style.properties.emplace_back(css::PropertyId::MaxWidth, "asdf");
         layout = layout::create_layout(style, 1000).value();
         expect_eq(layout.dimensions.border_box().width, 1000);
         expect_eq(layout.children.at(0).dimensions.border_box().width, 100);

--- a/render/render_test.cpp
+++ b/render/render_test.cpp
@@ -335,7 +335,7 @@ int main() {
                 });
 
         styled.properties[0].second = "underline";
-        styled.properties.push_back({css::PropertyId::FontStyle, "italic"});
+        styled.properties.emplace_back(css::PropertyId::FontStyle, "italic");
 
         render::render_layout(saver, layout);
         expect_eq(saver.take_commands(),
@@ -367,7 +367,7 @@ int main() {
                         },
                 });
 
-        styled.properties.push_back({css::PropertyId::FontWeight, "bold"});
+        styled.properties.emplace_back(css::PropertyId::FontWeight, "bold");
 
         render::render_layout(saver, layout);
         expect_eq(saver.take_commands(),
@@ -531,7 +531,7 @@ int main() {
         expect_eq(saver.take_commands(), CanvasCommands{gfx::ClearCmd{{0xFF, 0xFF, 0xFF}}});
 
         // Body background.
-        styled.children[0].properties.push_back({css::PropertyId::BackgroundColor, "#abc"});
+        styled.children[0].properties.emplace_back(css::PropertyId::BackgroundColor, "#abc");
         render::render_layout(saver, layout);
         expect_eq(saver.take_commands(),
                 CanvasCommands{
@@ -540,7 +540,7 @@ int main() {
                 });
 
         // Html background.
-        styled.properties.push_back({css::PropertyId::BackgroundColor, "#123"});
+        styled.properties.emplace_back(css::PropertyId::BackgroundColor, "#123");
         render::render_layout(saver, layout);
         expect_eq(saver.take_commands(),
                 CanvasCommands{

--- a/style/style.cpp
+++ b/style/style.cpp
@@ -250,8 +250,7 @@ void style_tree_impl(StyledNode &current,
 
 std::unique_ptr<StyledNode> style_tree(
         dom::Node const &root, css::StyleSheet const &stylesheet, css::MediaQuery::Context const &ctx) {
-    // TODO(robinlinden): std::make_unique once Clang supports it (C++20/p0960). Not supported as of Clang 14.
-    auto tree_root = std::unique_ptr<StyledNode>(new StyledNode{root});
+    auto tree_root = std::make_unique<StyledNode>(root);
     style_tree_impl(*tree_root, root, stylesheet, ctx);
     return tree_root;
 }

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -177,7 +177,7 @@ int main() {
         expect_eq(child.get_property<css::PropertyId::BackgroundColor>(), gfx::Color::from_css_name("blue"));
 
         // "color: currentcolor" should be treated as inherit.
-        child.properties.push_back({css::PropertyId::Color, "currentcolor"s});
+        child.properties.emplace_back(css::PropertyId::Color, "currentcolor"s);
         expect_eq(child.get_property<css::PropertyId::Color>(), gfx::Color::from_css_name("blue"));
     });
 

--- a/url/url.cpp
+++ b/url/url.cpp
@@ -1042,7 +1042,7 @@ void UrlParser::state_path_start() {
             back(1);
         }
     } else if (state_override_.has_value() && !url_.host.has_value()) {
-        std::get<1>(url_.path).push_back("");
+        std::get<1>(url_.path).emplace_back("");
     }
 }
 
@@ -1059,11 +1059,11 @@ void UrlParser::state_path() {
             shorten_url_path(url_);
 
             if (c != '/' && !(special_schemes.contains(url_.scheme) && c == '\\')) {
-                std::get<1>(url_.path).push_back("");
+                std::get<1>(url_.path).emplace_back("");
             }
         } else if ((buffer_ == "." || util::lowercased(buffer_) == "%2e")
                 && (c != '/' && !(special_schemes.contains(url_.scheme) && c == '\\'))) {
-            std::get<1>(url_.path).push_back("");
+            std::get<1>(url_.path).emplace_back("");
         } else if (buffer_ != "." && util::lowercased(buffer_) != "%2e") {
             if (url_.scheme == "file" && std::get<1>(url_.path).empty() && is_windows_drive_letter(buffer_)) {
                 buffer_[1] = ':';

--- a/wasm/validation.cpp
+++ b/wasm/validation.cpp
@@ -170,7 +170,7 @@ void InstValidator::push_vals(std::vector<ValueType> const &vals) {
     value_stack.reserve(value_stack.size() + vals.size());
 
     for (ValueType const &val : vals) {
-        value_stack.push_back(val);
+        value_stack.emplace_back(val);
     }
 }
 


### PR DESCRIPTION
These were previously blocked by Xcode 15 and older not implementing p0960.