### PR TITLE
css: Steal to_string(StyleSheet) from browser/gui

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -4,7 +4,6 @@
 
 #include "browser/gui/app.h"
 
-#include "css/rule.h"
 #include "css/style_sheet.h"
 #include "dom/dom.h"
 #include "dom/xpath.h"
@@ -122,14 +121,6 @@ std::string element_text(layout::LayoutBox const *element) {
     }
 
     return std::get<dom::Element>(element->node->node).name;
-}
-
-std::string stylesheet_to_string(css::StyleSheet const &stylesheet) {
-    std::stringstream ss;
-    for (auto const &rule : stylesheet.rules) {
-        ss << css::to_string(rule) << '\n';
-    }
-    return std::move(ss).str();
 }
 
 template<std::size_t WidthT, std::size_t HeightT>
@@ -820,7 +811,7 @@ void App::run_debug_widget() const {
     }
 
     if (ImGui::Button("Stylesheet")) {
-        std::cout << "\nStylesheet:\n" << stylesheet_to_string(page().stylesheet) << '\n';
+        std::cout << "\nStylesheet:\n" << to_string(page().stylesheet) << '\n';
     }
 
     std::optional<layout::LayoutBox> const &layout =

--- a/css/style_sheet.cpp
+++ b/css/style_sheet.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2022-2025 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "css/style_sheet.h"
+
+#include "css/rule.h"
+
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace css {
+
+std::string to_string(css::StyleSheet const &stylesheet) {
+    std::stringstream ss;
+    for (auto const &rule : stylesheet.rules) {
+        ss << to_string(rule) << '\n';
+    }
+    return std::move(ss).str();
+}
+
+} // namespace css

--- a/css/style_sheet.h
+++ b/css/style_sheet.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -8,6 +8,7 @@
 #include "css/rule.h"
 
 #include <iterator>
+#include <string>
 #include <vector>
 
 namespace css {
@@ -22,6 +23,8 @@ struct StyleSheet {
                 end(rules), std::make_move_iterator(begin(other.rules)), std::make_move_iterator(end(other.rules)));
     }
 };
+
+std::string to_string(css::StyleSheet const &);
 
 } // namespace css
 

--- a/css/style_sheet_test.cpp
+++ b/css/style_sheet_test.cpp
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "css/style_sheet.h"
 
+#include "css/property_id.h"
 #include "css/rule.h"
 #include "etest/etest2.h"
 
@@ -23,6 +24,16 @@ int main() {
 
         a1.splice(std::move(a2));
         a.expect_eq(a1.rules, std::vector<css::Rule>{{{"a"}}, {{"b"}}, {{"c"}}, {{"d"}}});
+    });
+
+    s.add_test("to_string(StyleSheet)", [](etest::IActions &a) {
+        css::StyleSheet stylesheet;
+        stylesheet.rules.push_back({.selectors = {"a", "b"}, .declarations = {{css::PropertyId::Color, "blue"}}});
+
+        a.expect_eq(css::to_string(stylesheet),
+                "Selectors: a, b\n"
+                "Declarations:\n"
+                "  color: blue\n\n");
     });
 
     return s.run();


### PR DESCRIPTION
browser/gui/app.cpp is getting big, and this feels more at home in //css.