### PR TITLE
style: Support resolving variables pointing to variables

### DIFF
--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -279,6 +279,7 @@ std::string_view StyledNode::get_raw_property(css::PropertyId property) const {
                 return fallback;
             }
 
+            spdlog::warn("Unable to resolve '{}'", var_name);
             return it->second;
         }
 

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -280,7 +280,7 @@ std::string_view StyledNode::get_raw_property(css::PropertyId property) const {
             }
 
             spdlog::warn("Unable to resolve '{}'", var_name);
-            return it->second;
+            return css::initial_value(property);
         }
 
         return *prop;

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -508,11 +508,16 @@ int main() {
                 },
         };
 
-        // TODO(robinlinden)
-        // expect_eq(styled_node.get_property<css::PropertyId::FontWeight>(), //
-        //         style::FontWeight::bold());
         expect_eq(styled_node.get_property<css::PropertyId::FontWeight>(), //
-                std::nullopt);
+                style::FontWeight::bold());
+
+        // Circular references are bad.
+        styled_node.custom_properties = {
+                {"--a", "var(--b)"},
+                {"--b", "var(--a)"},
+        };
+        expect_eq(styled_node.get_property<css::PropertyId::FontWeight>(), //
+                style::FontWeight::normal());
     });
 
     etest::test("var() with fallback, var exists", [] {

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -487,8 +487,10 @@ int main() {
         expect_eq(styled_node.get_property<css::PropertyId::Color>(), //
                 gfx::Color{0xaa, 0xbb, 0xcc});
 
+        // Unresolved variables return the initial value.
+        expect_eq(css::initial_value(css::PropertyId::FontWeight), "normal");
         expect_eq(styled_node.get_property<css::PropertyId::FontWeight>(), //
-                std::nullopt);
+                style::FontWeight::normal());
 
         styled_node.custom_properties = {{"--weight", "bold"}};
         expect_eq(styled_node.get_property<css::PropertyId::FontWeight>(), //


### PR DESCRIPTION
This makes the colors on Swedish news website https://svt.se work:

Before:
![text being obscured by red-coloured blocks](https://github.com/user-attachments/assets/fae1e305-782b-4771-878c-22aa6e7cef06)


After:
![everything looks "fine"](https://github.com/user-attachments/assets/e37d1fac-b364-4312-b8eb-f69fd0139ba4)
