### PR TITLE
ci: Set up buildbuddy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -121,6 +121,9 @@ build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_ti
 build:clang-tidy --output_groups=report
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
 
+build:buildbuddy-bes --bes_results_url=https://app.buildbuddy.io/invocation/
+build:buildbuddy-bes --bes_backend=grpcs://remote.buildbuddy.io
+
 # Cross-compilation
 # =========================================================
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -123,6 +123,17 @@ build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
 
 build:buildbuddy-bes --bes_results_url=https://app.buildbuddy.io/invocation/
 build:buildbuddy-bes --bes_backend=grpcs://remote.buildbuddy.io
+build:buildbuddy-cache-common --config=buildbuddy-bes
+build:buildbuddy-cache-common --remote_cache=grpcs://remote.buildbuddy.io
+build:buildbuddy-cache-common --remote_timeout=3600
+build:buildbuddy-cache-common --remote_cache_compression
+build:buildbuddy-cache-common --noslim_profile
+build:buildbuddy-cache-common --experimental_profile_include_target_label
+build:buildbuddy-cache-common --experimental_profile_include_primary_output
+build:buildbuddy-cache --config=buildbuddy-cache-common
+build:buildbuddy-cache --noremote_upload_local_results
+build:buildbuddy-cache-upload --config=buildbuddy-cache-common
+build:buildbuddy-cache-upload --remote_upload_local_results
 
 # Cross-compilation
 # =========================================================

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,7 @@ jobs:
         with:
           path: ~/.cache/bazel
           key: ${{ matrix.name }}-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
+      - run: echo "build --config=buildbuddy-bes" >.bazelrc.local
       - name: Test
         run: bazel test //... ${{ matrix.bazel }}
       - name: Run
@@ -127,6 +128,7 @@ jobs:
           echo "CC=clang-19" >> $GITHUB_ENV
           echo "CXX=clang++-19" >> $GITHUB_ENV
       - run: sudo apt-get install libx11-dev libxi-dev
+      - run: echo "build --config=buildbuddy-bes" >.bazelrc.local
       - name: Coverage
         run: bazel coverage ... ${{ matrix.bazel }}
       # clang 19 coverage has a lot of problems w/ boringssl:
@@ -157,6 +159,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends qemu-user-static binfmt-support
       - run: sudo update-binfmts --enable qemu-aarch64
       - run: echo "build --config=linux-aarch64-musl" >.bazelrc.local
+      - run: echo "build --config=buildbuddy-bes" >>.bazelrc.local
       - run: bazel test ...
       - name: Run tui
         run: |
@@ -181,6 +184,7 @@ jobs:
       # Register wasmtime as the wasm binary format handler.
       - run: echo -n ":wasm32-wasi:M::\x00asm:\xff\xff\xff\xff:$(pwd)/${WASMTIME_NAME}/wasmtime:" | sudo tee /proc/sys/fs/binfmt_misc/register
       - run: echo "build --config=wasi-wasm" >.bazelrc.local
+      - run: echo "build --config=buildbuddy-bes" >>.bazelrc.local
       - run: bazel test ...
 
   macos:
@@ -193,6 +197,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+      - run: echo "build --config=buildbuddy-bes" >.bazelrc.local
       - run: bazelisk test //...
       - name: Run tui
         run: |
@@ -213,6 +218,7 @@ jobs:
           path: ~/.cache/bazel
           key: windows_msvc-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
       - run: echo "build --disk_cache ~/.cache/bazel" >.bazelrc.local
+      - run: echo "build --config=buildbuddy-bes" >>.bazelrc.local
       - name: Test
         run: bazel test ... -c dbg
       - name: Run tui
@@ -237,6 +243,7 @@ jobs:
           key: windows_clang_cl-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
       - run: echo "build --config clang-cl" >.bazelrc.local
       - run: echo "build --disk_cache ~/.cache/bazel" >>.bazelrc.local
+      - run: echo "build --config=buildbuddy-bes" >>.bazelrc.local
       - run: bazel test ...
       - name: Run tui
         run: |
