### PR TITLE
url: Add to_string(Url) and to_string(ValidationError)

### DIFF
--- a/url/url.h
+++ b/url/url.h
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2022-2023 David Zero <zero-one@zer0-one.net>
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -110,6 +110,10 @@ struct Url {
     bool operator==(Url const &b) const { return serialize() == b.serialize(); }
 };
 
+inline std::string to_string(url::Url const &url) {
+    return url.serialize();
+}
+
 enum class ValidationError : std::uint8_t {
     // IDNA
     DomainToAscii,
@@ -144,6 +148,71 @@ enum class ValidationError : std::uint8_t {
     FileInvalidWindowsDriveLetter,
     FileInvalidWindowsDriveLetterHost
 };
+
+constexpr std::string_view to_string(ValidationError e) {
+    switch (e) {
+        case ValidationError::DomainToAscii:
+            return "DomainToAscii";
+        case ValidationError::DomainToUnicode:
+            return "DomainToUnicode";
+        case ValidationError::DomainInvalidCodePoint:
+            return "DomainInvalidCodePoint";
+        case ValidationError::HostInvalidCodePoint:
+            return "HostInvalidCodePoint";
+        case ValidationError::IPv4EmptyPart:
+            return "IPv4EmptyPart";
+        case ValidationError::IPv4TooManyParts:
+            return "IPv4TooManyParts";
+        case ValidationError::IPv4NonNumericPart:
+            return "IPv4NonNumericPart";
+        case ValidationError::IPv4NonDecimalPart:
+            return "IPv4NonDecimalPart";
+        case ValidationError::IPv4OutOfRangePart:
+            return "IPv4OutOfRangePart";
+        case ValidationError::IPv6Unclosed:
+            return "IPv6Unclosed";
+        case ValidationError::IPv6InvalidCompression:
+            return "IPv6InvalidCompression";
+        case ValidationError::IPv6TooManyPieces:
+            return "IPv6TooManyPieces";
+        case ValidationError::IPv6MultipleCompression:
+            return "IPv6MultipleCompression";
+        case ValidationError::IPv6InvalidCodePoint:
+            return "IPv6InvalidCodePoint";
+        case ValidationError::IPv6TooFewPieces:
+            return "IPv6TooFewPieces";
+        case ValidationError::IPv4InIPv6TooManyPieces:
+            return "IPv4InIPv6TooManyPieces";
+        case ValidationError::IPv4InIPv6InvalidCodePoint:
+            return "IPv4InIPv6InvalidCodePoint";
+        case ValidationError::IPv4InIPv6OutOfRangePart:
+            return "IPv4InIPv6OutOfRangePart";
+        case ValidationError::IPv4InIPv6TooFewParts:
+            return "IPv4InIPv6TooFewParts";
+        case ValidationError::InvalidUrlUnit:
+            return "InvalidUrlUnit";
+        case ValidationError::SpecialSchemeMissingFollowingSolidus:
+            return "SpecialSchemeMissingFollowingSolidus";
+        case ValidationError::MissingSchemeNonRelativeUrl:
+            return "MissingSchemeNonRelativeUrl";
+        case ValidationError::InvalidReverseSolidus:
+            return "InvalidReverseSolidus";
+        case ValidationError::InvalidCredentials:
+            return "InvalidCredentials";
+        case ValidationError::HostMissing:
+            return "HostMissing";
+        case ValidationError::PortOutOfRange:
+            return "PortOutOfRange";
+        case ValidationError::PortInvalid:
+            return "PortInvalid";
+        case ValidationError::FileInvalidWindowsDriveLetter:
+            return "FileInvalidWindowsDriveLetter";
+        case ValidationError::FileInvalidWindowsDriveLetterHost:
+            return "FileInvalidWindowsDriveLetterHost";
+    }
+
+    return "Unknown error";
+}
 
 std::string_view description(ValidationError);
 

--- a/url/url_test.cpp
+++ b/url/url_test.cpp
@@ -39,6 +39,22 @@ ParseResult parse_url(std::string input, std::optional<url::Url> base = std::nul
 int main() {
     etest::Suite s{};
 
+    s.add_test("to_string(ValidationError)", [](etest::IActions &a) {
+        static constexpr auto kFirstError = url::ValidationError::DomainToAscii;
+        static constexpr auto kLastError = url::ValidationError::FileInvalidWindowsDriveLetterHost;
+
+        auto error = static_cast<int>(kFirstError);
+        a.expect_eq(error, 0);
+
+        while (error <= static_cast<int>(kLastError)) {
+            a.expect(to_string(static_cast<url::ValidationError>(error)) != "Unknown error",
+                    std::to_string(error) + " is missing an error message");
+            error += 1;
+        }
+
+        a.expect_eq(to_string(static_cast<url::ValidationError>(error + 1)), "Unknown error");
+    });
+
     url::Url const base{"https",
             "",
             "",
@@ -95,6 +111,7 @@ int main() {
         a.expect(!url->fragment.has_value());
 
         a.expect_eq(url->serialize(), "https://example.com:8080/index.html");
+        a.expect_eq(to_string(*url), "https://example.com:8080/index.html");
     });
 
     s.add_test("URL parsing: 1 unicode char", [](etest::IActions &a) {


### PR DESCRIPTION
A bunch of the C++ stdlib supports to_string(Type), as do a lot of our types, and it's what we support for printing types in //etest, so this makes things more convenient.