### PR TITLE
html2: Parse </li> more correctly

### DIFF
--- a/html2/iparser_actions.h
+++ b/html2/iparser_actions.h
@@ -99,6 +99,16 @@ public:
         return has_element_in_scope_impl<kScopeElements>(element_name);
     }
 
+    // https://html.spec.whatwg.org/multipage/parsing.html#has-an-element-in-list-item-scope
+    bool has_element_in_list_item_scope(std::string_view element_name) const {
+        static constexpr auto kScopeElements = std::to_array<std::string_view>({
+                "ol", "ul", "applet", "caption", "html", "table", "td", "th", "marquee", "object", "template",
+                // TODO(robinlinden): Add MathML and SVG elements.
+        });
+
+        return has_element_in_scope_impl<kScopeElements>(element_name);
+    }
+
     bool has_element_in_table_scope(std::string_view element_name) const {
         static constexpr auto kScopeElements = std::to_array<std::string_view>({"html", "table", "template"});
         return has_element_in_scope_impl<kScopeElements>(element_name);

--- a/html2/iparser_actions.h
+++ b/html2/iparser_actions.h
@@ -9,8 +9,6 @@
 #include "html2/token.h"
 #include "html2/tokenizer.h"
 
-#include <algorithm>
-#include <array>
 #include <cstdint>
 #include <span>
 #include <string>
@@ -50,69 +48,6 @@ public:
     virtual std::vector<std::string_view> names_of_open_elements() const = 0;
 
     virtual InsertionMode current_insertion_mode() const = 0;
-
-    template<auto const &array>
-    static constexpr bool is_in_array(std::string_view str) {
-        return std::ranges::find(array, str) != std::cend(array);
-    }
-
-private:
-    template<auto const &scope_elements>
-    bool has_element_in_scope_impl(std::string_view element_name) const {
-        for (auto const element : names_of_open_elements()) {
-            if (element == element_name) {
-                return true;
-            }
-
-            if (is_in_array<scope_elements>(element)) {
-                return false;
-            }
-        }
-
-        return false;
-    }
-
-public:
-    // https://html.spec.whatwg.org/multipage/parsing.html#has-an-element-in-scope
-    bool has_element_in_scope(std::string_view element_name) const {
-        static constexpr auto kScopeElements = std::to_array<std::string_view>({
-                "applet", "caption", "html", "table", "td", "th", "marquee", "object", "template",
-                // TODO(robinlinden): Add MathML and SVG elements.
-                // MathML mi, MathML mo, MathML mn, MathML ms, MathML mtext,
-                // MathML annotation-xml, SVG foreignObject, SVG desc, SVG
-                // title,
-        });
-
-        return has_element_in_scope_impl<kScopeElements>(element_name);
-    }
-
-    // https://html.spec.whatwg.org/multipage/parsing.html#has-an-element-in-button-scope
-    bool has_element_in_button_scope(std::string_view element_name) const {
-        static constexpr auto kScopeElements = std::to_array<std::string_view>({
-                "button", "applet", "caption", "html", "table", "td", "th", "marquee", "object", "template",
-                // TODO(robinlinden): Add MathML and SVG elements.
-                // MathML mi, MathML mo, MathML mn, MathML ms, MathML mtext,
-                // MathML annotation-xml, SVG foreignObject, SVG desc, SVG
-                // title,
-        });
-
-        return has_element_in_scope_impl<kScopeElements>(element_name);
-    }
-
-    // https://html.spec.whatwg.org/multipage/parsing.html#has-an-element-in-list-item-scope
-    bool has_element_in_list_item_scope(std::string_view element_name) const {
-        static constexpr auto kScopeElements = std::to_array<std::string_view>({
-                "ol", "ul", "applet", "caption", "html", "table", "td", "th", "marquee", "object", "template",
-                // TODO(robinlinden): Add MathML and SVG elements.
-        });
-
-        return has_element_in_scope_impl<kScopeElements>(element_name);
-    }
-
-    bool has_element_in_table_scope(std::string_view element_name) const {
-        static constexpr auto kScopeElements = std::to_array<std::string_view>({"html", "table", "template"});
-        return has_element_in_scope_impl<kScopeElements>(element_name);
-    }
 };
 
 } // namespace html2

--- a/html2/parser_states.cpp
+++ b/html2/parser_states.cpp
@@ -925,6 +925,26 @@ std::optional<InsertionMode> InBody::process(IActions &a, html2::Token const &to
 
     // TODO(robinlinden): Most things.
 
+    if (end != nullptr && end->tag_name == "li") {
+        if (!a.has_element_in_list_item_scope("li")) {
+            // Parse error.
+            return {};
+        }
+
+        generate_implied_end_tags(a, "li");
+        if (a.current_node_name() != "li") {
+            // Parse error.
+        }
+
+        while (a.current_node_name() != "li") {
+            a.pop_current_node();
+        }
+
+        a.pop_current_node();
+    }
+
+    // TODO(robinlinden): Most things.
+
     if (start != nullptr && start->tag_name == "table") {
         if (a.quirks_mode() != QuirksMode::Quirks && a.has_element_in_button_scope("p")) {
             close_a_p_element();

--- a/html2/parser_states_test.cpp
+++ b/html2/parser_states_test.cpp
@@ -532,6 +532,18 @@ void in_body_tests(etest::Suite &s) {
         a.expect_eq(body, dom::Element{"body", {}, {dom::Element{"br"}}});
     });
 
+    s.add_test("InBody: </li>, no <li>", [](etest::IActions &a) {
+        auto res = parse("<body></li>", {});
+        auto const &body = std::get<dom::Element>(res.document.html().children.at(1));
+        a.expect_eq(body, dom::Element{"body"});
+    });
+
+    s.add_test("InBody: </li>, non-implicitly-closed node on stack", [](etest::IActions &a) {
+        auto res = parse("<body><li><a></li>", {});
+        auto const &body = std::get<dom::Element>(res.document.html().children.at(1));
+        a.expect_eq(body, dom::Element{"body", {}, {dom::Element{"li", {}, {dom::Element{"a"}}}}});
+    });
+
     s.add_test("InBody: <table>", [](etest::IActions &a) {
         auto res = parse("<body><table>", {});
         auto const &body = std::get<dom::Element>(res.document.html().children.at(1));


### PR DESCRIPTION
This brings the `time ./bazel-bin/browser/gui/gui --exit-after-load https://w.on-t.work/usable-web/` from 0m3.166s to 0m1.341s (real.)

Also, rendering https://w.on-t.work/usable-web/ works way better (but it still doesn't look good.)

Before:
![before, only the first section is rendered](https://github.com/user-attachments/assets/16b647f1-3560-4c48-b2bd-5486ae970a4b)
(Yeah, it just ends at "General")

After:
![after, all text is displayed](https://github.com/user-attachments/assets/edf52e8e-48fe-456c-b367-d3028d107a6e)

So things work way better, but there are a few sizing issues to resolve before it's usable.