@@ -285,7 +292,7 @@ jobs:
           sudo update-alternatives --set clang-tidy /usr/bin/clang-tidy-19
           update-alternatives --query clang-tidy
           clang-tidy --version
-      - run: bazel build ... --config libc++ --config clang-tidy --keep_going
+      - run: bazel build ... --config libc++ --config clang-tidy --config buildbuddy-bes --keep_going
 
   buildifier:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,9 @@ jobs:
         with:
           path: ~/.cache/bazel
           key: ${{ matrix.name }}-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
-      - run: echo "build --config=buildbuddy-bes" >.bazelrc.local
+      - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >.bazelrc.local
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
       - name: Test
         run: bazel test //... ${{ matrix.bazel }}
       - name: Run
@@ -128,7 +130,9 @@ jobs:
           echo "CC=clang-19" >> $GITHUB_ENV
           echo "CXX=clang++-19" >> $GITHUB_ENV
       - run: sudo apt-get install libx11-dev libxi-dev
-      - run: echo "build --config=buildbuddy-bes" >.bazelrc.local
+      - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >.bazelrc.local
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
       - name: Coverage
         run: bazel coverage ... ${{ matrix.bazel }}
       # clang 19 coverage has a lot of problems w/ boringssl:
@@ -159,7 +163,9 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends qemu-user-static binfmt-support
       - run: sudo update-binfmts --enable qemu-aarch64
       - run: echo "build --config=linux-aarch64-musl" >.bazelrc.local
-      - run: echo "build --config=buildbuddy-bes" >>.bazelrc.local
+      - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >>.bazelrc.local
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
       - run: bazel test ...
       - name: Run tui
         run: |
@@ -184,7 +190,9 @@ jobs:
       # Register wasmtime as the wasm binary format handler.
       - run: echo -n ":wasm32-wasi:M::\x00asm:\xff\xff\xff\xff:$(pwd)/${WASMTIME_NAME}/wasmtime:" | sudo tee /proc/sys/fs/binfmt_misc/register
       - run: echo "build --config=wasi-wasm" >.bazelrc.local
-      - run: echo "build --config=buildbuddy-bes" >>.bazelrc.local
+      - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >>.bazelrc.local
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
       - run: bazel test ...
 
   macos:
@@ -197,7 +205,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - run: echo "build --config=buildbuddy-bes" >.bazelrc.local
+      - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >.bazelrc.local
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
       - run: bazelisk test //...
       - name: Run tui
         run: |
@@ -218,7 +228,9 @@ jobs:
           path: ~/.cache/bazel
           key: windows_msvc-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
       - run: echo "build --disk_cache ~/.cache/bazel" >.bazelrc.local
-      - run: echo "build --config=buildbuddy-bes" >>.bazelrc.local
+      - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >>.bazelrc.local
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
       - name: Test
         run: bazel test ... -c dbg
       - name: Run tui
@@ -243,7 +255,9 @@ jobs:
           key: windows_clang_cl-${{ hashFiles('.bazelversion', 'WORKSPACE', 'third_party/**') }}
       - run: echo "build --config clang-cl" >.bazelrc.local
       - run: echo "build --disk_cache ~/.cache/bazel" >>.bazelrc.local
-      - run: echo "build --config=buildbuddy-bes" >>.bazelrc.local
+      - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >>.bazelrc.local
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
       - run: bazel test ...
       - name: Run tui
         run: |
@@ -292,7 +306,9 @@ jobs:
           sudo update-alternatives --set clang-tidy /usr/bin/clang-tidy-19
           update-alternatives --query clang-tidy
           clang-tidy --version
-      - run: bazel build ... --config libc++ --config clang-tidy --config buildbuddy-bes --keep_going
+      - run: bazel build ... --config libc++ --config clang-tidy --config buildbuddy-cache-upload  --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} --keep_going
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   buildifier:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This both allows us to see detailed timing information from the builds and gives us a remote cache.

When using one of the buildbuddy configs, the build output starts with a line like `INFO: Streaming build results to: https://app.buildbuddy.io/invocation/7108bed1-5b77-4b61-8db2-c9d1a6b283d1`, where the link leads to the information for that build.