### PR TITLE
build: Add a hermetic llvm --config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -184,6 +184,13 @@ build:wasi-wasm --extra_toolchains=@zig_sdk//toolchain:wasip1_wasm
 # https://github.com/WebAssembly/wasi-sdk/tree/f1ebc52a74394cdf885d03bfde13899b3d5c6d2d?tab=readme-ov-file#notable-limitations
 build:wasi-wasm --copt=-fno-exceptions
 
+# Hermetic LLVM toolchain
+# =========================================================
+# Note that these toolchains don't work on Windows:
+# https://github.com/bazel-contrib/toolchains_llvm/issues/395
+
+build:clang-amd64 --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
+
 # Fuzzing options
 # =========================================================
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,10 +59,8 @@ jobs:
 
           - name: clang-20-libc++
             os: ubuntu-24.04
-            compiler: clang
-            version: 20
-            bazel: --config libc++ --keep_going
-            apt: libc++abi-20-dev libc++-20-dev libclang-rt-20-dev
+            bazel: --config clang-amd64
+            skip-compiler-install: true
 
     steps:
       - name: Setup gcc
@@ -82,9 +80,15 @@ jobs:
           sudo apt-add-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${{ matrix.version }} main"
       - uses: actions/checkout@v4
       - name: Install
+        if: ${{ !matrix.skip-compiler-install }}
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends ${{ matrix.compiler }}-${{ matrix.version }} ${{ matrix.apt }} libx11-dev libxi-dev
+      - name: Install
+        if: ${{ matrix.skip-compiler-install }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends ${{ matrix.apt }} libx11-dev libxi-dev
       - uses: actions/cache@v4
         if: ${{ github.ref == 'refs/heads/master' }}
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,8 @@ jobs:
         if: env.BUILDBUDDY_API_KEY != ''
       - name: Test
         run: bazel test //... ${{ matrix.bazel }}
+      - name: Print elf binary comment
+        run: readelf -p .comment ./bazel-bin/browser/tui/tui
       - name: Run
         run: |
           echo "<html><body><h1>Example</h1><p>This is an example page.</p></body></html>" >example.html

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -194,6 +194,21 @@ archive_override(
     url = "https://github.com/bazel-contrib/rules_jvm_external/releases/download/{0}/rules_jvm_external-{0}.tar.gz".format(RULES_JVM_EXTERNAL_VERSION),
 )
 
+# https://github.com/bazel-contrib/toolchains_llvm
+TOOLCHAINS_LLVM_VERSION = "1.4.0"
+
+bazel_dep(name = "toolchains_llvm")  # Apache-2.0
+archive_override(
+    module_name = "toolchains_llvm",
+    integrity = "sha256-/e0CVpYX0kVRoK0JwHUNxTowlyNxV7gookVoHwrnOfg=",
+    strip_prefix = "toolchains_llvm-v%s" % TOOLCHAINS_LLVM_VERSION,
+    url = "https://github.com/bazel-contrib/toolchains_llvm/releases/download/v{0}/toolchains_llvm-v{0}.tar.gz".format(TOOLCHAINS_LLVM_VERSION),
+)
+
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.toolchain(llvm_version = "20.1.2")
+use_repo(llvm, "llvm_toolchain")
+
 # Other Bazel-required dependencies
 # =========================================================
 


### PR DESCRIPTION
This downloads and uses a full LLVM setup to keep things as reproducible as possible, similar to our zig cross-compilation setup, but without going via the zig cc stuff.