### PR TITLE
layout: Make property accesses for anon blocks nicer

### DIFF
--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -396,9 +396,8 @@ void Layouter::layout_anonymous_block(LayoutBox &box, geom::Rect const &bounds, 
     box.dimensions.content.width = last_block_width;
     int last_child_end{};
     int current_line{};
-    auto font_size = type::Px{!box.children.empty() ? box.children[0].get_property<css::PropertyId::FontSize>() : 0};
-    auto font_families = !box.children.empty() ? box.children[0].get_property<css::PropertyId::FontFamily>()
-                                               : std::vector<std::string_view>{};
+    auto font_size = type::Px{box.get_property<css::PropertyId::FontSize>()};
+    auto font_families = box.get_property<css::PropertyId::FontFamily>();
 
     auto maybe_font = find_font(font_families);
     if (!maybe_font) {
@@ -407,8 +406,7 @@ void Layouter::layout_anonymous_block(LayoutBox &box, geom::Rect const &bounds, 
     }
     auto font = *maybe_font;
 
-    auto weight =
-            to_type(!box.children.empty() ? box.children[0].get_property<css::PropertyId::FontWeight>() : std::nullopt);
+    auto weight = to_type(box.get_property<css::PropertyId::FontWeight>());
 
     for (std::size_t i = 0; i < box.children.size(); ++i) {
         auto *child = &box.children[i];

--- a/layout/layout_box.h
+++ b/layout/layout_box.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -35,9 +35,19 @@ struct LayoutBox {
 
     template<css::PropertyId T>
     auto get_property() const {
-        // Calling get_property on an anonymous block (the only type that
-        // doesn't have a StyleNode) is a programming error.
-        assert(!is_anonymous_block());
+        if (is_anonymous_block()) {
+            if (css::is_inherited(T)) {
+                // TODO(robinlinden): Sad roundabout way of getting the parent.
+                // Make this nicer.
+                assert(!children.empty());
+                auto const *child = children.front().node;
+                assert(child != nullptr && child->parent != nullptr);
+                return child->parent->get_property<T>();
+            }
+
+            return style::initial_value<T>();
+        }
+
         assert(node);
         return node->get_property<T>();
     }

--- a/layout/layout_box_test.cpp
+++ b/layout/layout_box_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -12,6 +12,7 @@
 #include "dom/xpath.h"
 #include "etest/etest2.h"
 #include "style/styled_node.h"
+#include "style/unresolved_value.h"
 
 #include <cstddef>
 #include <string>
@@ -122,6 +123,9 @@ int main() {
                                 }},
                 },
         };
+
+        set_up_parent_ptrs(styled_node);
+
         auto layout = layout::create_layout(styled_node, 123).value();
 
         // Verify that we have a shady anon-box to deal with in here.
@@ -184,6 +188,10 @@ int main() {
                 "    p\n"
                 "    block {0,30,35,0} {5,15,0,0} {0,0,0,0}\n";
         a.expect_eq(to_string(layout::create_layout(style_root, 0).value()), expected);
+    });
+
+    s.add_test("anonymous block, get_property", [](etest::IActions &a) {
+        a.expect_eq(layout::LayoutBox{}.get_property<css::PropertyId::Width>(), style::UnresolvedValue{"auto"});
     });
 
     return s.run();

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -930,6 +930,8 @@ int main() {
             },
         };
 
+        set_up_parent_ptrs(style_root);
+
         auto expected_layout = layout::LayoutBox{
             .node = &style_root,
             .dimensions = {},

--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -224,6 +224,16 @@ inline std::vector<StyledNode const *> dom_children(StyledNode const &node) {
     return children;
 }
 
+template<css::PropertyId T>
+inline auto initial_value() {
+    // Sad roundabout way of getting css::initial_value(T) parsed via the
+    // StyledNode property system.
+    // TODO(robinlinden): Don't require dummy nodes for this.
+    dom::Node dom{};
+    style::StyledNode style{.node = dom};
+    return style.get_property<T>();
+}
+
 } // namespace style
 
 #endif

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -659,5 +659,15 @@ int main() {
         expect_property_eq<MaxWidth>(a, "none", style::UnresolvedValue{"none"});
     });
 
+    s.add_test("style::initial_value", [](etest::IActions &a) {
+        a.expect_eq(style::initial_value<css::PropertyId::Width>(), style::UnresolvedValue{"auto"});
+        a.expect_eq(style::initial_value<css::PropertyId::FontSize>(), 16);
+        a.expect_eq(style::initial_value<css::PropertyId::FontWeight>(), style::FontWeight::normal());
+        a.expect_eq(style::initial_value<css::PropertyId::FontStyle>(), style::FontStyle::Normal);
+        a.expect_eq(style::initial_value<css::PropertyId::TextAlign>(), style::TextAlign::Left);
+        a.expect_eq(style::initial_value<css::PropertyId::TextDecorationLine>(),
+                std::vector{style::TextDecorationLine::None});
+    });
+
     return s.run();
 }


### PR DESCRIPTION
Due to the way the parent ptr is found, LayoutBox::get_property now
requires that the parent ptrs in the style tree are correctly set.