### PR TITLE
build: Apply buildbuddy suggestions to the remote cache setup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -124,6 +124,8 @@ build:buildbuddy-cache-common --config=buildbuddy-bes
 build:buildbuddy-cache-common --remote_cache=grpcs://remote.buildbuddy.io
 build:buildbuddy-cache-common --remote_timeout=3600
 build:buildbuddy-cache-common --remote_cache_compression
+build:buildbuddy-cache-common --experimental_remote_cache_compression_threshold=100
+build:buildbuddy-cache-common --nolegacy_important_outputs
 build:buildbuddy-cache-common --noslim_profile
 build:buildbuddy-cache-common --experimental_profile_include_target_label
 build:buildbuddy-cache-common --experimental_profile_include_primary_output


### PR DESCRIPTION
As far as I can tell, these are already the defaults in the version of Bazel we're targeting, but they probably recommend these settings for a reason.

![buildbuddy suggestions](https://github.com/user-attachments/assets/5cf8138d-29a3-42a8-b5fd-986e573205f0)
