### PR TITLE
html2/test: Make eof token checking implicit

### DIFF
--- a/html2/tokenizer_fuzz_test.cpp
+++ b/html2/tokenizer_fuzz_test.cpp
@@ -1,13 +1,15 @@
-// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "html2/tokenizer.h"
 
+#include "html2/token.h"
+
 #include <cstddef>
 #include <cstdint>
-#include <optional>
 #include <string_view>
+#include <variant>
 
 extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *data, std::size_t size);
 


### PR DESCRIPTION
The tokenizer always ends with this, and every test checks for it, so
let's make checking for it implicit.