### PR TITLE
img/png: Fix assertion failure when fed 16-bitdepth images

### DIFF
--- a/img/png.cpp
+++ b/img/png.cpp
@@ -68,6 +68,7 @@ std::optional<Png> Png::from(std::istream &is) {
     png_read_info(png, info);
 
     png_set_expand(png);
+    png_set_scale_16(png);
     png_set_gray_to_rgb(png);
     png_set_add_alpha(png, 0xff, PNG_FILLER_AFTER);
     int const interlacing_passes = png_set_interlace_handling(png);


### PR DESCRIPTION

![cruel image in 16-bitdepth format](https://github.com/user-attachments/assets/1cdd2c6e-d1c4-41d0-8292-ab8b34aa606f)
^ this image was responsible for triggering an assertion failure when I was trying to read w3 specs. :(