### PR TITLE
Target Unicode 16

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -505,8 +505,8 @@ EOF""",
 # https://www.unicode.org/Public/idna/
 http_file(
     name = "idna_mapping_table",
-    sha256 = "402cbd285f1f952fcd0834b63541d54f69d3d8f1b8f8599bf71a1a14935f82c4",
-    url = "https://www.unicode.org/Public/idna/15.1.0/IdnaMappingTable.txt",
+    integrity = "sha256-bbLvTtNfOz3nTrwuAEBKlgf3bUmfV2uNQEPPFPHtF1w=",
+    url = "https://www.unicode.org/Public/idna/16.0.0/IdnaMappingTable.txt",
 )
 
 # https://github.com/ocornut/imgui

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -680,13 +680,13 @@ bazel_dep(name = "ucd")
 archive_override(
     module_name = "ucd",
     build_file_content = """exports_files(["UnicodeData.txt"])""",
-    integrity = "sha256-yxxmPQU5JlAM1QEilzYEV1JxOgZr11gCCYWYt6cFYXc=",
+    integrity = "sha256-yG3YHysUpDsMwGSqX4mqckE4aAHjXFnHmE5XmDJjTrI=",
     patch_cmds = [
         """cat <<EOF >MODULE.bazel
 module(name = "ucd")
 EOF""",
     ],
-    url = "https://www.unicode.org/Public/15.1.0/ucd/UCD.zip",
+    url = "https://www.unicode.org/Public/16.0.0/ucd/UCD.zip",
 )
 
 # https://github.com/illiliti/libudev-zero

--- a/idna/uts46.cpp
+++ b/idna/uts46.cpp
@@ -9,7 +9,6 @@
 #include "unicode/util.h"
 
 #include <algorithm>
-#include <cassert>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -34,16 +33,6 @@ std::optional<std::string> Uts46::map(std::string_view input) {
         }
 
         if (std::holds_alternative<uts46::Disallowed>(entry)) {
-            return std::nullopt;
-        }
-
-        // tr46 strongly recommends using the std3 rules, so no opt-out for
-        // this.
-        if (std::holds_alternative<uts46::DisallowedStd3Valid>(entry)) {
-            return std::nullopt;
-        }
-
-        if (std::holds_alternative<uts46::DisallowedStd3Mapped>(entry)) {
             return std::nullopt;
         }
 

--- a/idna/uts46_test.cpp
+++ b/idna/uts46_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2024-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -7,26 +7,23 @@
 #include "etest/etest2.h"
 
 #include <optional>
-#include <string_view>
-
-using namespace std::literals;
 
 // https://unicode.org/reports/tr46/#Table_Example_Processing
 int main() {
     etest::Suite s{};
 
     s.add_test("disallowed", [](etest::IActions &a) {
-        // The first unicode value
-        a.expect_eq(idna::Uts46::map("\0"sv), std::nullopt);
+        // The first disallowed unicode value.
+        a.expect_eq(idna::Uts46::map("\xc2\x80"), std::nullopt); // U+0080
         // and the last one, U+10FFFF, but in UTF-8.
         a.expect_eq(idna::Uts46::map("\xf4\x8f\xbf\xbf"), std::nullopt);
 
-        a.expect_eq(idna::Uts46::map(","), std::nullopt);
-        a.expect_eq(idna::Uts46::map("\xc2\xa0"), std::nullopt);
+        a.expect_eq(idna::Uts46::map("\xc2\x9f"), std::nullopt); // Application program command.
         a.expect_eq(idna::Uts46::map("a⒈com"), std::nullopt);
     });
 
     s.add_test("mapped", [](etest::IActions &a) {
+        a.expect_eq(idna::Uts46::map("\xc2\xa0"), " "); // No-break space.
         a.expect_eq(idna::Uts46::map("ABCXYZ"), "abcxyz");
         a.expect_eq(idna::Uts46::map("日本語。ＪＰ"), "日本語.jp");
         a.expect_eq(idna::Uts46::map("☕.us"), "☕.us");


### PR DESCRIPTION
No exciting changes in tr44, just some changes in the input data: https://www.unicode.org/reports/tr44/#Change_History
tr46 has completely dropped IDNA2003 starting w/ Unicode 16, so that was nuked: https://www.unicode.org/reports/tr46/#IDNAComparison