### PR TITLE
url: Make //util:string a private dependency

### DIFF
--- a/url/BUILD
+++ b/url/BUILD
@@ -43,13 +43,13 @@ cc_library(
         ":percent_encode",
         ":rtti_hack",
         "//unicode:util",
+        "//util:string",
         "//util:uuid",
         "@icu//:common",
         "@icu//:icudata",
     ],
     tags = ["no-cross"],
     visibility = ["//visibility:public"],
-    deps = ["//util:string"],
 )
 
 cc_test(

--- a/url/url.cpp
+++ b/url/url.cpp
@@ -48,6 +48,14 @@ namespace url {
 
 namespace {
 
+constexpr bool is_windows_drive_letter(std::string_view input) {
+    return input.size() == 2 && util::is_alpha(input[0]) && (input[1] == ':' || input[1] == '|');
+}
+
+constexpr bool is_normal_windows_drive_letter(std::string_view input) {
+    return input.size() == 2 && util::is_alpha(input[0]) && input[1] == ':';
+}
+
 constexpr auto kSpecialSchemes = std::to_array<std::pair<std::string_view, std::uint16_t>>({
         {"ftp", std::uint16_t{21}},
         {"file", std::uint16_t{0}},

--- a/url/url.h
+++ b/url/url.h
@@ -6,8 +6,6 @@
 #ifndef URL_URL_H_
 #define URL_URL_H_
 
-#include "util/string.h"
-
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -328,14 +326,6 @@ private:
     // Misc
     bool starts_with_windows_drive_letter(std::string_view) const;
     void shorten_url_path(Url &) const;
-
-    constexpr bool is_windows_drive_letter(std::string_view input) const {
-        return input.size() == 2 && util::is_alpha(input[0]) && (input[1] == ':' || input[1] == '|');
-    }
-
-    constexpr bool is_normal_windows_drive_letter(std::string_view input) const {
-        return input.size() == 2 && util::is_alpha(input[0]) && input[1] == ':';
-    }
 
     // Parser state
     std::string_view input_{};


### PR DESCRIPTION
`is_windows_drive_letter` and `is_normal_windows_drive_letter` were already private to `UrlParser`, so moving them into the .cpp is an easy way of getting rid of this public dependency with no real downsides.