### PR TITLE
layout: Treat unresolvable %-heights as 'auto'

### DIFF
--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -572,8 +572,8 @@ void Layouter::calculate_non_inline_height(LayoutBox &box, int const font_size) 
     if (auto height = box.get_property<css::PropertyId::Height>(); !height.is_auto()) {
         if (box.node->parent == nullptr) {
             content.height = height.resolve(font_size, resolution_context_, resolution_context_.viewport_height);
-        } else {
-            content.height = height.resolve(font_size, resolution_context_);
+        } else if (auto maybe_height = height.try_resolve(font_size, resolution_context_)) {
+            content.height = *maybe_height;
         }
     }
 


### PR DESCRIPTION
This makes https://tosdr.org/en usable.

Before:
![before: only the alt-text for images is shown](https://github.com/user-attachments/assets/7b0a3763-f61c-4531-ae8b-2f1fcb720151)

After:
![after: the website is sort of usable and all text is shown](https://github.com/user-attachments/assets/4677af40-2b97-48bd-9448-d3ef6b3594ea)


I didn't take any screenshots with the images enabled until afterwards, and I'm too lazy to go back and redo my beautiful screenshots, but here's an after w/ images enabled:
![after, images enabled, now in addition to the text, the website icons are shown](https://github.com/user-attachments/assets/47260077-b302-4152-a84f-1ae90b57f1ee)
