### PR TITLE
url: Update parsing to work w/ newer wpt

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -5,3 +5,8 @@ ignore=body-is-missing
 # Each commit must start with the main area it affects.
 [title-match-regex]
 regex=^(archive|azm|browser|bzl|css|css2|dom|dom2|engine|etest|geom|gfx|html|html2|idna|img|js|json|layout|net|os|protocol|render|style|tui|type|unicode|uri|url|util|wasm|all|build|ci|deps|doc|meta)(/.*|\+.*)?:
+
+# Splitting git trailers, e.g. the references to commits in other repos, into
+# two lines is silly.
+[ignore-body-lines]
+regex=^See:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -740,13 +740,13 @@ EOF""",
     url = "https://github.com/KhronosGroup/Vulkan-Hpp/archive/v%s.tar.gz" % VULKAN_TAG,
 )
 
-# HEAD, last updated at 2025-03-05.
+# HEAD, last updated at 2025-04-17.
 # https://github.com/web-platform-tests/wpt/blob/master/url/resources/urltestdata.json
-WPT_REVISION = "d2c39364360cfa39ce900f643f55ca6ef7b33093"
+WPT_REVISION = "048018b5af85f8d47b8a704b48cf6f9c0a461876"
 
 http_file(
     name = "wpt_urltestdata",
-    integrity = "sha256-uEvEsGs4NzOPiClE4EWUtsNzGtIGUV8TieQqFR9xM4E=",
+    integrity = "sha256-V4MdYOxP+cF7e1eftgpS3yWpXgcgjKGeM9tfbmjXpuc=",
     url = "https://raw.githubusercontent.com/web-platform-tests/wpt/%s/url/resources/urltestdata.json" % WPT_REVISION,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -740,13 +740,13 @@ EOF""",
     url = "https://github.com/KhronosGroup/Vulkan-Hpp/archive/v%s.tar.gz" % VULKAN_TAG,
 )
 
-# HEAD as of 2025-01-28.
+# HEAD, last updated at 2025-03-05.
 # https://github.com/web-platform-tests/wpt/blob/master/url/resources/urltestdata.json
-WPT_REVISION = "45e7dd49afae442ab0bb56b00d72dd138a4b47e9"
+WPT_REVISION = "d2c39364360cfa39ce900f643f55ca6ef7b33093"
 
 http_file(
     name = "wpt_urltestdata",
-    integrity = "sha256-3519vF5rx/YZyC1lgUjXg/DaltvGu4DqWpCubPiuo+A=",
+    integrity = "sha256-uEvEsGs4NzOPiClE4EWUtsNzGtIGUV8TieQqFR9xM4E=",
     url = "https://raw.githubusercontent.com/web-platform-tests/wpt/%s/url/resources/urltestdata.json" % WPT_REVISION,
 )
 

--- a/url/percent_encode.h
+++ b/url/percent_encode.h
@@ -23,6 +23,7 @@
 
 namespace url {
 
+// https://url.spec.whatwg.org/#percent-encoded-bytes
 struct PercentEncodeSet {
     static constexpr bool c0_control(char c) {
         return util::is_c0(c) || c == 0x7f || static_cast<std::uint8_t>(c) > 0x7f;
@@ -38,10 +39,10 @@ struct PercentEncodeSet {
 
     static constexpr bool special_query(char c) { return query(c) || c == '\''; }
 
-    static constexpr bool path(char c) { return query(c) || c == '?' || c == '`' || c == '{' || c == '}'; }
+    static constexpr bool path(char c) { return query(c) || c == '?' || c == '^' || c == '`' || c == '{' || c == '}'; }
 
     static constexpr bool userinfo(char c) {
-        return path(c) || c == '/' || c == ':' || c == ';' || c == '=' || c == '@' || (c >= '[' && c <= '^')
+        return path(c) || c == '/' || c == ':' || c == ';' || c == '=' || c == '@' || (c >= '[' && c <= ']')
                 || c == '|';
     }
 


### PR DESCRIPTION
Both commits are simple changes to comply w/ the newer spec versions. The spec changes are linked in the corresponding commits.