### PR TITLE
engine: Load stylesheets wherever they appear

### DIFF
--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -124,7 +124,9 @@ tl::expected<std::unique_ptr<PageState>, NavigationError> Engine::navigate(uri::
         state->stylesheet.splice(css::parse(style_content.text));
     }
 
-    auto head_links = dom::nodes_by_xpath(state->dom.html(), "/html/head/link");
+    // Stylesheets can appear a bit everywhere:
+    // https://html.spec.whatwg.org/multipage/semantics.html#allowed-in-the-body
+    auto head_links = dom::nodes_by_xpath(state->dom.html(), "//link");
     std::erase_if(head_links, [](auto const *link) {
         return !link->attributes.contains("rel")
                 || (link->attributes.contains("rel") && link->attributes.at("rel") != "stylesheet")

--- a/engine/engine_test.cpp
+++ b/engine/engine_test.cpp
@@ -163,7 +163,9 @@ int main() {
                 .body{"<html><head>"
                       "<link rel=stylesheet href=one.css />"
                       "<link rel=stylesheet href=two.css />"
-                      "</head></html>"},
+                      "</head><body>"
+                      "<link rel=stylesheet href=sad.css />"
+                      "</body></html>"},
         };
         responses["hax://example.com/one.css"s] = Response{
                 .status_line = {.status_code = 200},
@@ -173,11 +175,16 @@ int main() {
                 .status_line = {.status_code = 200},
                 .body{"p { color: green; }"},
         };
+        responses["hax://example.com/sad.css"s] = Response{
+                .status_line = {.status_code = 200},
+                .body{"a { color: red; }"},
+        };
         engine::Engine e{std::make_unique<FakeProtocolHandler>(std::move(responses))};
         auto page = e.navigate(uri::Uri::parse("hax://example.com").value()).value();
         a.expect(contains(
                 page->stylesheet.rules, {.selectors{"p"}, .declarations{{css::PropertyId::FontSize, "123em"}}}));
         a.expect(contains(page->stylesheet.rules, {.selectors{"p"}, .declarations{{css::PropertyId::Color, "green"}}}));
+        a.expect(contains(page->stylesheet.rules, {.selectors{"a"}, .declarations{{css::PropertyId::Color, "red"}}}));
     });
 
     s.add_test("stylesheet link, unsupported Content-Encoding", [](etest::IActions &a) {


### PR DESCRIPTION
This fixes google.com not being able to find its CSS variables.