### PR TITLE
type/sfml: Fix cache never considering lookup failures to be cached

### DIFF
--- a/type/sfml.cpp
+++ b/type/sfml.cpp
@@ -85,7 +85,7 @@ Size SfmlFont::measure(std::string_view text, Px font_size, Weight weight) const
 }
 
 std::optional<std::shared_ptr<IFont const>> SfmlType::font(std::string_view name) const {
-    if (auto font = font_cache_.find(name); font != font_cache_.end() && font->second.has_value()) {
+    if (auto font = font_cache_.find(name); font != font_cache_.end()) {
         return font->second;
     }
 


### PR DESCRIPTION
Caching lookup failures is good because otherwise we will look at all fonts available every time someone requests the unavailable font, likely multiple times during every render.

This improves the performance of pages where the first font in the font-family property isn't available by several orders of magnitude.