### PR TITLE
css: Support `prefers-reduced-motion` and em-units in media queries

### DIFF
--- a/css/media_query.h
+++ b/css/media_query.h
@@ -237,6 +237,14 @@ private:
             return std::nullopt;
         }
 
+        if (value_unit == "em") {
+            // TODO(robinlinden): Make configurable. Needs to match the default
+            // font size in the StyledNode property calulations right now.
+            static constexpr int kDefaultFontSize{16};
+            value *= kDefaultFontSize;
+            value_unit = "px";
+        }
+
         // ...and we only handle px as the unit.
         if (value != 0 && value_unit != "px") {
             return std::nullopt;

--- a/css/media_query_test.cpp
+++ b/css/media_query_test.cpp
@@ -49,6 +49,10 @@ void to_string_tests(etest::Suite &s) {
     s.add_test("to_string", [](etest::IActions &a) {
         a.expect_eq(css::to_string(css::MediaQuery::parse("(width: 300px)").value()), //
                 "300 <= width <= 300");
+
+        // 1em == 16px right now. This will probably break when that's made configurable.
+        a.expect_eq(css::to_string(css::MediaQuery::parse("(width: 10em)").value()), //
+                "160 <= width <= 160");
     });
 
     s.add_test("to_string: prefers-color-scheme", [](etest::IActions &a) {

--- a/css/media_query_test.cpp
+++ b/css/media_query_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -54,6 +54,11 @@ void to_string_tests(etest::Suite &s) {
     s.add_test("to_string: prefers-color-scheme", [](etest::IActions &a) {
         a.expect_eq(css::to_string(css::MediaQuery::PrefersColorScheme{.color_scheme = css::ColorScheme::Light}), //
                 "prefers-color-scheme: light");
+    });
+
+    s.add_test("to_string: prefers-reduced-motion", [](etest::IActions &a) {
+        a.expect_eq(css::to_string(css::MediaQuery::PrefersReducedMotion{}), //
+                "prefers-reduced-motion: reduce");
     });
 
     s.add_test("to_string: type", [](etest::IActions &a) {
@@ -171,6 +176,26 @@ void prefers_color_scheme_tests(etest::Suite &s) {
     });
 }
 
+void prefers_reduced_motion_tests(etest::Suite &s) {
+    s.add_test("prefers-reduced-motion: reduce", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(prefers-reduced-motion: reduce)"),
+                css::MediaQuery{css::MediaQuery::PrefersReducedMotion{}});
+
+        auto query = css::MediaQuery::PrefersReducedMotion{};
+        a.expect(query.evaluate({.reduce_motion = css::ReduceMotion::Reduce}));
+        a.expect(!query.evaluate({.reduce_motion = css::ReduceMotion::NoPreference}));
+    });
+
+    s.add_test("prefers-reduced-motion: no-preference", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(prefers-reduced-motion: no-preference)"),
+                css::MediaQuery{css::MediaQuery::False{}});
+    });
+
+    s.add_test("prefers-reduced-motion: no-preference", [](etest::IActions &a) {
+        a.expect_eq(css::MediaQuery::parse("(prefers-reduced-motion: yasss)"), std::nullopt);
+    });
+}
+
 void type_tests(etest::Suite &s) {
     s.add_test("type", [](etest::IActions &a) {
         a.expect_eq(css::MediaQuery::parse("all"), css::MediaQuery{css::MediaQuery::True{}});
@@ -240,6 +265,7 @@ int main() {
     false_tests(s);
     true_tests(s);
     prefers_color_scheme_tests(s);
+    prefers_reduced_motion_tests(s);
     type_tests(s);
     width_tests(s);
     return s.run();

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -550,6 +550,8 @@ std::optional<TextTransform> StyledNode::get_text_transform_property() const {
     return std::nullopt;
 }
 
+// TODO(robinlinden): Make configurable. Needs to match the default font size in
+// our media query parsing right now.
 static constexpr int kDefaultFontSize{16};
 // https://drafts.csswg.org/css-fonts-4/#absolute-size-mapping
 constexpr int kMediumFontSize = kDefaultFontSize;


### PR DESCRIPTION
This adds support for `prefers-reduced-motion: reduce` and things like `max-width: 30em`.

Both of these things are in use on e.g. https://snarkynomad.com.