### PR TITLE
util/string: Switch split_once to take a char delimiter

### DIFF
--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -687,7 +687,7 @@ void Parser::expand_border_radius_values(Declarations &declarations, std::string
     std::string top_right;
     std::string bottom_right;
     std::string bottom_left;
-    auto [horizontal, vertical] = util::split_once(value, "/");
+    auto [horizontal, vertical] = util::split_once(value, '/');
     Tokenizer tokenizer(horizontal, ' ');
 
     auto unchecked_get = [](Tokenizer &t) -> std::string_view {

--- a/protocol/http.cpp
+++ b/protocol/http.cpp
@@ -94,7 +94,7 @@ std::optional<StatusLine> Http::parse_status_line(std::string_view status_line) 
 Headers Http::parse_headers(std::string_view header) {
     Headers headers;
     for (auto sep = header.find("\r\n"); sep != std::string_view::npos; sep = header.find("\r\n")) {
-        auto kv = util::split_once(header.substr(0, sep), ":");
+        auto kv = util::split_once(header.substr(0, sep), ':');
         if (is_valid_header(kv)) {
             kv.second = util::trim(kv.second);
             headers.add(std::move(kv));
@@ -103,7 +103,7 @@ Headers Http::parse_headers(std::string_view header) {
         header.remove_prefix(sep + 2);
     }
 
-    auto kv = util::split_once(header, ":");
+    auto kv = util::split_once(header, ':');
     if (is_valid_header(kv)) {
         kv.second = util::trim(kv.second);
         headers.add(std::move(kv));

--- a/style/style.cpp
+++ b/style/style.cpp
@@ -45,7 +45,7 @@ bool contains_class(std::string_view classes, std::string_view needle_class) {
 bool is_match(style::StyledNode const &node, std::string_view selector) {
     auto const &element = std::get<dom::Element>(node.node);
     // https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
-    auto [selector_, psuedo_class] = util::split_once(selector, ":");
+    auto [selector_, psuedo_class] = util::split_once(selector, ':');
 
     // https://developer.mozilla.org/en-US/docs/Web/CSS/Child_combinator
     if (selector_.contains('>')) {
@@ -169,12 +169,12 @@ bool is_match(style::StyledNode const &node, std::string_view selector) {
     // https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors
     if (selector_.starts_with('[') && selector_.contains(']')) {
         selector_.remove_prefix(1);
-        auto [attr, rest] = util::split_once(selector_, "]");
+        auto [attr, rest] = util::split_once(selector_, ']');
         if (!rest.empty() && !is_match(node, rest)) {
             return false;
         }
 
-        auto [key, value] = util::split_once(attr, "=");
+        auto [key, value] = util::split_once(attr, '=');
         if (value.empty()) {
             return element.attributes.contains(key);
         }

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -282,7 +282,7 @@ std::optional<std::string_view> StyledNode::resolve_variable(std::string_view va
     while (is_var(value)) {
         // Remove "var(" from the start and ")" from the end. 5 characters in total.
         auto var = value.substr(4, value.size() - 5);
-        auto [var_name, fallback] = util::split_once(var, ",");
+        auto [var_name, fallback] = util::split_once(var, ',');
 
         std::optional<std::string_view> prop;
         for (auto const *current = this; current != nullptr; current = current->parent) {
@@ -787,7 +787,7 @@ std::optional<WhiteSpace> StyledNode::get_white_space_property() const {
 
 std::pair<int, int> StyledNode::get_border_radius_property(css::PropertyId id) const {
     auto raw = get_raw_property(id);
-    auto [horizontal, vertical] = raw.contains('/') ? util::split_once(raw, "/") : std::pair{raw, raw};
+    auto [horizontal, vertical] = raw.contains('/') ? util::split_once(raw, '/') : std::pair{raw, raw};
     auto horizontal_prop = UnresolvedValue{horizontal};
     auto vertical_prop = UnresolvedValue{vertical};
 

--- a/util/string.h
+++ b/util/string.h
@@ -107,9 +107,9 @@ constexpr std::vector<std::string_view> split(std::string_view str, std::string_
     return result;
 }
 
-constexpr std::pair<std::string_view, std::string_view> split_once(std::string_view str, std::string_view sep) {
+constexpr std::pair<std::string_view, std::string_view> split_once(std::string_view str, char sep) {
     if (auto p = str.find(sep); p != std::string_view::npos) {
-        return {str.substr(0, p), str.substr(p + sep.size())};
+        return {str.substr(0, p), str.substr(p + 1)};
     }
     return {str, ""};
 }

--- a/util/string_test.cpp
+++ b/util/string_test.cpp
@@ -178,37 +178,30 @@ int main() {
         a.expect_eq(s[5], "");
     });
 
-    es.add_test("split once, single char delimiter", [](etest::IActions &a) {
+    es.constexpr_test("split once, single char delimiter", [](etest::IActions &a) {
         std::string_view str{"a,b,c,d"};
-        auto p = split_once(str, ",");
+        auto p = split_once(str, ',');
         a.expect_eq(p.first, "a");
         a.expect_eq(p.second, "b,c,d");
     });
 
-    es.add_test("split once, multi char delimiter", [](etest::IActions &a) {
-        std::string_view str{"abcccde"};
-        auto p = split_once(str, "ccc");
-        a.expect_eq(p.first, "ab");
-        a.expect_eq(p.second, "de");
-    });
-
-    es.add_test("split once, delimiter at start", [](etest::IActions &a) {
+    es.constexpr_test("split once, delimiter at start", [](etest::IActions &a) {
         std::string_view str{",a"};
-        auto p = split_once(str, ",");
+        auto p = split_once(str, ',');
         a.expect_eq(p.first, "");
         a.expect_eq(p.second, "a");
     });
 
-    es.add_test("split once, delimiter at end", [](etest::IActions &a) {
+    es.constexpr_test("split once, delimiter at end", [](etest::IActions &a) {
         std::string_view str{"a,"};
-        auto p = split_once(str, ",");
+        auto p = split_once(str, ',');
         a.expect_eq(p.first, "a");
         a.expect_eq(p.second, "");
     });
 
-    es.add_test("split once, only delimiter", [](etest::IActions &a) {
+    es.constexpr_test("split once, only delimiter", [](etest::IActions &a) {
         std::string_view str{","};
-        auto p = split_once(str, ",");
+        auto p = split_once(str, ',');
         a.expect_eq(p.first, "");
         a.expect_eq(p.second, "");
     });


### PR DESCRIPTION
The only place we used a multi-char delimiter was in a unit test, so no real need to support that use-case.