### PR TITLE
etest: Support filtering what tests to run

### DIFF
--- a/etest/etest2.h
+++ b/etest/etest2.h
@@ -55,6 +55,8 @@ void print_to(std::ostream &os, std::string_view actual_op, T const &a, U const 
 struct RunOptions {
     bool run_disabled_tests{false};
     std::optional<unsigned> rng_seed;
+    // Pattern to match test names against. Must be a valid regex compatible w/ std::regex.
+    std::string_view test_name_filter{".*"};
 };
 
 class IActions {

--- a/etest/test_name_filter_test.cpp
+++ b/etest/test_name_filter_test.cpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "etest/etest2.h"
+
+int main() {
+    auto s = etest::Suite{};
+    s.add_test("good 1", [](auto &) {});
+    s.add_test("good 2", [](auto &) {});
+    s.add_test("good 3", [](auto &) {});
+    s.add_test("BAD (not good)", [](auto &a) { a.require(false); });
+    return s.run({.test_name_filter = "^good"});
+}


### PR DESCRIPTION
With this, e.g. patching html2/tokenizer_test.cpp's `s.run()` into 
```cpp
    return s.run({
            .test_name_filter = "^before",
    });
```
will lead to running the test giving the output
```
206 test(s) registered.
Running 4 tests with the seed 727136149.
before attribute name: missing value: PASSED
before doctype name, unexpected null: PASSED
before attribute name: =            : PASSED
before doctype name, eof            : PASSED
```

or w/ the pattern `"before"`:

```
206 test(s) registered.
Running 13 tests with the seed 3650204568.
doctype before system identifier, missing identifier             : PASSED
before doctype name, unexpected null                             : PASSED
doctype before system identifier, double-quoted system identifier: PASSED
doctype system keyword, missing quote before identifier          : PASSED
before attribute name: missing value                             : PASSED
doctype, missing whitespace before doctype name                  : PASSED
before doctype name, eof                                         : PASSED
doctype before system identifier, single-quoted system identifier: PASSED
comment, eof before comment is closed                            : PASSED
before attribute name: =                                         : PASSED
comment, end before comment                                      : PASSED
doctype before system identifier, more eof in doctype            : PASSED
doctype before system identifier, missing quote before identifier: PASSED
```

Resolves #108