### PR TITLE
etest: Simplify IActions

### DIFF
--- a/etest/etest2.cpp
+++ b/etest/etest2.cpp
@@ -30,27 +30,8 @@ namespace {
 struct TestFailure : public std::exception {};
 
 struct Actions : public IActions {
-    // Weak test requirement. Allows the test to continue even if the check fails.
-    void expect(
-            bool b, std::optional<std::string_view> log_message, std::source_location const &loc) noexcept override {
-        if (b) {
-            return;
-        }
-
-        ++assertion_failures;
-        test_log << "  expectation failure at " << loc.file_name() << "(" << loc.line() << ":" << loc.column() << ")\n";
-
-        if (log_message) {
-            test_log << *log_message << "\n\n";
-        }
-    }
-
-    // Hard test requirement. Stops the test (using an exception) if the check fails.
-    void require(bool b, std::optional<std::string_view> log_message, std::source_location const &loc) override {
-        if (b) {
-            return;
-        }
-
+    [[noreturn]] void requirement_failure(
+            std::optional<std::string_view> log_message, std::source_location const &loc) override {
         test_log << "  requirement failure at " << loc.file_name() << "(" << loc.line() << ":" << loc.column() << ")\n";
 
         if (log_message) {
@@ -62,6 +43,16 @@ struct Actions : public IActions {
 #else
         std::abort();
 #endif
+    }
+
+    void expectation_failure(
+            std::optional<std::string_view> log_message, std::source_location const &loc) noexcept override {
+        ++assertion_failures;
+        test_log << "  expectation failure at " << loc.file_name() << "(" << loc.line() << ":" << loc.column() << ")\n";
+
+        if (log_message) {
+            test_log << *log_message << "\n\n";
+        }
     }
 
     std::stringstream test_log;


### PR DESCRIPTION
Splitting out requirement_failure and expectation_failure in this way allows us to simplify the actions inheriting from IActions, conveys more information to the compiler (using noreturn), and allows us to drop a nolint.

The [[noreturn]] thing is extra nice as now compilers can know that e.g.
```
a.require_eq(some_vec.empty(), false);
a.expect_eq(some_vec[0], 42);
```
will never access some_vec[0] if some_vec is empty.