### PR TITLE
tool: Set up a tool for embedding resources in a nicer-than-xxd way

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -4,7 +4,7 @@ ignore=body-is-missing
 # TODO(robinlinden): Better way of documenting and setting this up.
 # Each commit must start with the main area it affects.
 [title-match-regex]
-regex=^(archive|azm|browser|bzl|css|css2|dom|dom2|engine|etest|geom|gfx|html|html2|idna|img|js|json|layout|net|os|protocol|render|style|tui|type|unicode|uri|url|util|wasm|all|build|ci|deps|doc|meta)(/.*|\+.*)?:
+regex=^(archive|azm|browser|bzl|css|css2|dom|dom2|engine|etest|geom|gfx|html|html2|idna|img|js|json|layout|net|os|protocol|render|style|tool|tui|type|unicode|uri|url|util|wasm|all|build|ci|deps|doc|meta)(/.*|\+.*)?:
 
 # Splitting git trailers, e.g. the references to commits in other repos, into
 # two lines is silly.

--- a/css/BUILD
+++ b/css/BUILD
@@ -6,7 +6,8 @@ genrule(
     name = "default_css",
     srcs = ["default.css"],
     outs = ["default_css.h"],
-    cmd = "xxd -i $< >$@",
+    cmd = "$(location //tool:embed) --name kDefaultCss $< >$@",
+    tools = ["//tool:embed"],
 )
 
 cc_library(

--- a/css/default.cpp
+++ b/css/default.cpp
@@ -1,21 +1,17 @@
-// SPDX-FileCopyrightText: 2021-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "css/default.h"
 
+#include "css/default_css.h"
 #include "css/parser.h"
 #include "css/style_sheet.h"
 
-#include <string_view>
-
 namespace css {
-namespace {
-#include "css/default_css.h"
-} // namespace
 
 StyleSheet default_style() {
-    return css::parse(std::string_view{reinterpret_cast<char const *>(css_default_css), css_default_css_len});
+    return css::parse(kDefaultCss);
 }
 
 } // namespace css

--- a/gfx/BUILD
+++ b/gfx/BUILD
@@ -20,14 +20,16 @@ genrule(
     name = "basic_vertex_shader",
     srcs = ["basic_shader.vert"],
     outs = ["basic_vertex_shader.h"],
-    cmd = "xxd -i $< >$@",
+    cmd = "$(location //tool:embed) --name kBasicVertexShader $< >$@",
+    tools = ["//tool:embed"],
 )
 
 genrule(
     name = "rect_fragment_shader",
     srcs = ["rect_shader.frag"],
     outs = ["rect_fragment_shader.h"],
-    cmd = "xxd -i $< >$@",
+    cmd = "$(location //tool:embed) --name kRectFragmentShader $< >$@",
+    tools = ["//tool:embed"],
 )
 
 cc_library(

--- a/gfx/opengl_canvas.cpp
+++ b/gfx/opengl_canvas.cpp
@@ -4,9 +4,11 @@
 
 #include "gfx/opengl_canvas.h"
 
+#include "gfx/basic_vertex_shader.h"
 #include "gfx/color.h"
 #include "gfx/icanvas.h"
 #include "gfx/opengl_shader.h"
+#include "gfx/rect_fragment_shader.h"
 
 #include "geom/geom.h"
 
@@ -18,17 +20,10 @@
 #include <utility>
 
 namespace gfx {
-namespace {
-#include "gfx/basic_vertex_shader.h"
-#include "gfx/rect_fragment_shader.h"
-
-std::string_view const vertex_shader{reinterpret_cast<char const *>(gfx_basic_shader_vert), gfx_basic_shader_vert_len};
-std::string_view const fragment_shader{reinterpret_cast<char const *>(gfx_rect_shader_frag), gfx_rect_shader_frag_len};
-} // namespace
 
 OpenGLCanvas::OpenGLCanvas()
     : border_shader_{[] {
-          auto shader = OpenGLShader::create(vertex_shader, fragment_shader);
+          auto shader = OpenGLShader::create(kBasicVertexShader, kRectFragmentShader);
           assert(shader.has_value());
           return std::move(shader).value();
       }()} {

--- a/gfx/sfml_canvas.cpp
+++ b/gfx/sfml_canvas.cpp
@@ -5,10 +5,13 @@
 
 #include "gfx/sfml_canvas.h"
 
-#include "geom/geom.h"
+#include "gfx/basic_vertex_shader.h"
 #include "gfx/color.h"
 #include "gfx/font.h"
 #include "gfx/icanvas.h"
+#include "gfx/rect_fragment_shader.h"
+
+#include "geom/geom.h"
 #include "type/sfml.h"
 
 #include <SFML/Graphics/Color.hpp>
@@ -35,9 +38,6 @@
 
 namespace gfx {
 namespace {
-
-#include "gfx/basic_vertex_shader.h"
-#include "gfx/rect_fragment_shader.h"
 
 sf::Font const &find_font(type::SfmlType &type, std::span<gfx::Font const> font_families) {
     for (auto const &family : font_families) {
@@ -94,9 +94,7 @@ sf::Text::Style to_sfml(FontStyle style) {
 
 SfmlCanvas::SfmlCanvas(sf::RenderTarget &target, type::SfmlType &type) : target_{target}, type_{type} {
     // TODO(robinlinden): Error-handling.
-    std::ignore = border_shader_.loadFromMemory(
-            std::string_view{reinterpret_cast<char const *>(gfx_basic_shader_vert), gfx_basic_shader_vert_len},
-            std::string_view{reinterpret_cast<char const *>(gfx_rect_shader_frag), gfx_rect_shader_frag_len});
+    std::ignore = border_shader_.loadFromMemory(kBasicVertexShader, kRectFragmentShader);
 }
 
 void SfmlCanvas::set_viewport_size(int width, int height) {

--- a/img/BUILD
+++ b/img/BUILD
@@ -56,7 +56,8 @@ genrule(
     name = "tiny_png",
     srcs = ["tiny.png"],
     outs = ["tiny_png.h"],
-    cmd = "xxd -i $< >$@",
+    cmd = "$(location //tool:embed) --name kTinyPng $< >$@",
+    tools = ["//tool:embed"],
 )
 
 # See: https://web.archive.org/web/20111224041840/http://www.techsupportteam.org/forum/digital-imaging-photography/1892-worlds-smallest-valid-jpeg.html
@@ -64,7 +65,8 @@ genrule(
     name = "tiny_jpg",
     srcs = ["tiny.jpg"],
     outs = ["tiny_jpg.h"],
-    cmd = "xxd -i $< >$@",
+    cmd = "$(location //tool:embed) --name kTinyJpg $< >$@",
+    tools = ["//tool:embed"],
 )
 
 extra_srcs = {

--- a/img/jpeg_turbo_test.cpp
+++ b/img/jpeg_turbo_test.cpp
@@ -4,6 +4,8 @@
 
 #include "img/jpeg_turbo.h"
 
+#include "img/tiny_jpg.h"
+
 #include "etest/etest2.h"
 
 #include <cstddef>
@@ -12,9 +14,8 @@
 #include <tuple>
 
 namespace {
-#include "img/tiny_jpg.h"
 // NOLINTNEXTLINE(cert-err58-cpp): Why would this throw?
-std::span<std::byte const> const jpg_bytes(reinterpret_cast<std::byte const *>(img_tiny_jpg), img_tiny_jpg_len);
+std::span<std::byte const> const jpg_bytes(reinterpret_cast<std::byte const *>(kTinyJpg.data()), kTinyJpg.size());
 } // namespace
 
 int main() {
@@ -32,7 +33,7 @@ int main() {
 
     // The same bytes should make the same image, span/ostream shouldn't matter.
     s.add_test("JpegTurbo::from(ostream &)", [](etest::IActions &a) {
-        std::stringstream ss{std::string{reinterpret_cast<char const *>(img_tiny_jpg), img_tiny_jpg_len}};
+        std::stringstream ss{std::string{kTinyJpg}};
         auto const image = img::JpegTurbo::from(ss).value();
         a.expect_eq(image, img::JpegTurbo::from(jpg_bytes).value());
     });

--- a/img/png_test.cpp
+++ b/img/png_test.cpp
@@ -1,8 +1,10 @@
-// SPDX-FileCopyrightText: 2022-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "img/png.h"
+
+#include "img/tiny_png.h"
 
 #include "etest/etest2.h"
 
@@ -14,11 +16,6 @@
 #include <string_view>
 #include <utility>
 #include <vector>
-
-namespace {
-#include "img/tiny_png.h"
-std::string_view const png_bytes(reinterpret_cast<char const *>(img_tiny_png), img_tiny_png_len);
-} // namespace
 
 int main() {
     etest::Suite s;
@@ -37,18 +34,18 @@ int main() {
             return expected;
         }();
 
-        auto png = img::Png::from(std::stringstream(std::string{png_bytes})).value();
+        auto png = img::Png::from(std::stringstream(std::string{kTinyPng})).value();
         a.expect_eq(png, img::Png{.width = 256, .height = 256, .bytes = std::move(expected_pixels)});
     });
 
     s.add_test("invalid signatures are rejected", [](etest::IActions &a) {
-        auto invalid_signature_bytes = std::string{png_bytes};
+        auto invalid_signature_bytes = std::string{kTinyPng};
         invalid_signature_bytes[7] = 'b';
         a.expect_eq(img::Png::from(std::stringstream(std::move(invalid_signature_bytes))), std::nullopt);
     });
 
     s.add_test("it handles truncated files", [](etest::IActions &a) {
-        auto truncated_bytes = std::string{png_bytes.substr(0, 30)};
+        auto truncated_bytes = std::string{kTinyPng.substr(0, 30)};
         a.expect_eq(img::Png::from(std::stringstream(std::move(truncated_bytes))), std::nullopt);
     });
 

--- a/tool/BUILD
+++ b/tool/BUILD
@@ -1,0 +1,10 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("//bzl:copts.bzl", "HASTUR_COPTS")
+
+cc_binary(
+    name = "embed",
+    srcs = ["embed.cpp"],
+    copts = HASTUR_COPTS,
+    visibility = ["//visibility:public"],
+    deps = ["//util:arg_parser"],
+)

--- a/tool/embed.cpp
+++ b/tool/embed.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2025 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "util/arg_parser.h"
+
+#include <array>
+#include <cstdio>
+#include <fstream>
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+int main(int argc, char **argv) {
+    std::string name;
+    std::string input_file;
+
+    if (auto res = util::ArgParser{}.argument("--name", name).positional(input_file).parse(argc, argv); !res) {
+        std::cerr << "Error: " << res.error().message << '\n';
+        return 1;
+    }
+
+    if (input_file.empty() || name.empty()) {
+        std::string_view program_name = argv[0] != nullptr ? argv[0] : "<bin>";
+        std::cerr << "Usage: " << program_name << " --name <name> <input_file>\n";
+        return 1;
+    }
+
+    std::ifstream file(input_file, std::ios::binary);
+    if (!file) {
+        std::cerr << "Error: Could not open file '" << input_file << "'\n";
+        return 1;
+    }
+
+    std::cout << "#ifndef HST_GENERATED_" << name << "_H\n";
+    std::cout << "#define HST_GENERATED_" << name << "_H\n";
+
+    std::cout << "#include <array>\n";
+    std::cout << "#include <string_view>\n";
+    std::cout << "constexpr auto " << name << "Bytes = std::to_array<char>({\n";
+    std::array<char, 1024> data{};
+    while (file.read(data.data(), data.size()) || file.gcount() > 0) {
+        std::string_view chunk{data.data(), static_cast<std::size_t>(file.gcount())};
+        std::size_t count{};
+        for (unsigned char c : chunk) {
+            std::cout << "'\\x" << std::hex << std::setw(2) << std::setfill('0') << int{c} << "',";
+            count++;
+            if (count % 32 == 0) {
+                std::cout << '\n';
+            }
+        }
+    }
+    std::cout << "});\n";
+
+    std::cout << "constexpr auto " << name << " = std::string_view{" << name << "Bytes.data(), " << name
+              << "Bytes.size()};\n";
+    std::cout << "#endif // HST_GENERATED_" << name << "_H\n";
+}


### PR DESCRIPTION
This will go away once we target compilers w/ support for `#embed`, but
I feel this is a decent intermediate step as this is very little code,
allows us to treat the resources as compile-time constants instead of
mutable data, and doesn't require any namespace hacks where we include
the resources.

There's some issue w/ compiling the font embed file in MSVC in CI (without any output), but I can't reproduce it locally. Leaving that one as xxd while I investigate.