### PR TITLE
deps: Use rules_shell instead of the native sh_test rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,6 +61,14 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.33.2/rules_python-0.33.2.tar.gz",
 )
 
+# https://github.com/bazelbuild/rules_shell
+http_archive(
+    name = "rules_shell",  # Apache-2.0
+    sha256 = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53",
+    strip_prefix = "rules_shell-0.3.0",
+    url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
+)
+
 # Third-party Bazel
 # =========================================================
 
@@ -453,3 +461,9 @@ fuzzing_py_deps_install_deps()
 load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
 
 zig_toolchains()
+
+load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
+
+rules_shell_dependencies()
+
+rules_shell_toolchains()

--- a/html2/BUILD
+++ b/html2/BUILD
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//bzl:copts.bzl", "HASTUR_COPTS", "HASTUR_FUZZ_PLATFORMS")
 
 cc_library(


### PR DESCRIPTION
The native rule is being removed in favour of rules_shell in Bazel 8.