### PR TITLE
css2: Fix invalid escapes being allowed if not first in idents

### DIFF
--- a/css2/tokenizer.cpp
+++ b/css2/tokenizer.cpp
@@ -567,7 +567,7 @@ std::string Tokenizer::consume_an_ident_sequence(char first_byte) {
             continue;
         }
 
-        if (*c == '\\') {
+        if (is_valid_escape_sequence(*c, peek_input(0))) {
             result += consume_an_escaped_code_point();
             continue;
         }

--- a/css2/tokenizer.h
+++ b/css2/tokenizer.h
@@ -22,7 +22,6 @@ namespace css2 {
 // https://www.w3.org/TR/css-syntax-3/#tokenizer-algorithms
 enum class State : std::uint8_t {
     Main,
-    CommercialAt,
     IdentLike,
 };
 

--- a/css2/tokenizer.h
+++ b/css2/tokenizer.h
@@ -22,9 +22,6 @@ namespace css2 {
 // https://www.w3.org/TR/css-syntax-3/#tokenizer-algorithms
 enum class State : std::uint8_t {
     Main,
-    CommentStart,
-    Comment,
-    CommentEnd,
     CommercialAt,
     IdentLike,
 };
@@ -73,6 +70,7 @@ private:
     [[nodiscard]] std::string consume_an_ident_sequence(char first_byte);
     [[nodiscard]] Token consume_a_url_token();
     void consume_the_remnants_of_a_bad_url();
+    void consume_comments();
 };
 
 } // namespace css2

--- a/css2/tokenizer.h
+++ b/css2/tokenizer.h
@@ -22,7 +22,6 @@ namespace css2 {
 // https://www.w3.org/TR/css-syntax-3/#tokenizer-algorithms
 enum class State : std::uint8_t {
     Main,
-    IdentLike,
 };
 
 enum class ParseError : std::uint8_t {
@@ -67,6 +66,7 @@ private:
     std::string consume_an_escaped_code_point();
     Token consume_a_numeric_token(char first_byte);
     [[nodiscard]] std::string consume_an_ident_sequence(char first_byte);
+    [[nodiscard]] Token consume_an_identlike_token(char first_byte);
     [[nodiscard]] Token consume_a_url_token();
     void consume_the_remnants_of_a_bad_url();
     void consume_comments();

--- a/css2/tokenizer.h
+++ b/css2/tokenizer.h
@@ -19,11 +19,6 @@
 
 namespace css2 {
 
-// https://www.w3.org/TR/css-syntax-3/#tokenizer-algorithms
-enum class State : std::uint8_t {
-    Main,
-};
-
 enum class ParseError : std::uint8_t {
     DisallowedCharacterInUrl,
     EofInComment,
@@ -46,7 +41,6 @@ public:
 private:
     std::string_view input_;
     std::size_t pos_{0};
-    State state_{State::Main};
 
     std::function<void(Token &&)> on_emit_;
     std::function<void(ParseError)> on_error_;
@@ -59,7 +53,6 @@ private:
     bool inputs_starts_number(char first_character) const;
     bool is_eof() const;
     void reconsume();
-    void reconsume_in(State);
 
     Token consume_string(char ending_code_point);
     std::variant<std::int32_t, double> consume_number(char first_byte);

--- a/css2/tokenizer_test.cpp
+++ b/css2/tokenizer_test.cpp
@@ -333,6 +333,14 @@ int main() {
         expect_token(output, WhitespaceToken{});
     });
 
+    s.add_test("at keyword start, but with bad escape later", [](etest::IActions &a) {
+        auto output = run_tokenizer(a, "@aaa\\\n");
+        expect_token(output, AtKeywordToken{"aaa"});
+        expect_error(output, ParseError::InvalidEscapeSequence);
+        expect_token(output, DelimToken{'\\'});
+        expect_token(output, WhitespaceToken{});
+    });
+
     s.add_test("at keyword token with digit", [](etest::IActions &a) {
         auto output = run_tokenizer(a, "@b4z");
 


### PR DESCRIPTION
This also simplifies the tokenizer by not having any states aside from what used to be the "main" state. This was mostly so that it was easier to compare things to the spec when checking that things look correct, but it also both removes a lot of code and flattens what's left.