### PR TITLE
build: Don't require a system Python installation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,8 +29,7 @@ build --incompatible_enforce_config_setting_visibility
 # Third-party configuration
 # =========================================================
 
-# TODO(robinlinden): Investigate why this is broken: https://github.com/robinlinden/hastur/issues/1181
-# build --@rules_python//python/config_settings:bootstrap_impl=script
+build --@rules_python//python/config_settings:bootstrap_impl=script
 
 # Compiler configuration
 # =========================================================

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ matrix.container != '' }}
         run: |
           echo '#!/bin/sh\n"$@"' >/usr/bin/sudo && chmod +x /usr/bin/sudo
-          apt-get update && apt-get install --assume-yes --no-install-recommends curl ca-certificates xxd python3
+          apt-get update && apt-get install --assume-yes --no-install-recommends curl ca-certificates xxd
           curl --location --output /usr/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64 && chmod +x /usr/bin/bazel
           # icu requires gcc to exist.
           ln -s /usr/bin/gcc-${{ matrix.version }} /usr/bin/gcc


### PR DESCRIPTION
Turns out `--bootstrap_impl=script` was broken on Windows, and rules_python, as of 1.5.0, forces `--bootstrap_impl=system_python` there.

Resolves #1181