### PR TITLE
build: Make cross-compilation on macOS/Windows hosts easier

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -147,6 +147,9 @@ build:zig-cross --dynamic_mode=off
 # * py_test targets have host dependencies.
 build:zig-cross --build_tag_filters=-no-cross
 build:zig-cross --test_tag_filters=-no-cross
+# zig cc seems pretty happy with the flags we use on Linux.
+build:zig-cross --noenable_platform_specific_config
+build:zig-cross --config=linux
 
 build:zig-cross-musl --config=zig-cross
 build:zig-cross-musl --copt=-fPIC


### PR DESCRIPTION
Previously, you'd get the Windows or macOS flags by default and have to manually pass `--noenable_platform_specific_config --config=linux` for things to work.