### PR TITLE
html2: Handle more closing tag special cases

### DIFF
--- a/html2/parser_states.cpp
+++ b/html2/parser_states.cpp
@@ -981,6 +981,56 @@ std::optional<InsertionMode> InBody::process(IActions &a, html2::Token const &to
 
     // TODO(robinlinden): Most things.
 
+    static constexpr auto kClosingTags = std::to_array<std::string_view>({
+            "address",
+            "article",
+            "aside",
+            "blockquote",
+            "button",
+            "center",
+            "details",
+            "dialog",
+            "dir",
+            "div",
+            "dl",
+            "fieldset",
+            "figcaption",
+            "figure",
+            "footer",
+            "header",
+            "hgroup",
+            "listing",
+            "main",
+            "menu",
+            "nav",
+            "ol",
+            "pre",
+            "search",
+            "section",
+            "summary",
+            "ul",
+    });
+    if (end != nullptr && is_in_array<kClosingTags>(end->tag_name)) {
+        if (!has_element_in_scope(a, end->tag_name)) {
+            // Parse error.
+            return {};
+        }
+
+        generate_implied_end_tags(a, end->tag_name);
+        if (a.current_node_name() != end->tag_name) {
+            // Parse error.
+        }
+
+        while (a.current_node_name() != end->tag_name) {
+            a.pop_current_node();
+        }
+
+        a.pop_current_node();
+        return {};
+    }
+
+    // TODO(robinlinden): Most things.
+
     if (end != nullptr && end->tag_name == "li") {
         if (!has_element_in_list_item_scope(a, "li")) {
             // Parse error.

--- a/html2/parser_states_test.cpp
+++ b/html2/parser_states_test.cpp
@@ -532,6 +532,18 @@ void in_body_tests(etest::Suite &s) {
         a.expect_eq(body, dom::Element{"body", {}, {dom::Element{"br"}}});
     });
 
+    s.add_test("InBody: </ul>, no <ul>", [](etest::IActions &a) {
+        auto res = parse("<body></ul>", {});
+        auto const &body = std::get<dom::Element>(res.document.html().children.at(1));
+        a.expect_eq(body, dom::Element{"body"});
+    });
+
+    s.add_test("InBody: </ul>, non-implicitly-closed node on stack", [](etest::IActions &a) {
+        auto res = parse("<body><ul><a></ul>", {});
+        auto const &body = std::get<dom::Element>(res.document.html().children.at(1));
+        a.expect_eq(body, dom::Element{"body", {}, {dom::Element{"ul", {}, {dom::Element{"a"}}}}});
+    });
+
     s.add_test("InBody: </li>, no <li>", [](etest::IActions &a) {
         auto res = parse("<body></li>", {});
         auto const &body = std::get<dom::Element>(res.document.html().children.at(1));


### PR DESCRIPTION
This fixes lots of "right drift" issues on e.g. http://www.libpng.org/pub/png/pngpic2.html.

Before:
![html elements are drifting to the right w/ each "improperly" closed node](https://github.com/user-attachments/assets/adb80c86-fdef-4a7b-a0c4-899bacb3871d)

After:
![unbothered, moisturized, happy, in its lane, focused, flourishing](https://github.com/user-attachments/assets/ccc143ec-98fd-434c-9ffd-08d91cafc13e)
