### PR TITLE
ci: Only use buildbuddy if an API key is available

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,7 @@ jobs:
       - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >.bazelrc.local
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        if: env.BUILDBUDDY_API_KEY != ''
       - name: Test
         run: bazel test //... ${{ matrix.bazel }}
       - name: Run
@@ -133,6 +134,7 @@ jobs:
       - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >.bazelrc.local
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        if: env.BUILDBUDDY_API_KEY != ''
       - name: Coverage
         run: bazel coverage ... ${{ matrix.bazel }}
       # clang 19 coverage has a lot of problems w/ boringssl:
@@ -166,6 +168,7 @@ jobs:
       - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >>.bazelrc.local
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        if: env.BUILDBUDDY_API_KEY != ''
       - run: bazel test ...
       - name: Run tui
         run: |
@@ -193,6 +196,7 @@ jobs:
       - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >>.bazelrc.local
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        if: env.BUILDBUDDY_API_KEY != ''
       - run: bazel test ...
 
   macos:
@@ -208,6 +212,7 @@ jobs:
       - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >.bazelrc.local
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        if: env.BUILDBUDDY_API_KEY != ''
       - run: bazelisk test //...
       - name: Run tui
         run: |
@@ -231,6 +236,7 @@ jobs:
       - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >>.bazelrc.local
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        if: env.BUILDBUDDY_API_KEY != ''
       - name: Test
         run: bazel test ... -c dbg
       - name: Run tui
@@ -258,6 +264,7 @@ jobs:
       - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >>.bazelrc.local
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        if: env.BUILDBUDDY_API_KEY != ''
       - run: bazel test ...
       - name: Run tui
         run: |
@@ -308,9 +315,11 @@ jobs:
           sudo update-alternatives --set clang-tidy /usr/bin/clang-tidy-19
           update-alternatives --query clang-tidy
           clang-tidy --version
-      - run: bazel build ... --config libc++ --config clang-tidy --config buildbuddy-cache-upload  --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} --keep_going
+      - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >>.bazelrc.local
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        if: env.BUILDBUDDY_API_KEY != ''
+      - run: bazel build ... --config libc++ --config clang-tidy --keep_going
 
   buildifier:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
While this does speed up CI *a lot* and gives lovely build timing information, I need to work out how we want to deal with reads/writes to the buildbuddy cache from forks and how we manage the mandatory API keys.

@Zer0-One this should resolve the issues you saw in https://github.com/robinlinden/hastur/actions/runs/13147361339.