### PR TITLE
ci: Move the link-liveness check into a script

### DIFF
--- a/.github/scripts/check_url_liveness
+++ b/.github/scripts/check_url_liveness
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-grep --recursive --no-filename --only-matching --exclude-dir="*corpus" --exclude-dir=.github --exclude=WORKSPACE --exclude=*test.cpp --exclude=ci.yaml 'https://[^)(}{",# ]*' | grep -v '^https://$' | sort | uniq | xargs wget --spider --no-verbose
+grep --recursive --no-filename --only-matching --exclude-dir="*corpus" --exclude-dir=.github --exclude-dir="bazel-*" --exclude-dir=.cache --exclude-dir=external --exclude=WORKSPACE --exclude=*test.cpp --exclude=ci.yaml --exclude="*.bazel.lock" 'https://[^)(}{",# ]*' | grep -v '^https://$' | sort | uniq | xargs wget --spider --no-verbose

--- a/.github/scripts/check_url_liveness
+++ b/.github/scripts/check_url_liveness
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+grep --recursive --no-filename --only-matching --exclude-dir="*corpus" --exclude-dir=.github --exclude=WORKSPACE --exclude=*test.cpp --exclude=ci.yaml 'https://[^)(}{",# ]*' | grep -v '^https://$' | sort | uniq | xargs wget --spider --no-verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -317,13 +317,6 @@ jobs:
       - run: ./shfmt -i 2 -w $(./shfmt -f .)
       - run: git diff --exit-code
 
-  link-liveness:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-      - run: grep --recursive --no-filename --only-matching --exclude-dir="*corpus" --exclude=WORKSPACE --exclude=*test.cpp --exclude=ci.yaml 'https://[^)(}{",# ]*' | grep -v '^https://$' | sort | uniq | xargs wget --spider --no-verbose
-
   gitlint:
     runs-on: ubuntu-24.04
     timeout-minutes: 5


### PR DESCRIPTION
I guess the (new?) cloudflare stuff makes our spidering unhappy. I'll check this locally every now and then. It's not that often that things go down for reasons that require us to do something about it.

![rip opengl wiki](https://github.com/user-attachments/assets/14431799-c21e-4bb7-bb4d-1c6af9b2f101)
