### PR TITLE
style: Drop support for text-decoration: blink

### DIFF
--- a/gfx/font.h
+++ b/gfx/font.h
@@ -22,6 +22,7 @@ struct FontStyle {
     bool italic{false};
     bool strikethrough{false};
     bool underlined{false};
+    bool overlined{false};
 
     [[nodiscard]] constexpr bool operator==(FontStyle const &) const = default;
 };

--- a/render/BUILD
+++ b/render/BUILD
@@ -14,7 +14,6 @@ cc_library(
         "//gfx",
         "//layout",
         "//style",
-        "@spdlog",
     ],
 )
 

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -57,6 +57,9 @@ gfx::FontStyle to_gfx(style::FontStyle style,
             case style::TextDecorationLine::LineThrough:
                 gfx.strikethrough = true;
                 break;
+            case style::TextDecorationLine::Overline:
+                gfx.overlined = true;
+                break;
             default:
                 spdlog::warn("Unhandled text decoration line '{}'", std::to_underlying(decoration));
                 break;

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -17,6 +17,7 @@
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
+#include <cassert>
 #include <iterator>
 #include <optional>
 #include <string_view>
@@ -120,11 +121,7 @@ void do_render(gfx::ICanvas &painter, layout::LayoutBox const &layout) {
 }
 
 bool should_render(layout::LayoutBox const &layout) {
-    if (layout.is_anonymous_block()) {
-        return false;
-    }
-
-    return layout.get_property<css::PropertyId::Display>().has_value();
+    return !layout.is_anonymous_block();
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
@@ -134,6 +131,8 @@ void render_layout_impl(gfx::ICanvas &painter, layout::LayoutBox const &layout, 
     }
 
     if (should_render(layout)) {
+        // display: none'd elements aren't part of the layout tree, so they won't appear here.
+        assert(layout.get_property<css::PropertyId::Display>().has_value());
         do_render(painter, layout);
     }
 

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -14,14 +14,11 @@
 #include "layout/layout_box.h"
 #include "style/styled_node.h"
 
-#include <spdlog/spdlog.h>
-
 #include <algorithm>
 #include <cassert>
 #include <iterator>
 #include <optional>
 #include <string_view>
-#include <utility>
 #include <vector>
 
 namespace render {
@@ -59,9 +56,6 @@ gfx::FontStyle to_gfx(style::FontStyle style,
                 break;
             case style::TextDecorationLine::Overline:
                 gfx.overlined = true;
-                break;
-            default:
-                spdlog::warn("Unhandled text decoration line '{}'", std::to_underlying(decoration));
                 break;
         }
     }

--- a/render/render_test.cpp
+++ b/render/render_test.cpp
@@ -367,6 +367,22 @@ int main() {
                         },
                 });
 
+        styled.properties[0].second = "overline";
+
+        render::render_layout(saver, layout);
+        expect_eq(saver.take_commands(),
+                CanvasCommands{
+                        gfx::ClearCmd{{0xFF, 0xFF, 0xFF}},
+                        gfx::DrawTextWithFontOptionsCmd{
+                                {0, 0},
+                                "hello",
+                                {"arial"},
+                                16,
+                                {.italic = true, .overlined = true},
+                                gfx::Color::from_css_name("canvastext").value(),
+                        },
+                });
+
         styled.properties.emplace_back(css::PropertyId::FontWeight, "bold");
 
         render::render_layout(saver, layout);
@@ -378,7 +394,7 @@ int main() {
                                 "hello",
                                 {"arial"},
                                 16,
-                                {.bold = true, .italic = true},
+                                {.bold = true, .italic = true, .overlined = true},
                                 gfx::Color::from_css_name("canvastext").value(),
                         },
                 });

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -466,7 +466,8 @@ std::vector<TextDecorationLine> StyledNode::get_text_decoration_line_property() 
         }
 
         if (v == "blink") {
-            return TextDecorationLine::Blink;
+            spdlog::warn("Deprecated text-decoration-line value '{}'", v);
+            return std::nullopt;
         }
 
         spdlog::warn("Unhandled text-decoration-line value '{}'", v);

--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -84,7 +84,6 @@ enum class TextDecorationLine : std::uint8_t {
     Underline,
     Overline,
     LineThrough,
-    Blink,
 };
 
 enum class TextTransform : std::uint8_t {

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -403,9 +403,10 @@ int main() {
         expect_property_eq<css::PropertyId::TextDecorationLine>(a, "underline", std::vector{Underline});
         expect_property_eq<css::PropertyId::TextDecorationLine>(a, "overline", std::vector{Overline});
         expect_property_eq<css::PropertyId::TextDecorationLine>(a, "line-through", std::vector{LineThrough});
-        expect_property_eq<css::PropertyId::TextDecorationLine>(a, "blink", std::vector{Blink});
-        expect_property_eq<css::PropertyId::TextDecorationLine>(a, "underline blink", std::vector{Underline, Blink});
+        expect_property_eq<css::PropertyId::TextDecorationLine>(
+                a, "underline overline", std::vector{Underline, Overline});
 
+        expect_property_eq<css::PropertyId::TextDecorationLine>(a, "blink", std::vector<style::TextDecorationLine>{});
         expect_property_eq<css::PropertyId::TextDecorationLine>(
                 a, "unhandled!", std::vector<style::TextDecorationLine>{});
     });
@@ -439,7 +440,7 @@ int main() {
         style::StyledNode styled_node{
                 .node = dom,
                 .properties{
-                        {css::PropertyId::TextDecorationLine, "blink"s},
+                        {css::PropertyId::TextDecorationLine, "overline"s},
                         {css::PropertyId::Display, "block"s},
                 },
         };
@@ -447,7 +448,7 @@ int main() {
 
         a.expect(!css::is_inherited(css::PropertyId::TextDecorationLine));
         a.expect_eq(child.get_property<css::PropertyId::TextDecorationLine>(),
-                std::vector{style::TextDecorationLine::Blink});
+                std::vector{style::TextDecorationLine::Overline});
 
         // Text is always "display: inline".
         a.expect_eq(child.get_property<css::PropertyId::Display>(), style::Display::inline_flow());


### PR DESCRIPTION
This does nothing in e.g. Firefox as well.