### PR TITLE
json: Improve error reporting

### DIFF
--- a/json/BUILD
+++ b/json/BUILD
@@ -10,6 +10,8 @@ cc_library(
     deps = [
         "//unicode:util",
         "//util:from_chars",
+        "//util:string",
+        "@expected",
     ],
 )
 
@@ -21,6 +23,7 @@ cc_library(
     deps = [
         ":json",
         "//etest",
+        "@expected",
     ],
 ) for src in glob(
     include = ["*_test.cpp"],


### PR DESCRIPTION
This isn't perfect, but it's a lot better than only getting a nullopt back. More granular error codes, as well as row:col-info can be added later.