### PR TITLE
img/png: Support interlaced pngs

### DIFF
--- a/img/png.cpp
+++ b/img/png.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -67,6 +67,7 @@ std::optional<Png> Png::from(std::istream &is) {
 
     png_set_expand(png);
     png_set_add_alpha(png, 0xff, PNG_FILLER_AFTER);
+    int const interlacing_passes = png_set_interlace_handling(png);
 
     png_read_update_info(png, info);
 
@@ -76,8 +77,10 @@ std::optional<Png> Png::from(std::istream &is) {
     std::vector<unsigned char> bytes;
     bytes.resize(bytes_per_row * height);
 
-    for (std::uint32_t row = 0; row < height; ++row) {
-        png_read_row(png, bytes.data() + row * bytes_per_row, nullptr);
+    for (int i = 0; i < interlacing_passes; ++i) {
+        for (std::uint32_t row = 0; row < height; ++row) {
+            png_read_row(png, bytes.data() + row * bytes_per_row, nullptr);
+        }
     }
 
     Png ret{


### PR DESCRIPTION
This fixes image-rendering issues on e.g. http://www.libpng.org/pub/png/pngpic2.html and https://gr.ht/2019/07/14/informed-consent.html

Before:
![before, interlaced images are rendered as several small images](https://github.com/user-attachments/assets/555a9966-35ed-44b6-abbf-7b4771dd4eef)



After:
![after, things look fine](https://github.com/user-attachments/assets/25b04b63-55db-465b-970a-a044c07f5126)
