### PR TITLE
css: Make more of the media query code constexpr-enabled

### DIFF
--- a/css/media_query.h
+++ b/css/media_query.h
@@ -158,7 +158,7 @@ struct And {
     std::vector<MediaQuery> queries;
     [[nodiscard]] bool operator==(And const &other) const = default;
 
-    inline bool evaluate(Context const &) const;
+    constexpr bool evaluate(Context const &) const;
 };
 
 } // namespace detail
@@ -351,15 +351,15 @@ private:
     }
 };
 
-inline bool detail::And::evaluate(Context const &ctx) const {
+constexpr bool detail::And::evaluate(Context const &ctx) const {
     return std::ranges::all_of(queries, [&](auto const &q) { return q.evaluate(ctx); });
 }
 
-inline std::string to_string(MediaQuery::Width const &width) {
+constexpr std::string to_string(MediaQuery::Width const &width) {
     return std::to_string(width.min) + " <= width <= " + std::to_string(width.max);
 }
 
-inline std::string to_string(MediaQuery::Height const &height) {
+constexpr std::string to_string(MediaQuery::Height const &height) {
     return std::to_string(height.min) + " <= height <= " + std::to_string(height.max);
 }
 


### PR DESCRIPTION
The rest of the file is stuck being non-constexpr due to us still supporting Clang 17 (via the zig cc stuff) and Clang 18.