### PR TITLE
dom: Fix dom nodes being printed in the wrong order

### DIFF
--- a/dom/dom.cpp
+++ b/dom/dom.cpp
@@ -5,6 +5,7 @@
 #include "dom/dom.h"
 
 #include <ostream>
+#include <ranges>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -43,8 +44,8 @@ void print_node(dom::Node const &node, std::ostream &os, int initial_depth = 0) 
                 print_attribute(attribute, os, current_depth + 1);
             }
 
-            for (auto const &child : element->children) {
-                to_print.emplace(to_print.begin(), &child, current_depth + 1);
+            for (auto const &child : element->children | std::views::reverse) {
+                to_print.emplace_back(&child, current_depth + 1);
             }
         } else {
             os << '"' << std::get<dom::Text>(*current_node).text << '"';

--- a/dom/dom_test.cpp
+++ b/dom/dom_test.cpp
@@ -45,5 +45,32 @@ int main() {
         a.expect_eq(to_string(root), expected);
     });
 
+    s.add_test("to_string(Document) 2", [](etest::IActions &a) {
+        auto document = dom::Document{.doctype{"html5"}};
+        document.html_node = dom::Element{
+                .name{"html"},
+                .children{{
+                        dom::Element{
+                                .name{"head"},
+                                .children{{dom::Element{.name{"title"}, .children{dom::Text{"hello"}}}}},
+                        },
+                        dom::Element{
+                                .name{"body"},
+                                .children{dom::Text{"goodbye"}},
+                        },
+                }},
+        };
+
+        std::string_view expected = R"(#document
+| <!DOCTYPE html5>
+| <html>
+|   <head>
+|     <title>
+|       "hello"
+|   <body>
+|     "goodbye")";
+        a.expect_eq(to_string(document), expected);
+    });
+
     return s.run();
 }


### PR DESCRIPTION
Before:
```
#document
| <!DOCTYPE html5>
| <html>
|   <head>
|   <body>
|     <title>
|     "goodbye"
|       "hello"
```

After:
```
#document
| <!DOCTYPE html5>
| <html>
|   <head>
|     <title>
|       "hello"
|   <body>
|     "goodbye"
```