### PR TITLE
build: Enable bzlmod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,12 @@
 # Bazel configuration
 # =========================================================
 
-# https://github.com/bazelbuild/bazel/issues/18958
 common --enable_workspace
-common --noenable_bzlmod
+
+# We handle hermeticity by explicitly specifying dependencies instead of using
+# the lockfile system.
+common --lockfile_mode=off
+common --registry=file://this/does/not/exist
 
 build --enable_platform_specific_config
 coverage --combined_report=lcov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -219,6 +219,7 @@ jobs:
         run: |
           echo "<html><body><h1>Example</h1><p>This is an example page.</p></body></html>" >example.html
           python3 -m http.server --bind localhost 12345 &
+          sleep 5 # Sometimes the server isn't ready by the time the tui starts.
           bazel run browser:tui -c dbg http://localhost:12345/example.html
       - run: bazel run browser -c dbg -- --exit-after-load http://localhost:12345/example.html
 
@@ -241,6 +242,7 @@ jobs:
         run: |
           echo "<html><body><h1>Example</h1><p>This is an example page.</p></body></html>" >example.html
           python3 -m http.server --bind localhost 12345 &
+          sleep 5 # Sometimes the server isn't ready by the time the tui starts.
           bazel run browser:tui http://localhost:12345/example.html
       - run: bazel run browser -- --exit-after-load http://localhost:12345/example.html
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,296 @@
+""" This comment is required for Buildifier to be happy. """
+
+module(name = "hastur")
+
+# Bazel
+# =========================================================
+
+# https://github.com/bazelbuild/apple_support
+bazel_dep(name = "apple_support")  # Apache-2.0
+archive_override(
+    module_name = "apple_support",
+    integrity = "sha256-tT9kkedCVJ8ThmYo3f/MddHzstaYfcTxShayQhE8iQs=",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.17.1/apple_support.1.17.1.tar.gz"],
+)
+
+# https://github.com/bazelbuild/platforms
+bazel_dep(name = "platforms")  # Apache-2.0
+archive_override(
+    module_name = "platforms",
+    integrity = "sha256-IY7+juc20mo1cmY7N0olPAErcW2K8MB+hC6C8jigp+4=",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz"],
+)
+
+# https://github.com/bazelbuild/rules_cc
+# 0.1.0 isn't compatible w/ Bazel 7.4.0:
+# ERROR: Traceback (most recent call last):
+#   File "<...>/external/remote_java_tools/BUILD", line 7, column 60, in <toplevel>
+#     load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library")
+# Error: file '@rules_cc//cc:defs.bzl' does not contain symbol 'cc_proto_library'
+bazel_dep(name = "rules_cc")  # Apache-2.0
+archive_override(
+    module_name = "rules_cc",
+    integrity = "sha256-q8YF3YUPgTuzcAS3fbIBBqGTEalrLaHJK3idpSnSj+E=",
+    patch_cmds = [
+        # rules_cc depends on protobuf as of 0.0.13, and adding that for rules_cc is silly.
+        # https://github.com/bazelbuild/rules_cc/commit/013a08285803532d9c5de010da51dd45b4cd2722
+        "sed -i'' -e /@com_google_protobuf/d cc/defs.bzl",
+        "sed -i'' -e 's/_cc_proto_library/native.cc_proto_library/g' cc/defs.bzl",
+    ],
+    strip_prefix = "rules_cc-0.0.17",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.17/rules_cc-0.0.17.tar.gz"],
+)
+
+# https://github.com/bazelbuild/rules_java
+archive_override(
+    module_name = "rules_java",
+    integrity = "sha256-pkqwRhbnakSMLC2BZdg28NL7CQYgDQt8c3b0bdYuWcw=",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.2/rules_java-8.6.2.tar.gz"],
+)
+
+# https://github.com/bazelbuild/rules_license
+# Not actually a direct dependency, so the bazel_dep will be removed once
+# boringssl is moved here from the WORKSPACE.
+bazel_dep(name = "rules_license")  # Apache-2.0
+archive_override(
+    module_name = "rules_license",
+    integrity = "sha256-JtQCH2iY4juC75UweDid1JrCtWGKxWSt5O+HzO0Uezg=",
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz"],
+)
+
+# https://github.com/bazelbuild/rules_python
+# 0.40.0 instead of 1.0.0 as 1.0.0 has changed up the hermetic toolchain <-> pip
+# integration, and we'll deal with that kind of changes when migrating to bzlmod
+# anyway.
+bazel_dep(name = "rules_python")  # Apache-2.0
+archive_override(
+    module_name = "rules_python",
+    integrity = "sha256-aQ4BQXJKu1aCZ+ADx7bZpUkl30DCdahwpNk0Fh3J3VM=",
+    strip_prefix = "rules_python-0.40.0",
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.40.0/rules_python-0.40.0.tar.gz"],
+)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.12.3", is_default = True)
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "pypi",
+    python_version = "3.12.3",
+    requirements_lock = "//third_party:requirements.txt",
+)
+use_repo(pip, "pypi")
+
+# https://github.com/bazelbuild/rules_fuzzing
+bazel_dep(name = "rules_fuzzing")  # Apache-2.0
+archive_override(
+    module_name = "rules_fuzzing",
+    integrity = "sha256-5rwhm/rJ4fg7Mn3QkPcoqflz7pm5tdjloYSicy7whiM=",
+    strip_prefix = "rules_fuzzing-0.5.2",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/releases/download/v0.5.2/rules_fuzzing-0.5.2.zip"],
+)
+
+# https://github.com/bazelbuild/rules_pkg
+archive_override(
+    module_name = "rules_pkg",
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz"],
+    integrity = "sha256-0gyVGWDtd8t7NBwqWUiFNOSU1a0dMMSBjHNtV3cqn+8=",
+)
+
+# https://github.com/bazelbuild/rules_proto
+archive_override(
+    module_name = "rules_proto",
+    strip_prefix = "rules_proto-7.0.2",
+    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.0.2/rules_proto-7.0.2.tar.gz"],
+    integrity = "sha256-DlxkolmabibGoD1hYiQtIx7MDeIZU0w4y0QCFx3vIeg=",
+)
+
+# https://github.com/bazelbuild/rules_shell
+bazel_dep(name = "rules_shell")  # Apache-2.0
+archive_override(
+    module_name = "rules_shell",
+    integrity = "sha256-2M1KOpH8HcaNTH1rZV8J3vEJ9xhkN+P1Cptgq0NqDFM=",
+    strip_prefix = "rules_shell-0.3.0",
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz"],
+)
+
+# https://github.com/bazelbuild/bazel-skylib
+archive_override(
+    module_name = "bazel_skylib",
+    integrity = "sha256-vCg8381SalLDIBJ5zaS8KYZS76iYsQtNsIN9xRZSdW8=",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz"],
+)
+
+# https://github.com/bazelbuild/rules_android
+archive_override(
+    module_name = "rules_android",
+    strip_prefix = "rules_android-0.6.0",
+    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.0/rules_android-v0.6.0.tar.gz"],
+    integrity = "sha256-r4S2mrPRbdGkEFYobmUR8UepTM6plWA+E+k0yRXBYxw=",
+)
+
+# https://github.com/bazelbuild/rules_kotlin
+archive_override(
+    module_name = "rules_kotlin",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.6/rules_kotlin-v1.9.6.tar.gz"],
+    integrity = "sha256-O3cpdv7Hvc2h2EudObF2WJQkwEfrIXW+0JqsYw5Qr0M=",
+)
+
+# https://github.com/bazelbuild/stardoc
+archive_override(
+    module_name = "stardoc",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.2/stardoc-0.7.2.tar.gz"],
+    integrity = "sha256-Dh7UqY8m5xh3a9ZNBT0CuzTZhXLM0D1ro1URKhIFcGs=",
+)
+
+# https://github.com/bazelbuild/bazel-worker-api
+archive_override(
+    module_name = "bazel_worker_api",
+    strip_prefix = "bazel-worker-api-0.0.4/proto",
+    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.4/bazel-worker-api-v0.0.4.tar.gz"],
+    integrity = "sha256-ebMLzauMsNzhUjso/3mAZ0GXFfVUCopEa7zPOT5et5w=",
+)
+archive_override(
+    module_name = "bazel_worker_java",
+    strip_prefix = "bazel-worker-api-0.0.4/java",
+    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.4/bazel-worker-api-v0.0.4.tar.gz"],
+    integrity = "sha256-ebMLzauMsNzhUjso/3mAZ0GXFfVUCopEa7zPOT5et5w=",
+)
+
+# Bazel contrib
+# =========================================================
+
+# https://github.com/bazel-contrib/bazel_features
+archive_override(
+    module_name = "bazel_features",
+    integrity = "sha256-nH+aTJl8vw65NXK2iw/wu5giAEYzEBoW2JSZ6BQZAyM=",
+    strip_prefix = "bazel_features-1.22.0",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.22.0/bazel_features-v1.22.0.tar.gz"],
+)
+
+# https://github.com/bazel-contrib/bazel-gazelle
+archive_override(
+    module_name = "gazelle",
+    integrity = "sha256-qAiTKSrh146u7dUNHKuY8kKhfj1XQbG5+1i1/Z0tV7w=",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.40.0/bazel-gazelle-v0.40.0.tar.gz"],
+)
+
+# https://github.com/bazel-contrib/rules_go
+archive_override(
+    module_name = "rules_go",
+    integrity = "sha256-9KkxRRjKas+hbMSrQ7C4zh5OpkuBw42KN3KIPxUzRrg=",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
+)
+
+# https://github.com/bazel-contrib/rules_jvm_external
+archive_override(
+    module_name = "rules_jvm_external",
+    strip_prefix = "rules_jvm_external-6.6",
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.6/rules_jvm_external-6.6.tar.gz"],
+    integrity = "sha256-Ov5RlQab03k3NSiJnAOjBy9WjTO9lv4De9Q7H1kFNec=",
+)
+
+# Other Bazel-required dependencies
+# =========================================================
+
+# https://github.com/robolectric/robolectric-bazel
+archive_override(
+    module_name = "rules_robolectric",
+    strip_prefix = "robolectric-bazel-4.14.1.2",
+    urls = ["https://github.com/robolectric/robolectric-bazel/releases/download/4.14.1.2/robolectric-bazel-4.14.1.2.tar.gz"],
+    integrity = "sha256-stIWS66A/PvdB46y8JNboGVXQCuMgUko2eO+xzWOK3s=",
+)
+
+# https://github.com/fmeum/buildozer
+archive_override(
+    module_name = "buildozer",
+    integrity = "sha256-/HfDfwjmdFCKV5jYSRiuUrO5UQGZ4KwBESo3iWfaQVg=",
+    strip_prefix = "buildozer-7.1.2",
+    urls = ["https://github.com/fmeum/buildozer/releases/download/v7.1.2/buildozer-v7.1.2.tar.gz"],
+)
+
+# https://github.com/google/googletest
+archive_override(
+    module_name = "googletest",
+    urls = ["https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz"],
+    strip_prefix = "googletest-1.15.2",
+    integrity = "sha256-e0K01u1IgQxTYsJloX+uvpDcI3PIheUhZDnTeSfwKSY=",
+)
+
+# https://github.com/protocolbuffers/protobuf
+archive_override(
+    module_name = "protobuf",
+    integrity = "sha256-PTKUDpdcStm4umlkDnj1UnB1uuM8ookCdb8muFPAliw=",
+    strip_prefix = "protobuf-29.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protobuf-29.1.tar.gz"],
+)
+
+# https://github.com/abseil/abseil-cpp
+archive_override(
+    module_name = "abseil-cpp",
+    integrity = "sha256-9Q5awxGoE4Laf6dblzEOS5AGR0+VYKxG9UqZZ/B9SuM=",
+    strip_prefix = "abseil-cpp-20240722.0",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz"],
+)
+
+# https://github.com/abseil/abseil-py
+archive_override(
+    module_name = "abseil-py",
+    strip_prefix = "abseil-py-2.1.0",
+    urls = ["https://github.com/abseil/abseil-py/archive/v2.1.0.tar.gz"],
+    integrity = "sha256-ij0IMOTrT2bE+pB8Bu32zhxxnO2BGhLibZ0xYvhHF1g=",
+    patch_cmds = [
+        """cat <<EOF >MODULE.bazel
+module(name = "abseil-py")
+EOF""",
+    ],
+)
+
+# https://github.com/open-source-parsers/jsoncpp
+archive_override(
+    module_name = "jsoncpp",
+    strip_prefix = "jsoncpp-1.9.6",
+    urls = ["https://github.com/open-source-parsers/jsoncpp/archive/1.9.6.tar.gz"],
+    integrity = "sha256-+Ttt1855axPQLBCLyfeYEiRaguV3WBxMmqvlcHXJDqI=",
+    patch_cmds = [
+        """cat <<EOF >MODULE.bazel
+module(name = "jsoncpp")
+EOF""",
+    ],
+)
+
+# https://github.com/google/re2
+archive_override(
+    module_name = "re2",
+    strip_prefix = "re2-2024-07-02",
+    urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.tar.gz"],
+    integrity = "sha256-6y34B8eBYBwUomClB6W7RQm+HuYmAky0WsvVfLnUAys=",
+)
+
+# https://github.com/pybind/pybind11_bazel
+archive_override(
+    module_name = "pybind11_bazel",
+    strip_prefix = "pybind11_bazel-2.13.6",
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.13.6/pybind11_bazel-2.13.6.tar.gz"],
+    integrity = "sha256-yuaAZwv6boJwPAPyo8mVQIzcv0NhbXvdGY70XTwydzE=",
+)
+
+# Third-party
+# =========================================================
+
+# https://github.com/madler/zlib
+bazel_dep(name = "zlib")  # Zlib
+archive_override(
+    module_name = "zlib",
+    build_file = "//third_party:zlib.BUILD",
+    integrity = "sha256-F+iIY/NgBnKrSRgvIXKBtvxNPHYr3jYZNeQ2qVIU0Fw=",
+    strip_prefix = "zlib-1.3.1",
+    urls = ["https://github.com/madler/zlib/archive/v1.3.1.tar.gz"],
+    patch_cmds = [
+        """cat <<EOF >MODULE.bazel
+module(name = "zlib")
+bazel_dep(name = "rules_cc")
+bazel_dep(name = "platforms")
+EOF""",
+    ],
+)


### PR DESCRIPTION
This only adds the dependencies that are required for Bazel to be happy
with not being able to access a bzlmod registry, and no dependencies are
updated in this change.