### PR TITLE
ci: Make waiting for the test server more reliable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -248,7 +248,11 @@ jobs:
         run: |
           echo "<html><body><h1>Example</h1><p>This is an example page.</p></body></html>" >example.html
           python3 -m http.server --bind localhost 12345 &
-          sleep 5 # Sometimes the server isn't ready by the time the tui starts.
+          # Wait for the server to start.
+          while ! curl --output /dev/null --silent --head --fail http://localhost:12345/example.html; do
+            sleep 1 && echo -n ?
+          done
+          echo "!"
           bazel run browser:tui http://localhost:12345/example.html
       - run: bazel run browser -- --exit-after-load http://localhost:12345/example.html
 


### PR DESCRIPTION
CI occasionally fails w/
```
[2025-03-06 18:57:02.357] [I] Navigating to http://localhost:12345/example.html
[2025-03-06 18:57:06.383] [E] Error loading "http://localhost:12345/example.html": Unresolved
```

Hopefully this fixes that.