### PR TITLE
Make it easier to depend on hastur

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -446,7 +446,6 @@ http_file(
 # https://github.com/fmtlib/fmt
 FMT_VERSION = "11.2.0"
 
-bazel_dep(name = "fmt")  # MIT
 archive_override(
     module_name = "fmt",
     build_file = "//third_party:fmt.BUILD",
@@ -708,7 +707,6 @@ EOF""",
 # https://github.com/nothings/stb
 STB_VERSION = "f58f558c120e9b32c217290b80bad1a0729fbb2c"
 
-bazel_dep(name = "stb")  # MIT/Unlicense
 archive_override(
     module_name = "stb",
     build_file = "//third_party:stb.BUILD",
@@ -738,9 +736,8 @@ EOF""",
 )
 
 # https://github.com/illiliti/libudev-zero
-bazel_dep(name = "udev-zero")
 archive_override(
-    module_name = "udev-zero",  # ISC
+    module_name = "udev-zero",
     build_file = "//third_party:udev-zero.BUILD",
     patch_cmds = [
         """cat <<EOF >MODULE.bazel
@@ -758,7 +755,6 @@ EOF""",
 # https://github.com/KhronosGroup/Vulkan-Hpp
 VULKAN_TAG = "1.4.320"
 
-bazel_dep(name = "vulkan")  # Apache-2.0
 archive_override(
     module_name = "vulkan",
     build_file = "//third_party:vulkan.BUILD",
@@ -803,7 +799,6 @@ http_file(
 # https://gitlab.freedesktop.org/xorg/lib/libxcursor
 XCURSOR_VERSION = "1.2.3"
 
-bazel_dep(name = "xcursor")  # MIT
 archive_override(
     module_name = "xcursor",
     build_file = "//third_party:xcursor.BUILD",
@@ -825,7 +820,6 @@ EOF""",
 # https://gitlab.freedesktop.org/xorg/lib/libxext
 XEXT_VERSION = "1.3.6"
 
-bazel_dep(name = "xext")  # MIT
 archive_override(
     module_name = "xext",
     build_file = "//third_party:xext.BUILD",
@@ -846,7 +840,6 @@ EOF""",
 # https://gitlab.freedesktop.org/xorg/lib/libxrandr
 XRANDR_VERSION = "1.5.4"
 
-bazel_dep(name = "xrandr")  # MIT
 archive_override(
     module_name = "xrandr",
     build_file = "//third_party:xrandr.BUILD",
@@ -869,7 +862,6 @@ EOF""",
 # https://gitlab.freedesktop.org/xorg/lib/libxrender
 XRENDER_VERSION = "0.9.12"
 
-bazel_dep(name = "xrender")  # MIT
 archive_override(
     module_name = "xrender",
     build_file = "//third_party:xrender.BUILD",


### PR DESCRIPTION
Both dev_dependencies and deps w/o a bazel_dep declaration are ignored when you depend on Hastur.

Note that I couldn't test this using `--ignore_dev_dependency` as it seems to be unusable if you use e.g. `archive_override`. No issue filed for this as I haven't looked into it too much other than noting that even without marking anything as a dev_dependency, we can't build w/ `--ignore_dev_dependency` as it causes
```
$ bazelisk test ... --ignore_dev_dependency
ERROR: Error computing the main repository mapping: bad bazel_dep on module 'platforms' with no version. Did you forget to specify a version, or a non-registry override?
```
for seemingly every dependency. We only get 1 of these errors per run, so I didn't confirm that it's literally every dep.