### PR TITLE
protocol: Support multiple http headers w/ the same key

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -831,7 +831,7 @@ void App::run_debug_widget() const {
     }
 
     if (ImGui::Button("Response headers")) {
-        std::cout << "\nResponse headers:\n" << page().response.headers.to_string() << '\n';
+        std::cout << "\nResponse headers:\n" << protocol::to_string(page().response.headers) << '\n';
     }
 
     if (ImGui::Button("Response body")) {

--- a/protocol/http.cpp
+++ b/protocol/http.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -97,7 +97,7 @@ Headers Http::parse_headers(std::string_view header) {
         auto kv = util::split_once(header.substr(0, sep), ':');
         if (is_valid_header(kv)) {
             kv.second = util::trim(kv.second);
-            headers.add(std::move(kv));
+            headers.emplace(kv);
         }
 
         header.remove_prefix(sep + 2);
@@ -106,7 +106,7 @@ Headers Http::parse_headers(std::string_view header) {
     auto kv = util::split_once(header, ':');
     if (is_valid_header(kv)) {
         kv.second = util::trim(kv.second);
-        headers.add(std::move(kv));
+        headers.emplace(kv);
     }
 
     return headers;

--- a/protocol/http.h
+++ b/protocol/http.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -54,8 +54,8 @@ public:
             return tl::unexpected{Error{ErrorCode::InvalidResponse, std::move(status_line)}};
         }
 
-        auto encoding = headers.get("transfer-encoding"sv);
-        if (encoding == "chunked"sv) {
+        auto encoding = headers.find("transfer-encoding"sv);
+        if (encoding != headers.end() && encoding->second == "chunked"sv) {
             auto body = Http::get_chunked_body(socket);
             if (!body) {
                 return tl::unexpected{Error{ErrorCode::InvalidResponse, std::move(status_line)}};

--- a/protocol/http_test.cpp
+++ b/protocol/http_test.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2021-2022 Mikael Larsson <c.mikael.larsson@gmail.com>
-// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -75,19 +75,19 @@ int main() {
         a.expect_eq(response.status_line.version, "HTTP/1.1");
         a.expect_eq(response.status_line.status_code, 200);
         a.expect_eq(response.status_line.reason, "OK");
-        a.expect_eq(response.headers.get("Content-Encoding"sv).value(), "gzip");
-        a.expect_eq(response.headers.get("Accept-Ranges"sv).value(), "bytes");
-        a.expect_eq(response.headers.get("Age"sv).value(), "367849");
-        a.expect_eq(response.headers.get("Cache-Control"sv).value(), "max-age=604800");
-        a.expect_eq(response.headers.get("Content-Type"sv).value(), "text/html; charset=UTF-8");
-        a.expect_eq(response.headers.get("Date"sv).value(), "Mon, 25 Oct 2021 19:48:04 GMT");
-        a.expect_eq(response.headers.get("Etag"sv).value(), R"("3147526947")");
-        a.expect_eq(response.headers.get("Expires"sv).value(), "Mon, 01 Nov 2021 19:48:04 GMT");
-        a.expect_eq(response.headers.get("Last-Modified"sv).value(), "Thu, 17 Oct 2019 07:18:26 GMT");
-        a.expect_eq(response.headers.get("Server"sv).value(), "ECS (nyb/1D2A)");
-        a.expect_eq(response.headers.get("Vary"sv).value(), "Accept-Encoding");
-        a.expect_eq(response.headers.get("X-Cache"sv).value(), "HIT");
-        a.expect_eq(response.headers.get("Content-Length"sv).value(), "123");
+        a.expect_eq(response.headers.find("Content-Encoding"sv)->second, "gzip");
+        a.expect_eq(response.headers.find("Accept-Ranges"sv)->second, "bytes");
+        a.expect_eq(response.headers.find("Age"sv)->second, "367849");
+        a.expect_eq(response.headers.find("Cache-Control"sv)->second, "max-age=604800");
+        a.expect_eq(response.headers.find("Content-Type"sv)->second, "text/html; charset=UTF-8");
+        a.expect_eq(response.headers.find("Date"sv)->second, "Mon, 25 Oct 2021 19:48:04 GMT");
+        a.expect_eq(response.headers.find("Etag"sv)->second, R"("3147526947")");
+        a.expect_eq(response.headers.find("Expires"sv)->second, "Mon, 01 Nov 2021 19:48:04 GMT");
+        a.expect_eq(response.headers.find("Last-Modified"sv)->second, "Thu, 17 Oct 2019 07:18:26 GMT");
+        a.expect_eq(response.headers.find("Server"sv)->second, "ECS (nyb/1D2A)");
+        a.expect_eq(response.headers.find("Vary"sv)->second, "Accept-Encoding");
+        a.expect_eq(response.headers.find("X-Cache"sv)->second, "HIT");
+        a.expect_eq(response.headers.find("Content-Length"sv)->second, "123");
         a.expect_eq(response.body,
                 "<!doctype html>\n"
                 "<html>\n"

--- a/protocol/response.cpp
+++ b/protocol/response.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -8,14 +8,20 @@
 #include "util/string.h"
 
 #include <algorithm>
-#include <cstddef>
-#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
 
 namespace protocol {
+namespace detail {
+
+bool CaseInsensitiveLess::operator()(std::string_view s1, std::string_view s2) const {
+    return std::ranges::lexicographical_compare(
+            s1, s2, [](char c1, char c2) { return util::lowercased(c1) < util::lowercased(c2); });
+}
+
+} // namespace detail
 
 std::string_view to_string(ErrorCode e) {
     switch (e) {
@@ -31,32 +37,12 @@ std::string_view to_string(ErrorCode e) {
     return "Unknown";
 }
 
-void Headers::add(std::pair<std::string_view, std::string_view> nv) {
-    headers_.emplace(nv);
-}
-
-std::optional<std::string_view> Headers::get(std::string_view name) const {
-    auto it = headers_.find(name);
-    if (it != cend(headers_)) {
-        return it->second;
-    }
-    return std::nullopt;
-}
-std::string Headers::to_string() const {
+std::string to_string(Headers const &h) {
     std::stringstream ss{};
-    for (auto const &[name, value] : headers_) {
+    for (auto const &[name, value] : h) {
         ss << name << ": " << value << "\n";
     }
     return std::move(ss).str();
-}
-
-std::size_t Headers::size() const {
-    return headers_.size();
-}
-
-bool Headers::CaseInsensitiveLess::operator()(std::string_view s1, std::string_view s2) const {
-    return std::ranges::lexicographical_compare(
-            s1, s2, [](char c1, char c2) { return util::lowercased(c1) < util::lowercased(c2); });
 }
 
 } // namespace protocol

--- a/protocol/response.h
+++ b/protocol/response.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -6,16 +6,21 @@
 #ifndef PROTOCOL_RESPONSE_H_
 #define PROTOCOL_RESPONSE_H_
 
-#include <cstddef>
 #include <cstdint>
-#include <initializer_list>
 #include <map>
 #include <optional>
 #include <string>
 #include <string_view>
-#include <utility>
 
 namespace protocol {
+namespace detail {
+
+struct CaseInsensitiveLess {
+    using is_transparent = void;
+    bool operator()(std::string_view, std::string_view) const;
+};
+
+} // namespace detail
 
 enum class ErrorCode : std::uint8_t {
     Unresolved,
@@ -34,25 +39,9 @@ struct StatusLine {
     [[nodiscard]] bool operator==(StatusLine const &) const = default;
 };
 
-class Headers {
-public:
-    Headers() = default;
-    Headers(std::initializer_list<std::map<std::string, std::string>::value_type> init) : headers_{std::move(init)} {}
+using Headers = std::map<std::string, std::string, detail::CaseInsensitiveLess>;
 
-    void add(std::pair<std::string_view, std::string_view> nv);
-    [[nodiscard]] std::optional<std::string_view> get(std::string_view name) const;
-    [[nodiscard]] std::string to_string() const;
-    [[nodiscard]] std::size_t size() const;
-
-    [[nodiscard]] bool operator==(Headers const &) const = default;
-
-private:
-    struct CaseInsensitiveLess {
-        using is_transparent = void;
-        bool operator()(std::string_view s1, std::string_view s2) const;
-    };
-    std::map<std::string, std::string, CaseInsensitiveLess> headers_;
-};
+std::string to_string(Headers const &);
 
 struct Response {
     StatusLine status_line;

--- a/protocol/response.h
+++ b/protocol/response.h
@@ -39,7 +39,7 @@ struct StatusLine {
     [[nodiscard]] bool operator==(StatusLine const &) const = default;
 };
 
-using Headers = std::map<std::string, std::string, detail::CaseInsensitiveLess>;
+using Headers = std::multimap<std::string, std::string, detail::CaseInsensitiveLess>;
 
 std::string to_string(Headers const &);
 

--- a/protocol/response_test.cpp
+++ b/protocol/response_test.cpp
@@ -7,7 +7,6 @@
 
 #include "etest/etest2.h"
 
-#include <cstddef>
 #include <string_view>
 #include <type_traits>
 
@@ -15,26 +14,6 @@ using namespace std::string_view_literals;
 
 int main() {
     etest::Suite s;
-
-    s.add_test("headers", [](etest::IActions &a) {
-        protocol::Headers headers;
-
-        headers.add({"Transfer-Encoding", "chunked"});
-        headers.add({"Content-Type", "text/html"});
-
-        a.expect(!headers.get("foo"sv));
-        a.expect_eq(headers.get("Transfer-Encoding"sv).value(), "chunked");
-        a.expect_eq(headers.get("transfer-encoding"sv).value(), "chunked");
-        a.expect_eq(headers.get("CONTENT-TYPE"sv).value(), "text/html");
-        a.expect_eq(headers.get("cOnTeNt-TyPe"sv).value(), "text/html");
-    });
-
-    s.add_test("headers, init-list", [](etest::IActions &a) {
-        protocol::Headers headers{{"Content-Type", "text/html"}};
-        a.expect_eq(headers.size(), std::size_t{1});
-        a.expect_eq(headers.get("CONTENT-TYPE"sv).value(), "text/html");
-        a.expect_eq(headers.get("cOnTeNt-TyPe"sv).value(), "text/html");
-    });
 
     s.add_test("ErrorCode, to_string", [](etest::IActions &a) {
         using protocol::ErrorCode;
@@ -46,13 +25,13 @@ int main() {
         a.expect_eq(to_string(static_cast<ErrorCode>(std::underlying_type_t<ErrorCode>{20})), "Unknown"sv);
     });
 
-    s.add_test("Headers, to_string()", [](etest::IActions &a) {
+    s.add_test("to_string(Headers)", [](etest::IActions &a) {
         // We don't preserve the order of headers, so let's just test one header.
         protocol::Headers headers{
                 {"Set-Cookie", "hello"},
         };
 
-        a.expect_eq(headers.to_string(), "Set-Cookie: hello\n");
+        a.expect_eq(protocol::to_string(headers), "Set-Cookie: hello\n");
     });
 
     return s.run();

--- a/protocol/response_test.cpp
+++ b/protocol/response_test.cpp
@@ -7,22 +7,19 @@
 
 #include "etest/etest2.h"
 
-#include <string_view>
 #include <type_traits>
-
-using namespace std::string_view_literals;
 
 int main() {
     etest::Suite s;
 
     s.add_test("ErrorCode, to_string", [](etest::IActions &a) {
         using protocol::ErrorCode;
-        a.expect_eq(to_string(ErrorCode::Unresolved), "Unresolved"sv);
-        a.expect_eq(to_string(ErrorCode::Unhandled), "Unhandled"sv);
-        a.expect_eq(to_string(ErrorCode::InvalidResponse), "InvalidResponse"sv);
-        a.expect_eq(to_string(ErrorCode::RedirectLimit), "RedirectLimit"sv);
+        a.expect_eq(to_string(ErrorCode::Unresolved), "Unresolved");
+        a.expect_eq(to_string(ErrorCode::Unhandled), "Unhandled");
+        a.expect_eq(to_string(ErrorCode::InvalidResponse), "InvalidResponse");
+        a.expect_eq(to_string(ErrorCode::RedirectLimit), "RedirectLimit");
         // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
-        a.expect_eq(to_string(static_cast<ErrorCode>(std::underlying_type_t<ErrorCode>{20})), "Unknown"sv);
+        a.expect_eq(to_string(static_cast<ErrorCode>(std::underlying_type_t<ErrorCode>{20})), "Unknown");
     });
 
     s.add_test("to_string(Headers)", [](etest::IActions &a) {

--- a/protocol/response_test.cpp
+++ b/protocol/response_test.cpp
@@ -26,12 +26,13 @@ int main() {
     });
 
     s.add_test("to_string(Headers)", [](etest::IActions &a) {
-        // We don't preserve the order of headers, so let's just test one header.
+        // The insertion order is preserved for values with the same key.
         protocol::Headers headers{
                 {"Set-Cookie", "hello"},
+                {"Set-Cookie", "goodbye"},
         };
 
-        a.expect_eq(protocol::to_string(headers), "Set-Cookie: hello\n");
+        a.expect_eq(protocol::to_string(headers), "Set-Cookie: hello\nSet-Cookie: goodbye\n");
     });
 
     return s.run();

--- a/protocol/response_test.cpp
+++ b/protocol/response_test.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2021-2022 Mikael Larsson <c.mikael.larsson@gmail.com>
-// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -44,6 +44,15 @@ int main() {
         a.expect_eq(to_string(ErrorCode::RedirectLimit), "RedirectLimit"sv);
         // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
         a.expect_eq(to_string(static_cast<ErrorCode>(std::underlying_type_t<ErrorCode>{20})), "Unknown"sv);
+    });
+
+    s.add_test("Headers, to_string()", [](etest::IActions &a) {
+        // We don't preserve the order of headers, so let's just test one header.
+        protocol::Headers headers{
+                {"Set-Cookie", "hello"},
+        };
+
+        a.expect_eq(headers.to_string(), "Set-Cookie: hello\n");
     });
 
     return s.run();


### PR DESCRIPTION
This is often used for e.g. `Set-Cookie`, and this is work towards getting cookies working.