### PR TITLE
render: Switch to draw_rect for drawing rects in the debug painting

### DIFF
--- a/gfx/canvas_command_saver.h
+++ b/gfx/canvas_command_saver.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -49,13 +49,6 @@ struct ClearCmd {
     [[nodiscard]] constexpr bool operator==(ClearCmd const &) const = default;
 };
 
-struct FillRectCmd {
-    geom::Rect rect{};
-    Color color{};
-
-    [[nodiscard]] constexpr bool operator==(FillRectCmd const &) const = default;
-};
-
 struct DrawRectCmd {
     geom::Rect rect{};
     Color color{};
@@ -98,7 +91,6 @@ using CanvasCommand = std::variant<SetViewportSizeCmd,
         SetScaleCmd,
         AddTranslationCmd,
         ClearCmd,
-        FillRectCmd,
         DrawRectCmd,
         DrawTextWithFontOptionsCmd,
         DrawTextCmd,
@@ -111,7 +103,6 @@ public:
     void set_scale(int scale) override { cmds_.emplace_back(SetScaleCmd{scale}); }
     void add_translation(int dx, int dy) override { cmds_.emplace_back(AddTranslationCmd{dx, dy}); }
     void clear(Color c) override { cmds_.emplace_back(ClearCmd{c}); }
-    void fill_rect(geom::Rect const &rect, Color color) override { cmds_.emplace_back(FillRectCmd{rect, color}); }
     void draw_rect(
             geom::Rect const &rect, Color const &color, Borders const &borders, Corners const &corners) override {
         cmds_.emplace_back(DrawRectCmd{rect, color, borders, corners});
@@ -158,7 +149,6 @@ public:
     constexpr void operator()(SetScaleCmd const &cmd) { canvas_.set_scale(cmd.scale); }
     constexpr void operator()(AddTranslationCmd const &cmd) { canvas_.add_translation(cmd.dx, cmd.dy); }
     constexpr void operator()(ClearCmd const &cmd) { canvas_.clear(cmd.color); }
-    constexpr void operator()(FillRectCmd const &cmd) { canvas_.fill_rect(cmd.rect, cmd.color); }
 
     constexpr void operator()(DrawRectCmd const &cmd) {
         canvas_.draw_rect(cmd.rect, cmd.color, cmd.borders, cmd.corners);

--- a/gfx/canvas_command_saver_test.cpp
+++ b/gfx/canvas_command_saver_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -60,12 +60,6 @@ int main() {
         a.expect_eq(saver.take_commands(), CanvasCommands{ClearCmd{{0xab, 0xcd, 0xef}}});
     });
 
-    s.add_test("CanvasCommandSaver::fill_rect", [](etest::IActions &a) {
-        CanvasCommandSaver saver;
-        saver.fill_rect({1, 2, 3, 4}, {0xab, 0xcd, 0xef});
-        a.expect_eq(saver.take_commands(), CanvasCommands{FillRectCmd{{1, 2, 3, 4}, {0xab, 0xcd, 0xef}}});
-    });
-
     s.add_test("CanvasCommandSaver::draw_border", [](etest::IActions &a) {
         CanvasCommandSaver saver;
 
@@ -115,7 +109,7 @@ int main() {
         saver.set_viewport_size(1, 2);
         saver.set_scale(1);
         saver.add_translation(1234, 5678);
-        saver.fill_rect({9, 9, 9, 9}, {0x12, 0x34, 0x56});
+        saver.draw_rect({9, 9, 9, 9}, {0x12, 0x34, 0x56}, {}, {});
         saver.draw_rect({9, 9, 9, 9}, {0x10, 0x11, 0x12}, {}, {});
         saver.draw_text({10, 10}, "beep beep boop!"sv, {"helvetica"}, {42}, {.italic = true}, {3, 2, 1});
         saver.draw_text({1, 5}, "hello?"sv, {{{"font1"}, {"font2"}}}, {42}, {}, {1, 2, 3});

--- a/gfx/gfx_example.cpp
+++ b/gfx/gfx_example.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -57,8 +57,8 @@ int main(int argc, char **argv) {
 
         canvas->clear(gfx::Color{0xFF, 0xFF, 0xFF});
 
-        canvas->fill_rect({200, 200, 100, 100}, gfx::Color{0, 0, 0xAA});
-        canvas->fill_rect({x / 4 + 50, y / 3 + 50, x / 2, y / 3}, gfx::Color{0xAA, 0, 0, 0x33});
+        canvas->draw_rect({200, 200, 100, 100}, gfx::Color{0, 0, 0xAA}, {}, {});
+        canvas->draw_rect({x / 4 + 50, y / 3 + 50, x / 2, y / 3}, gfx::Color{0xAA, 0, 0, 0x33}, {}, {});
 
         canvas->draw_rect({400, 100, 50, 50}, gfx::Color{80, 80, 80}, {}, {.top_right{50, 50}, .bottom_left{25, 25}});
 

--- a/gfx/icanvas.h
+++ b/gfx/icanvas.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -48,7 +48,6 @@ public:
     virtual void set_scale(int scale) = 0;
     virtual void add_translation(int dx, int dy) = 0;
     virtual void clear(Color) = 0;
-    virtual void fill_rect(geom::Rect const &, Color) = 0;
     virtual void draw_rect(geom::Rect const &, Color const &, Borders const &, Corners const &) = 0;
     virtual void draw_text(geom::Position, std::string_view, std::span<Font const>, FontSize, FontStyle, Color) = 0;
     virtual void draw_text(geom::Position, std::string_view, Font, FontSize, FontStyle, Color) = 0;

--- a/gfx/opengl_canvas.cpp
+++ b/gfx/opengl_canvas.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -50,13 +50,6 @@ void OpenGLCanvas::set_viewport_size(int width, int height) {
 void OpenGLCanvas::clear(Color c) {
     glClearColor(c.r / 255.f, c.g / 255.f, c.b / 255.f, c.a / 255.f);
     glClear(GL_COLOR_BUFFER_BIT);
-}
-
-void OpenGLCanvas::fill_rect(geom::Rect const &rect, Color color) {
-    auto translated{rect.translated(translation_x_, translation_y_)};
-    auto scaled{translated.scaled(scale_)};
-    glColor4ub(color.r, color.g, color.b, color.a);
-    glRecti(scaled.x, scaled.y, scaled.x + scaled.width, scaled.y + scaled.height);
 }
 
 void OpenGLCanvas::draw_rect(

--- a/gfx/opengl_canvas.h
+++ b/gfx/opengl_canvas.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -32,7 +32,6 @@ public:
     }
 
     void clear(Color) override;
-    void fill_rect(geom::Rect const &, Color) override;
     void draw_rect(geom::Rect const &, Color const &, Borders const &, Corners const &) override;
     void draw_text(geom::Position, std::string_view, std::span<Font const>, FontSize, FontStyle, Color) override {}
     void draw_text(geom::Position, std::string_view, Font, FontSize, FontStyle, Color) override {}

--- a/gfx/sfml_canvas.cpp
+++ b/gfx/sfml_canvas.cpp
@@ -137,16 +137,6 @@ void SfmlCanvas::clear(Color c) {
     textures_.clear();
 }
 
-void SfmlCanvas::fill_rect(geom::Rect const &rect, Color color) {
-    auto translated{rect.translated(tx_, ty_)};
-    auto scaled{translated.scaled(scale_)};
-
-    sf::RectangleShape drawable{{static_cast<float>(scaled.width), static_cast<float>(scaled.height)}};
-    drawable.setPosition({static_cast<float>(scaled.x), static_cast<float>(scaled.y)});
-    drawable.setFillColor(sf::Color{color.r, color.g, color.b, color.a});
-    target_.draw(drawable);
-}
-
 void SfmlCanvas::draw_rect(geom::Rect const &rect, Color const &color, Borders const &borders, Corners const &corners) {
     auto translated{rect.translated(tx_, ty_)};
     auto inner_rect{translated.scaled(scale_)};

--- a/gfx/sfml_canvas.h
+++ b/gfx/sfml_canvas.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -40,7 +40,6 @@ public:
     }
 
     void clear(Color) override;
-    void fill_rect(geom::Rect const &, Color) override;
     void draw_rect(geom::Rect const &, Color const &, Borders const &, Corners const &) override;
     void draw_text(geom::Position, std::string_view, std::span<Font const>, FontSize, FontStyle, Color) override;
     void draw_text(geom::Position, std::string_view, Font, FontSize, FontStyle, Color) override;

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -199,7 +199,7 @@ namespace {
 
 // NOLINTNEXTLINE(misc-no-recursion)
 void render_layout_depth_impl(gfx::ICanvas &painter, layout::LayoutBox const &layout) {
-    painter.fill_rect(layout.dimensions.padding_box(), {0xFF, 0xFF, 0xFF, 0x30});
+    painter.draw_rect(layout.dimensions.padding_box(), {0xFF, 0xFF, 0xFF, 0x30}, {}, {});
     for (auto const &child : layout.children) {
         render_layout_depth_impl(painter, child);
     }

--- a/render/render_test.cpp
+++ b/render/render_test.cpp
@@ -102,9 +102,9 @@ int main() {
         gfx::Color c{0xFF, 0xFF, 0xFF, 0x30};
         a.expect_eq(saver.take_commands(),
                 CanvasCommands{gfx::ClearCmd{},
-                        gfx::FillRectCmd{{10, 20, 100, 100}, c},
-                        gfx::FillRectCmd{{10, 20, 10, 10}, c},
-                        gfx::FillRectCmd{{10, 30, 10, 10}, c}});
+                        gfx::DrawRectCmd{{10, 20, 100, 100}, c},
+                        gfx::DrawRectCmd{{10, 20, 10, 10}, c},
+                        gfx::DrawRectCmd{{10, 30, 10, 10}, c}});
     });
 
     s.add_test("render block with transparent background-color", [](etest::IActions &a) {


### PR DESCRIPTION
This was literally the only place in the codebase where we still used
fill_rect, and draw_rect can do everything fill_rect can, so no point in
keeping it like this.