### PR TITLE
deps: Add mirrors for all freedesktop dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -734,9 +734,11 @@ http_file(
 )
 
 # https://gitlab.freedesktop.org/xorg/lib/libxcursor
-bazel_dep(name = "xcursor")
+XCURSOR_VERSION = "1.2.3"
+
+bazel_dep(name = "xcursor")  # MIT
 archive_override(
-    module_name = "xcursor",  # MIT
+    module_name = "xcursor",
     build_file = "//third_party:xcursor.BUILD",
     integrity = "sha256-hAKS5c366Ni3lboAvL5iCg3gr2rhhH4ULfCd7IanDtw=",
     patch_cmds = [
@@ -746,14 +748,19 @@ bazel_dep(name = "rules_cc")
 bazel_dep(name = "xrender")
 EOF""",
     ],
-    strip_prefix = "libxcursor-libXcursor-1.2.3",
-    url = "https://gitlab.freedesktop.org/xorg/lib/libxcursor/-/archive/libXcursor-1.2.3/libxcursor-libXcursor-1.2.3.tar.gz",
+    strip_prefix = "libxcursor-libXcursor-%s" % XCURSOR_VERSION,
+    urls = [
+        "https://github.com/robinlinden/libxcursor/archive/libXcursor-%s.tar.gz" % XCURSOR_VERSION,
+        "https://gitlab.freedesktop.org/xorg/lib/libxcursor/-/archive/libXcursor-{0}/libxcursor-libXcursor-{0}.tar.gz".format(XCURSOR_VERSION),
+    ],
 )
 
 # https://gitlab.freedesktop.org/xorg/lib/libxext
-bazel_dep(name = "xext")
+XEXT_VERSION = "1.3.6"
+
+bazel_dep(name = "xext")  # MIT
 archive_override(
-    module_name = "xext",  # MIT
+    module_name = "xext",
     build_file = "//third_party:xext.BUILD",
     integrity = "sha256-TkjqJxtfU8M4YBim4CY0VP5YKkE/zgJzreYB+/6eDHI=",
     patch_cmds = [
@@ -762,14 +769,19 @@ module(name = "xext")
 bazel_dep(name = "rules_cc")
 EOF""",
     ],
-    strip_prefix = "libxext-libXext-1.3.6",
-    url = "https://gitlab.freedesktop.org/xorg/lib/libxext/-/archive/libXext-1.3.6/libxext-libXext-1.3.6.tar.gz",
+    strip_prefix = "libxext-libXext-%s" % XEXT_VERSION,
+    urls = [
+        "https://github.com/robinlinden/libxext/archive/libXext-%s.tar.gz" % XEXT_VERSION,
+        "https://gitlab.freedesktop.org/xorg/lib/libxext/-/archive/libXext-{0}/libxext-libXext-{0}.tar.gz".format(XEXT_VERSION),
+    ],
 )
 
 # https://gitlab.freedesktop.org/xorg/lib/libxrandr
-bazel_dep(name = "xrandr")
+XRANDR_VERSION = "1.5.4"
+
+bazel_dep(name = "xrandr")  # MIT
 archive_override(
-    module_name = "xrandr",  # MIT
+    module_name = "xrandr",
     build_file = "//third_party:xrandr.BUILD",
     patch_cmds = [
         """cat <<EOF >MODULE.bazel
@@ -780,11 +792,16 @@ bazel_dep(name = "xrender")
 EOF""",
     ],
     sha256 = "a1909cbe9ded94187b6420ae8c347153f8278955265cb80a64cdae5501433396",
-    strip_prefix = "libxrandr-libXrandr-1.5.4",
-    url = "https://gitlab.freedesktop.org/xorg/lib/libxrandr/-/archive/libXrandr-1.5.4/libxrandr-libXrandr-1.5.4.tar.gz",
+    strip_prefix = "libxrandr-libXrandr-%s" % XRANDR_VERSION,
+    urls = [
+        "https://github.com/robinlinden/libxrandr/archive/libXrandr-%s.tar.gz" % XRANDR_VERSION,
+        "https://gitlab.freedesktop.org/xorg/lib/libxrandr/-/archive/libXrandr-{0}/libxrandr-libXrandr-{0}.tar.gz".format(XRANDR_VERSION),
+    ],
 )
 
 # https://gitlab.freedesktop.org/xorg/lib/libxrender
+XRENDER_VERSION = "0.9.12"
+
 bazel_dep(name = "xrender")  # MIT
 archive_override(
     module_name = "xrender",
@@ -796,8 +813,11 @@ module(name = "xrender")
 bazel_dep(name = "rules_cc")
 EOF""",
     ],
-    strip_prefix = "libxrender-libXrender-0.9.12",
-    url = "https://gitlab.freedesktop.org/xorg/lib/libxrender/-/archive/libXrender-0.9.12/libxrender-libXrender-0.9.12.tar.gz",
+    strip_prefix = "libxrender-libXrender-%s" % XRENDER_VERSION,
+    urls = [
+        "https://github.com/robinlinden/libxrender/archive/libXrender-%s.tar.gz" % XRENDER_VERSION,
+        "https://gitlab.freedesktop.org/xorg/lib/libxrender/-/archive/libXrender-{0}/libxrender-libXrender-{0}.tar.gz".format(XRENDER_VERSION),
+    ],
 )
 
 # https://github.com/madler/zlib


### PR DESCRIPTION
The freedesktop GitLab instance has pretty frequent downtime, and now there's 'up to a week' of downtime planned for the 16th of March.

See: https://gitlab.freedesktop.org/freedesktop/freedesktop/-/issues/2076