### PR TITLE
layout: Support % height on the root node

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -755,6 +755,7 @@ void App::switch_canvas() {
 engine::Options App::make_options() const {
     return {
             .layout_width = static_cast<int>(window_.getSize().x / scale_),
+            .viewport_height = static_cast<int>(window_.getSize().y / scale_),
             .dark_mode = os::is_dark_mode(),
     };
 }

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -175,16 +175,18 @@ tl::expected<std::unique_ptr<PageState>, NavigationError> Engine::navigate(uri::
 
     spdlog::info("Styling dom w/ {} rules", state->stylesheet.rules.size());
     state->layout_width = opts.layout_width;
+    state->viewport_height = opts.viewport_height;
     state->styled = style::style_tree(state->dom.html_node, state->stylesheet, to_media_context(opts));
-    state->layout = layout::create_layout(*state->styled, state->layout_width, *type_);
+    state->layout = layout::create_layout(*state->styled, {state->layout_width, state->viewport_height}, *type_);
 
     return state;
 }
 
 void Engine::relayout(PageState &state, Options opts) {
     state.layout_width = opts.layout_width;
+    state.viewport_height = opts.viewport_height;
     state.styled = style::style_tree(state.dom.html_node, state.stylesheet, to_media_context(opts));
-    state.layout = layout::create_layout(*state.styled, state.layout_width, *type_);
+    state.layout = layout::create_layout(*state.styled, {state.layout_width, state.viewport_height}, *type_);
 }
 
 Engine::LoadResult Engine::load(uri::Uri uri) {

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -27,6 +27,7 @@ namespace engine {
 struct Options {
     // Default chosen by rolling 1d600.
     int layout_width{600};
+    int viewport_height{800};
     bool dark_mode{false};
 };
 
@@ -38,6 +39,7 @@ struct PageState {
     std::unique_ptr<style::StyledNode> styled{};
     std::optional<layout::LayoutBox> layout{};
     int layout_width{};
+    int viewport_height{};
 };
 
 struct NavigationError {

--- a/layout/layout.h
+++ b/layout/layout.h
@@ -17,6 +17,11 @@
 
 namespace layout {
 
+struct LayoutInfo {
+    int viewport_width{};
+    int viewport_height{};
+};
+
 struct Size {
     int width{};
     int height{};
@@ -25,10 +30,19 @@ struct Size {
 
 std::optional<LayoutBox> create_layout(
         style::StyledNode const &,
-        int width,
+        LayoutInfo const &,
         type::IType const & = type::NaiveType{},
         std::function<std::optional<Size>(std::string_view)> const &get_intrensic_size_for_resource_at_url =
                 [](std::string_view) { return std::nullopt; });
+
+inline std::optional<LayoutBox> create_layout(
+        style::StyledNode const &node,
+        int width,
+        type::IType const &type = type::NaiveType{},
+        std::function<std::optional<Size>(std::string_view)> const &get_intrensic_size_for_resource_at_url =
+                [](std::string_view) { return std::nullopt; }) {
+    return create_layout(node, {width, 0}, type, get_intrensic_size_for_resource_at_url);
+}
 
 } // namespace layout
 

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -2127,6 +2127,17 @@ int main() {
         expect_eq(layout.children.at(0).dimensions.border_box().height, 100);
     });
 
+    etest::test("%-height on the root node", [] {
+        dom::Node dom = dom::Element{"html"};
+        style::StyledNode style{
+                .node{dom},
+                .properties{{css::PropertyId::Height, "50%"}, {css::PropertyId::Display, "block"}},
+        };
+
+        auto layout = layout::create_layout(style, {.viewport_height = 1000}).value();
+        expect_eq(layout.dimensions.border_box().height, 500);
+    });
+
     whitespace_collapsing_tests();
     text_transform_tests();
     img_tests();

--- a/style/unresolved_value.h
+++ b/style/unresolved_value.h
@@ -14,6 +14,7 @@ namespace style {
 struct ResolutionInfo {
     int root_font_size{};
     int viewport_width{};
+    int viewport_height{};
 };
 
 struct UnresolvedValue {


### PR DESCRIPTION
This is in use on e.g. https://bazel.build