### PR TITLE
style: Get rid of allocations in class selector matching

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -526,6 +526,25 @@ EOF""",
     url = "https://github.com/SFML/imgui-sfml/archive/4fec0d0f35f10f58b327cf5b4d12852ed1a77fbb.tar.gz",
 )
 
+# https://github.com/martinus/nanobench
+bazel_dep(name = "nanobench")  # MIT
+archive_override(
+    module_name = "nanobench",
+    build_file = "//third_party:nanobench.BUILD",
+    integrity = "sha256-U6WpE/ppXCNUZmG/LNIrKZ4Qo+mU2e2X2vibXK2g2nA=",
+    patch_cmds = [
+        """cat <<EOF >MODULE.bazel
+module(name = "nanobench")
+bazel_dep(name = "rules_cc")
+EOF""",
+        # nanobench's use of std::locale segfaults w/ -fno-rtti in combination w/ libstdc++.
+        # See: https://github.com/martinus/nanobench/issues/122
+        "sed -i'' -e /std::locale\\(/d src/include/nanobench.h",
+    ],
+    strip_prefix = "nanobench-4.3.11",
+    url = "https://github.com/martinus/nanobench/archive/refs/tags/v4.3.11.tar.gz",
+)
+
 # https://github.com/simdjson/simdjson
 bazel_dep(name = "simdjson")
 archive_override(

--- a/dom/dom.cpp
+++ b/dom/dom.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -36,6 +36,12 @@ std::string to_string(Document const &document) {
     std::stringstream ss;
     ss << "doctype: " << document.doctype << '\n';
     print_node(document.html_node, ss);
+    return std::move(ss).str();
+}
+
+std::string to_string(Node const &element) {
+    std::stringstream ss;
+    print_node(element, ss);
     return std::move(ss).str();
 }
 

--- a/dom/dom.h
+++ b/dom/dom.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -64,6 +64,7 @@ inline std::vector<Element const *> dom_children(Element const &e) {
 }
 
 std::string to_string(Document const &);
+std::string to_string(Node const &);
 
 } // namespace dom
 

--- a/dom/dom_test.cpp
+++ b/dom/dom_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -15,11 +15,17 @@ using dom::Element;
 int main() {
     etest::Suite s{"dom"};
 
-    s.add_test("to_string", [](etest::IActions &a) {
+    s.add_test("to_string(Document)", [](etest::IActions &a) {
         auto document = dom::Document{.doctype{"html5"}};
         document.html_node = dom::Element{.name{"span"}, .children{{dom::Text{"hello"}}}};
         auto expected = "doctype: html5\ntag: span\n  value: hello\n"sv;
         a.expect_eq(to_string(document), expected);
+    });
+
+    s.add_test("to_string(Node)", [](etest::IActions &a) {
+        dom::Node root = dom::Element{.name{"span"}, .children{{dom::Text{"hello"}}}};
+        auto expected = "tag: span\n  value: hello\n"sv;
+        a.expect_eq(to_string(root), expected);
     });
 
     return s.run();

--- a/style/BUILD
+++ b/style/BUILD
@@ -5,7 +5,10 @@ cc_library(
     name = "style",
     srcs = glob(
         include = ["*.cpp"],
-        exclude = ["*_test.cpp"],
+        exclude = [
+            "*_test.cpp",
+            "*_bench.cpp",
+        ],
     ),
     hdrs = glob(["*.h"]),
     copts = HASTUR_COPTS,
@@ -33,3 +36,16 @@ cc_library(
         "//gfx",
     ],
 ) for src in glob(["*_test.cpp"])]
+
+[cc_test(
+    name = src.removesuffix(".cpp"),
+    size = "small",
+    srcs = [src],
+    copts = HASTUR_COPTS,
+    deps = [
+        ":style",
+        "//dom",
+        "//etest",
+        "@nanobench",
+    ],
+) for src in glob(["*_bench.cpp"])]

--- a/style/style.cpp
+++ b/style/style.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <iterator>
 #include <memory>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -34,8 +35,13 @@ bool has_class(dom::Element const &element, std::string_view needle_class) {
         return false;
     }
 
-    auto classes = util::split(it->second, " ");
-    return std::ranges::any_of(classes, [&](auto const &c) { return c == needle_class; });
+    for (auto cls : std::string_view{it->second} | std::views::split(' ')) {
+        if (std::string_view{cls} == needle_class) {
+            return true;
+        }
+    }
+
+    return false;
 }
 } // namespace
 
@@ -145,8 +151,13 @@ bool is_match(style::StyledNode const &node, std::string_view selector) {
         }
 
         class_string.remove_prefix(1);
-        auto classes = util::split(class_string, ".");
-        return std::ranges::all_of(classes, [&](auto const &c) { return has_class(element, c); });
+        for (auto cls : class_string | std::views::split('.')) {
+            if (!has_class(element, std::string_view{cls})) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     if (selector_.starts_with('#')) {

--- a/style/style.cpp
+++ b/style/style.cpp
@@ -29,13 +29,8 @@ using namespace std::literals;
 
 namespace style {
 namespace {
-bool has_class(dom::Element const &element, std::string_view needle_class) {
-    auto it = element.attributes.find("class");
-    if (it == element.attributes.end()) {
-        return false;
-    }
-
-    for (auto cls : std::string_view{it->second} | std::views::split(' ')) {
+bool contains_class(std::string_view classes, std::string_view needle_class) {
+    for (auto cls : classes | std::views::split(' ')) {
         if (std::string_view{cls} == needle_class) {
             return true;
         }
@@ -145,6 +140,11 @@ bool is_match(style::StyledNode const &node, std::string_view selector) {
 
     auto class_position = selector_.find('.');
     if (class_position != std::string_view::npos) {
+        auto class_attr = element.attributes.find("class");
+        if (class_attr == element.attributes.end()) {
+            return false;
+        }
+
         auto class_string = selector_.substr(class_position);
         if (class_position != 0 && selector_.substr(0, class_position) != element.name) {
             return false;
@@ -152,7 +152,7 @@ bool is_match(style::StyledNode const &node, std::string_view selector) {
 
         class_string.remove_prefix(1);
         for (auto cls : class_string | std::views::split('.')) {
-            if (!has_class(element, std::string_view{cls})) {
+            if (!contains_class(class_attr->second, std::string_view{cls})) {
                 return false;
             }
         }

--- a/style/style_bench.cpp
+++ b/style/style_bench.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "style/style.h"
+
+#include "style/styled_node.h"
+
+#include "dom/dom.h"
+#include "etest/etest2.h"
+
+#include <nanobench.h>
+
+int main() {
+    etest::Suite s;
+
+    s.add_test("is_match: class", [](etest::IActions const &) {
+        ankerl::nanobench::Bench bench;
+        bench.title("is_match: class");
+
+        dom::Node few_classes_dom = dom::Element{"div", {{"class", "first second"}}};
+        auto few_classes = style::StyledNode{.node = few_classes_dom};
+        bench.run("match, few classes", [&] {
+            style::is_match(few_classes, ".first.second"); //
+        });
+
+        bench.run("no match, few classes", [&] {
+            style::is_match(few_classes, ".first.second.third.fourth"); //
+        });
+
+        dom::Node many_classes_dom = dom::Element{
+                "div",
+                {{"class", "one two three four five six seven eight nine ten"}},
+        };
+        auto many_classes = style::StyledNode{.node = many_classes_dom};
+        bench.run("match, many classes", [&] {
+            style::is_match(many_classes, ".eight.two.seven.ten"); //
+        });
+
+        bench.run("no match, many classes", [&] {
+            style::is_match(many_classes, ".eight.two.seve.ten"); //
+        });
+    });
+
+    return s.run();
+}

--- a/third_party/nanobench.BUILD
+++ b/third_party/nanobench.BUILD
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "nanobench",
+    hdrs = ["src/include/nanobench.h"],
+    defines = ["ANKERL_NANOBENCH_IMPLEMENT"],
+    strip_include_prefix = "src/include",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Before:
```
|               ns/op |                op/s |    err% |     total | is_match: class
|--------------------:|--------------------:|--------:|----------:|:----------------
|             1392.13 |           718322.70 |    1.2% |      0.01 | `match, few classes`
|             2272.80 |           439986.22 |    0.6% |      0.01 | `no match, few classes`
|             6605.88 |           151380.23 |    1.8% |      0.01 | `match, many classes`
|             5102.84 |           195969.17 |    0.2% |      0.01 | `no match, many classes`
```

After removing the bonus allocations:
```
|               ns/op |                op/s |    err% |     total | is_match: class
|--------------------:|--------------------:|--------:|----------:|:----------------
|              341.30 |          2929955.00 |    0.5% |      0.01 | `match, few classes`
|              536.39 |          1864327.70 |    0.7% |      0.01 | `no match, few classes`
|             1595.52 |           626753.07 |    1.3% |      0.01 | `match, many classes`
|             1160.63 |           861598.44 |    0.2% |      0.01 | `no match, many classes`
```

After also not looking up the class attribute once per class searched for:
```
|               ns/op |                op/s |    err% |     total | is_match: class
|--------------------:|--------------------:|--------:|----------:|:----------------
|              297.82 |          3357777.59 |    0.6% |      0.01 | `match, few classes`
|              452.88 |          2208102.43 |    1.0% |      0.01 | `no match, few classes`
|             1444.01 |           692515.43 |    0.4% |      0.01 | `match, many classes`
|             1085.37 |           921346.23 |    0.6% |      0.01 | `no match, many classes`
```

There's more low-hanging fruit, but dealing with that will be nicer now that there's easy access to benchmarking.