### PR TITLE
html2: Handle dd & dt start tags

### DIFF
--- a/html2/parser_states.cpp
+++ b/html2/parser_states.cpp
@@ -858,6 +858,39 @@ std::optional<InsertionMode> InBody::process(IActions &a, html2::Token const &to
         return {};
     }
 
+    if (start != nullptr && (start->tag_name == "dd" || start->tag_name == "dt")) {
+        a.set_frameset_ok(false);
+
+        auto open_elements = a.names_of_open_elements();
+        assert(!open_elements.empty());
+        for (auto node : open_elements) {
+            if (node == "dd" || node == "dt") {
+                generate_implied_end_tags(a, node);
+                if (a.current_node_name() != node) {
+                    // Parse error.
+                }
+
+                while (a.current_node_name() != node) {
+                    a.pop_current_node();
+                }
+
+                a.pop_current_node();
+                break;
+            }
+
+            if (is_special(node) && node != "address" && node != "div" && node != "p") {
+                break;
+            }
+        }
+
+        if (a.has_element_in_button_scope("p")) {
+            close_a_p_element();
+        }
+
+        a.insert_element_for(*start);
+        return {};
+    }
+
     // TODO(robinlinden): Most things.
 
     static constexpr auto kImmediatelyPoppedElements = std::to_array<std::string_view>({


### PR DESCRIPTION
This brings http://info.cern.ch/hypertext/WWW/History.html from

![before, unclosed elements cause right-drift](https://github.com/user-attachments/assets/583f23e4-32a5-469e-af9f-16dc2cad3d8a)

to

![after, the page doesn't drift](https://github.com/user-attachments/assets/8580f1d7-6c9c-437e-81a1-498e779b376e)
