### PR TITLE
engine: Hook up the JS tokenizer

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -848,6 +848,14 @@ void App::run_debug_widget() {
         }
     }
 
+    if (ImGui::Checkbox("Enable JavaScript", &enable_js_)) {
+        if (maybe_page_) {
+            // Scripting affects the html parsing, so we actually
+            // need to reload the page for now.
+            reload();
+        }
+    }
+
     if (ImGui::BeginCombo("Render backend", selected_canvas_ == Canvas::OpenGL ? "OpenGL" : "SFML")) {
         if (ImGui::Selectable("SFML", selected_canvas_ == Canvas::Sfml)) {
             select_canvas(Canvas::Sfml);
@@ -935,6 +943,7 @@ engine::Options App::make_options() const {
             .layout_width = static_cast<int>(window_.getSize().x / scale_),
             .viewport_height = static_cast<int>(window_.getSize().y / scale_),
             .dark_mode = os::is_dark_mode(),
+            .enable_js = enable_js_,
     };
 }
 

--- a/browser/gui/app.h
+++ b/browser/gui/app.h
@@ -76,6 +76,7 @@ private:
 
     bool render_debug_{};
     bool display_debug_gui_{};
+    bool enable_js_{false};
     bool load_images_{true};
 
     unsigned scale_{1};

--- a/engine/BUILD
+++ b/engine/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "//archive:zstd",
         "//html",
         "//html2",
+        "//js",
         "@spdlog",
     ],
     visibility = ["//visibility:public"],

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -127,8 +127,9 @@ tl::expected<std::unique_ptr<PageState>, NavigationError> Engine::navigate(uri::
     state->uri = std::move(result.uri_after_redirects);
     state->response = std::move(result.response.value());
     spdlog::info("Parsing HTML");
-    state->dom = html::parse(
-            state->response.body, {}, [](html2::ParseError e) { spdlog::warn("HTML parse error: {}", to_string(e)); });
+    state->dom = html::parse(state->response.body, {.scripting = opts.enable_js}, [](html2::ParseError e) {
+        spdlog::warn("HTML parse error: {}", to_string(e));
+    });
 
     spdlog::info("Parsing inline styles");
     state->stylesheet = css::default_style();

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -127,9 +127,9 @@ tl::expected<std::unique_ptr<PageState>, NavigationError> Engine::navigate(uri::
     state->uri = std::move(result.uri_after_redirects);
     state->response = std::move(result.response.value());
     spdlog::info("Parsing HTML");
-    state->dom = html::parse(state->response.body, {.scripting = opts.enable_js}, [](html2::ParseError e) {
+    state->dom = html::parse(state->response.body, {.scripting = opts.enable_js}, {.on_error = [](html2::ParseError e) {
         spdlog::warn("HTML parse error: {}", to_string(e));
-    });
+    }});
 
     spdlog::info("Parsing inline styles");
     state->stylesheet = css::default_style();

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -32,6 +32,7 @@ struct Options {
     int layout_width{600};
     int viewport_height{800};
     bool dark_mode{false};
+    bool enable_js{false};
 };
 
 struct PageState {


### PR DESCRIPTION
This doesn't run JS yet, but I'll open a PR for those parts soon. This is enough to make it easy to see what's needed for the tokenizer to work on websites we're testing against.

I might break things apart a bit later to allow the option of using a not-nih JS engine, but that's not really in scope while we're still getting all the basics set up.

```
[2025-06-01 19:54:58.344] [W] Failed to tokenize JavaScript in <script> tag:

    document.querySelectorAll("a").forEach((link) => {
      link.addEventListener("mouseover", (ev) => {
        if (link.className == "vid") {
          document.querySelector("#img").src = "";
          document.querySelector("#video").src = link.href;
          document.querySelector("#video").style.display = "revert";
        } else {
          document.querySelector("#img").src = link.href;
          document.querySelector("#video").pause();
          document.querySelector("#video").style.display = "none";
        }
      });
    });
```