### PR TITLE
css: Handle the rem unit in media queries

### DIFF
--- a/css/media_query.h
+++ b/css/media_query.h
@@ -237,7 +237,7 @@ private:
             return std::nullopt;
         }
 
-        if (value_unit == "em") {
+        if (value_unit == "em" || value_unit == "rem") {
             // TODO(robinlinden): Make configurable. Needs to match the default
             // font size in the StyledNode property calulations right now.
             static constexpr int kDefaultFontSize{16};

--- a/css/media_query_test.cpp
+++ b/css/media_query_test.cpp
@@ -53,6 +53,8 @@ void to_string_tests(etest::Suite &s) {
         // 1em == 16px right now. This will probably break when that's made configurable.
         a.expect_eq(css::to_string(css::MediaQuery::parse("(width: 10em)").value()), //
                 "160 <= width <= 160");
+        a.expect_eq(css::to_string(css::MediaQuery::parse("(width: 100rem)").value()), //
+                "1600 <= width <= 1600");
     });
 
     s.add_test("to_string: prefers-color-scheme", [](etest::IActions &a) {


### PR DESCRIPTION
This is in use on e.g. https://github.com.