### PR TITLE
render: Work around image px-count/layout-size mismatch

### DIFF
--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -377,6 +377,7 @@ void Layouter::layout_inline(LayoutBox &box, geom::Rect const &bounds, int last_
 
 // NOLINTNEXTLINE(misc-no-recursion)
 void Layouter::layout_block(LayoutBox &box, geom::Rect const &bounds, int last_block_width) const {
+    // TODO(robinlinden): Support <img> sizing. Enable block <img> in //render once done.
     assert(box.node);
     auto font_size = box.get_property<css::PropertyId::FontSize>();
     calculate_padding(box, font_size);

--- a/render/render.cpp
+++ b/render/render.cpp
@@ -121,7 +121,9 @@ void render_image(gfx::ICanvas &painter, layout::LayoutBox const &layout, ImageV
 std::optional<std::string_view> get_image_id(layout::LayoutBox const &layout) {
     assert(!layout.is_anonymous_block());
     auto const *img = std::get_if<dom::Element>(&layout.node->node);
-    if (img == nullptr || img->name != "img") {
+    // TODO(robinlinden): Allow images for `display: block` once hooked up in the layout system.
+    if (img == nullptr || img->name != "img"
+            || layout.get_property<css::PropertyId::Display>() == style::Display::block_flow()) {
         return {};
     }
 

--- a/render/render_test.cpp
+++ b/render/render_test.cpp
@@ -200,6 +200,12 @@ int main() {
         a.expect_eq(saver.take_commands(),
                 CanvasCommands{gfx::ClearCmd{{0xFF, 0xFF, 0xFF}}, gfx::DrawPixelsCmd{{0, 0, 1, 3}, img}});
 
+        // Failure: blocks aren't supported yet
+        styled.properties = {{css::PropertyId::Display, "block"}};
+        render::render_layout(saver, layout, {}, get_img_success);
+        a.expect_eq(saver.take_commands(), CanvasCommands{gfx::ClearCmd{{0xFF, 0xFF, 0xFF}}});
+        styled.properties.clear();
+
         // Failure: image not found
         render::render_layout(saver, layout, {}, get_img_failure);
         a.expect_eq(saver.take_commands(), CanvasCommands{gfx::ClearCmd{{0xFF, 0xFF, 0xFF}}});


### PR DESCRIPTION
The assertion failure is because we don't have any image scaling in place, and we only handle image sizes when doing inline layouts currently, so `display: block` on an `<img>`-tag can lead to the number of image bytes not matching what we need.

This assertion failure could be triggered in the wild on e.g. https://formspree.io/.