### PR TITLE
browser/gui: Hook up jpeg support

### DIFF
--- a/browser/gui/BUILD
+++ b/browser/gui/BUILD
@@ -18,6 +18,7 @@ cc_binary(
         "//gfx",
         "//gfx:opengl",
         "//gfx:sfml",
+        "//img:jpeg_turbo",
         "//img:png",
         "//layout",
         "//os:system_info",

--- a/browser/gui/app.h
+++ b/browser/gui/app.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -75,7 +75,7 @@ private:
 
     bool render_debug_{};
     bool display_debug_gui_{};
-    bool load_images_{};
+    bool load_images_{true};
 
     unsigned scale_{1};
 


### PR DESCRIPTION
Neat, if I may say so myself.

![jpeg image on arstechnica.com](https://github.com/user-attachments/assets/c597cdc9-7f30-4458-99c5-b81ad275dd8f)