### PR TITLE
archive/zlib: Allow limiting the output size

### DIFF
--- a/archive/zlib.h
+++ b/archive/zlib.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -25,7 +25,8 @@ enum class ZlibMode : std::uint8_t {
     Gzip,
 };
 
-tl::expected<std::vector<std::byte>, ZlibError> zlib_decode(std::span<std::byte const>, ZlibMode);
+tl::expected<std::vector<std::byte>, ZlibError> zlib_decode(
+        std::span<std::byte const>, ZlibMode, std::size_t max_output_length = std::size_t{1024} * 1024 * 1024);
 
 } // namespace archive
 

--- a/archive/zlib_test.cpp
+++ b/archive/zlib_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -40,6 +40,10 @@ int main() {
 
         auto res = zlib_decode(as_bytes(kZlibbedCss), ZlibMode::Zlib);
         a.expect(std::ranges::equal(res.value(), as_bytes(kExpected)));
+
+        auto err = zlib_decode(as_bytes(kZlibbedCss), ZlibMode::Zlib, 15);
+        a.expect(!err.has_value());
+        a.expect_eq(err.error().message, "Output too large");
     });
 
     s.add_test("gzip", [](etest::IActions &a) {
@@ -48,6 +52,10 @@ int main() {
 
         auto res = zlib_decode(as_bytes(kGzippedCss), ZlibMode::Gzip);
         a.expect(std::ranges::equal(res.value(), as_bytes(kExpected)));
+
+        auto err = zlib_decode(as_bytes(kGzippedCss), ZlibMode::Gzip, 15);
+        a.expect(!err.has_value());
+        a.expect_eq(err.error().message, "Output too large");
     });
 
     return s.run();


### PR DESCRIPTION
This was supported in both brotli and zstd, but not for the zlib decoder. :(