### PR TITLE
url/test: Don't let the JSON parser patch the test input

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -708,11 +708,12 @@ EOF""",
     url = "https://github.com/KhronosGroup/Vulkan-Hpp/archive/v%s.tar.gz" % VULKAN_TAG,
 )
 
-WPT_REVISION = "13861f4a19afa26daa9e2a4ca2dcce82fc2e1236"
+# HEAD as of 2025-01-28.
+WPT_REVISION = "45e7dd49afae442ab0bb56b00d72dd138a4b47e9"
 
 http_file(
     name = "wpt_urltestdata",
-    integrity = "sha256-XlND8jM+ECOXzWK3RnaBGO7QS5h31TF0wfI7aaQxpYg=",
+    integrity = "sha256-3519vF5rx/YZyC1lgUjXg/DaltvGu4DqWpCubPiuo+A=",
     url = "https://raw.githubusercontent.com/web-platform-tests/wpt/%s/url/resources/urltestdata.json" % WPT_REVISION,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -708,23 +708,12 @@ EOF""",
     url = "https://github.com/KhronosGroup/Vulkan-Hpp/archive/v%s.tar.gz" % VULKAN_TAG,
 )
 
-# Stuck on the last commit where the archive has the same content every
-# download. git_repository sort of works if we want to upgrade, but it's so slow
-# that downloading wpt occasionally times out in CI.
-# See: https://github.com/web-platform-tests/wpt/issues/47124
-# https://github.com/web-platform-tests/wpt
-bazel_dep(name = "wpt")
-archive_override(
-    module_name = "wpt",  # BSD-3-Clause
-    build_file_content = """exports_files(["url/resources/urltestdata.json"])""",
-    integrity = "sha256-sUgB+WnWZ3UEjMoPO5kL4g2kot0TigulBNHbCTi4v9A=",
-    patch_cmds = [
-        """cat <<EOF >MODULE.bazel
-module(name = "wpt")
-EOF""",
-    ],
-    strip_prefix = "wpt-13861f4a19afa26daa9e2a4ca2dcce82fc2e1236",
-    url = "https://github.com/web-platform-tests/wpt/archive/13861f4a19afa26daa9e2a4ca2dcce82fc2e1236.tar.gz",
+WPT_REVISION = "13861f4a19afa26daa9e2a4ca2dcce82fc2e1236"
+
+http_file(
+    name = "wpt_urltestdata",
+    integrity = "sha256-XlND8jM+ECOXzWK3RnaBGO7QS5h31TF0wfI7aaQxpYg=",
+    url = "https://raw.githubusercontent.com/web-platform-tests/wpt/%s/url/resources/urltestdata.json" % WPT_REVISION,
 )
 
 # https://gitlab.freedesktop.org/xorg/lib/libxcursor

--- a/url/BUILD
+++ b/url/BUILD
@@ -49,7 +49,7 @@ cc_test(
     name = "wpt_test",
     size = "small",
     srcs = ["wpt_test.cpp"],
-    args = ["$(location @wpt//:url/resources/urltestdata.json)"],
+    args = ["$(location @wpt_urltestdata//file)"],
     copts = HASTUR_COPTS + select({
         "@platforms//os:windows": [
             "/wd4100",
@@ -57,7 +57,7 @@ cc_test(
         ],
         "//conditions:default": [],
     }),
-    data = ["@wpt//:url/resources/urltestdata.json"],
+    data = ["@wpt_urltestdata//file"],
     tags = ["no-cross"],
     deps = [
         ":url",

--- a/url/wpt_test.cpp
+++ b/url/wpt_test.cpp
@@ -54,13 +54,13 @@ int main(int argc, char **argv) {
             }
 
             // Get input URL
-            std::string_view input = obj["input"].get_string(true);
+            std::string_view input = obj["input"].get_string();
 
             // Parse base URL if it exists
             std::optional<url::Url> base_test;
 
             if (!obj["base"].is_null()) {
-                std::string_view base_str = obj["base"].get_string(true);
+                std::string_view base_str = obj["base"].get_string();
 
                 base_test = p.parse(std::string{base_str});
 


### PR DESCRIPTION
The test case we were hacking around (because it didn't belong in the test suite we were running) was moved into a separate thing in `https://github.com/web-platform-tests/wpt/commit/2b9af57f5f61e06e93a0caff5256d2c435b5c468`.

Also, downloading wpt like this should make our Windows CI a lot happier, looking at recent runs:
![timing stats of Windows CI](https://github.com/user-attachments/assets/dd653a58-5fc1-4b0a-808e-7146ac72e24f)
