### PR TITLE
ci: Update codecov-cli

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,8 +151,6 @@ jobs:
       # lcov: ERROR: "external/boringssl/crypto/conf/internal.h":30:  function conf.c:lh_CONF_VALUE_insert found on line but no corresponding 'line' coverage data point.  Cannot derive function end line.
       - run: lcov --ignore-errors inconsistent --summary bazel-out/_coverage/_coverage_report.dat
       - name: Upload
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           pipx install codecov-cli==10.2.0
           codecovcli upload-process --fail-on-error --file bazel-out/_coverage/_coverage_report.dat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,14 +153,8 @@ jobs:
       - name: Upload
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        # TODO(robinlinden): codecov-cli 0.7.x breaks PRs from forks w/
-        # "Error: Codecov token not found. Please provide Codecov token with -t flag."
-        # whereas in 0.6.0, it still correctly detects PRs where tokenless
-        # uploads are required:
-        # "info - 2024-06-21 21:24:10,269 -- The PR is happening in a forked
-        #  repo. Using tokenless upload."
         run: |
-          pipx install codecov-cli==0.6.0
+          pipx install codecov-cli==10.2.0
           codecovcli upload-process --fail-on-error --file bazel-out/_coverage/_coverage_report.dat
 
   linux-aarch64-muslc:


### PR DESCRIPTION
The tokenless upload setup was apparently redone in codecov-cli 0.9.0,
so there's a chance a non-ancient version will work in forks now.