### PR TITLE
dom: Print nodes in the format used in the html5lib tests

### DIFF
--- a/dom/dom.cpp
+++ b/dom/dom.cpp
@@ -14,6 +14,15 @@
 namespace dom {
 namespace {
 
+void print_attribute(std::pair<std::string, std::string> const &attribute, std::ostream &os, std::uint8_t depth) {
+    os << "\n| ";
+    for (std::uint8_t i = 1; i < depth; ++i) {
+        os << "  ";
+    }
+
+    os << attribute.first << "=\"" << attribute.second << '"';
+}
+
 // NOLINTNEXTLINE(misc-no-recursion)
 void print_node(dom::Node const &node, std::ostream &os, std::uint8_t depth = 0) {
     if (depth > 0) {
@@ -26,6 +35,10 @@ void print_node(dom::Node const &node, std::ostream &os, std::uint8_t depth = 0)
 
     if (auto const *element = std::get_if<dom::Element>(&node)) {
         os << '<' << element->name << ">";
+        for (auto const &attribute : element->attributes) {
+            print_attribute(attribute, os, depth + 1);
+        }
+
         for (auto const &child : element->children) {
             print_node(child, os, depth + 1);
         }

--- a/dom/dom.cpp
+++ b/dom/dom.cpp
@@ -16,17 +16,21 @@ namespace {
 
 // NOLINTNEXTLINE(misc-no-recursion)
 void print_node(dom::Node const &node, std::ostream &os, std::uint8_t depth = 0) {
-    for (std::uint8_t i = 0; i < depth; ++i) {
+    if (depth > 0) {
+        os << "\n| ";
+    }
+
+    for (std::uint8_t i = 1; i < depth; ++i) {
         os << "  ";
     }
 
     if (auto const *element = std::get_if<dom::Element>(&node)) {
-        os << "tag: " << element->name << '\n';
+        os << '<' << element->name << ">";
         for (auto const &child : element->children) {
             print_node(child, os, depth + 1);
         }
     } else {
-        os << "value: " << std::get<dom::Text>(node).text << '\n';
+        os << '"' << std::get<dom::Text>(node).text << '"';
     }
 }
 
@@ -34,8 +38,12 @@ void print_node(dom::Node const &node, std::ostream &os, std::uint8_t depth = 0)
 
 std::string to_string(Document const &document) {
     std::stringstream ss;
-    ss << "doctype: " << document.doctype << '\n';
-    print_node(document.html_node, ss);
+    ss << "#document\n";
+    if (!document.doctype.empty()) {
+        ss << "| <!DOCTYPE " << document.doctype << '>';
+    }
+
+    print_node(document.html_node, ss, 1);
     return std::move(ss).str();
 }
 

--- a/dom/dom.h
+++ b/dom/dom.h
@@ -63,6 +63,8 @@ inline std::vector<Element const *> dom_children(Element const &e) {
     return children;
 }
 
+// Prints a dom tree in the format described at
+// https://github.com/html5lib/html5lib-tests/blob/a9f44960a9fedf265093d22b2aa3c7ca123727b9/tree-construction/README.md
 std::string to_string(Document const &);
 std::string to_string(Node const &);
 

--- a/dom/dom_test.cpp
+++ b/dom/dom_test.cpp
@@ -13,12 +13,27 @@ int main() {
 
     s.add_test("to_string(Document)", [](etest::IActions &a) {
         auto document = dom::Document{.doctype{"html5"}};
-        document.html_node = dom::Element{.name{"span"}, .children{{dom::Text{"hello"}}}};
+        document.html_node = dom::Element{
+                .name{"span"},
+                .children{{
+                        dom::Text{"hello"},
+                        dom::Element{
+                                .name{"a"},
+                                .attributes{{"href", "https://example.com"}, {"class", "link"}},
+                                .children{dom::Text{"go!"}},
+                        },
+                }},
+        };
+
         std::string_view expected =
                 "#document\n"
                 "| <!DOCTYPE html5>\n"
                 "| <span>\n"
-                "|   \"hello\"";
+                "|   \"hello\"\n"
+                "|   <a>\n"
+                "|     class=\"link\"\n"
+                "|     href=\"https://example.com\"\n"
+                "|     \"go!\"";
         a.expect_eq(to_string(document), expected);
     });
 

--- a/dom/dom_test.cpp
+++ b/dom/dom_test.cpp
@@ -8,23 +8,25 @@
 
 #include <string_view>
 
-using namespace std::literals;
-
-using dom::Element;
-
 int main() {
     etest::Suite s{"dom"};
 
     s.add_test("to_string(Document)", [](etest::IActions &a) {
         auto document = dom::Document{.doctype{"html5"}};
         document.html_node = dom::Element{.name{"span"}, .children{{dom::Text{"hello"}}}};
-        auto expected = "doctype: html5\ntag: span\n  value: hello\n"sv;
+        std::string_view expected =
+                "#document\n"
+                "| <!DOCTYPE html5>\n"
+                "| <span>\n"
+                "|   \"hello\"";
         a.expect_eq(to_string(document), expected);
     });
 
     s.add_test("to_string(Node)", [](etest::IActions &a) {
         dom::Node root = dom::Element{.name{"span"}, .children{{dom::Text{"hello"}}}};
-        auto expected = "tag: span\n  value: hello\n"sv;
+        std::string_view expected =
+                "<span>\n"
+                "| \"hello\"";
         a.expect_eq(to_string(root), expected);
     });
 


### PR DESCRIPTION
This is more compact and just generally nicer than my old ad-hoc format. It's also a bit of preparation for running the tree-construction html5lib-tests against our spec-compliant html parser.