### PR TITLE
dom: Support keeping comments around

### DIFF
--- a/dom/dom.cpp
+++ b/dom/dom.cpp
@@ -47,8 +47,11 @@ void print_node(dom::Node const &node, std::ostream &os, int initial_depth = 0) 
             for (auto const &child : element->children | std::views::reverse) {
                 to_print.emplace_back(&child, current_depth + 1);
             }
+        } else if (auto const *comment = std::get_if<dom::Comment>(current_node)) {
+            os << "<!-- " << comment->text << " -->";
         } else {
-            os << '"' << std::get<dom::Text>(*current_node).text << '"';
+            auto const &text = std::get<dom::Text>(*current_node);
+            os << '"' << text.text << '"';
         }
     }
 }
@@ -58,6 +61,10 @@ void print_node(dom::Node const &node, std::ostream &os, int initial_depth = 0) 
 std::string to_string(Document const &document) {
     std::stringstream ss;
     ss << "#document";
+    for (auto const &comment : document.pre_html_node_comments) {
+        ss << "\n| <!-- " << comment.text << " -->";
+    }
+
     if (!document.doctype.empty()) {
         ss << "\n| <!DOCTYPE " << document.doctype;
         if (!document.public_identifier.empty() || !document.system_identifier.empty()) {

--- a/dom/dom.h
+++ b/dom/dom.h
@@ -17,13 +17,19 @@ namespace dom {
 
 struct Text;
 struct Element;
+struct Comment;
 
 using AttrMap = std::map<std::string, std::string, std::less<>>;
-using Node = std::variant<Element, Text>;
+using Node = std::variant<Element, Text, Comment>;
 
 struct Text {
     std::string text;
     [[nodiscard]] bool operator==(Text const &) const = default;
+};
+
+struct Comment {
+    std::string text;
+    [[nodiscard]] bool operator==(Comment const &) const = default;
 };
 
 struct Element {
@@ -37,6 +43,7 @@ struct Document {
     std::string doctype;
     std::string public_identifier;
     std::string system_identifier;
+    std::vector<Comment> pre_html_node_comments;
     Node html_node;
 
     // https://dom.spec.whatwg.org/#concept-document-mode

--- a/dom/dom_test.cpp
+++ b/dom/dom_test.cpp
@@ -113,5 +113,43 @@ int main() {
 |     "goodbye")");
     });
 
+    s.add_test("to_string(Document), but with comments!", [](etest::IActions &a) {
+        auto document = dom::Document{
+                .doctype{"html5"},
+                .public_identifier{"-//W3C//DTD HTML 4.01//EN"},
+                .system_identifier{"http://www.w3.org/TR/html4/strict.dtd"},
+                .pre_html_node_comments{{"This is a comment before the html node"}, {"this is too!"}},
+        };
+        document.html_node = dom::Element{
+                .name{"html"},
+                .children{{
+                        dom::Element{
+                                .name{"head"},
+                                .children{{dom::Element{.name{"title"}, .children{dom::Text{"hello"}}}}},
+                        },
+                        dom::Element{
+                                .name{"body"},
+                                .children{
+                                        dom::Comment{"This is a comment inside body"},
+                                        dom::Text{"goodbye"},
+                                },
+                        },
+                }},
+        };
+
+        std::string_view expected = R"(#document
+| <!-- This is a comment before the html node -->
+| <!-- this is too! -->
+| <!DOCTYPE html5 "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+| <html>
+|   <head>
+|     <title>
+|       "hello"
+|   <body>
+|     <!-- This is a comment inside body -->
+|     "goodbye")";
+        a.expect_eq(to_string(document), expected);
+    });
+
     return s.run();
 }

--- a/html/BUILD
+++ b/html/BUILD
@@ -60,7 +60,7 @@ cc_library(
     # "adoption01",
     # "adoption02",
     # "blocks",
-    # "comments01",
+    "comments01",
     "doctype01",
     # "domjs-unsafe",
     "entities01",

--- a/html/html5lib_tree_construction_test.cpp
+++ b/html/html5lib_tree_construction_test.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
         }
 
         s.add_test(test.input, [=](etest::IActions &a) {
-            auto document = html::parse(test.input);
+            auto document = html::parse(test.input, {.include_comments = true});
             a.expect_eq(to_string(document), test.expected_result);
         });
     }

--- a/html/parser.h
+++ b/html/parser.h
@@ -41,7 +41,7 @@ private:
 
                       cbs.on_error(err);
                   }},
-          scripting_{opts.scripting}, cbs_{cbs} {}
+          scripting_{opts.scripting}, include_comments_{opts.include_comments}, cbs_{cbs} {}
 
     [[nodiscard]] dom::Document run() {
         tokenizer_.run();
@@ -61,9 +61,18 @@ private:
     dom::Document doc_{};
     std::vector<dom::Element *> open_elements_{};
     bool scripting_{false};
+    bool include_comments_{false};
     Callbacks const &cbs_;
     html2::InsertionMode insertion_mode_{};
-    Actions actions_{doc_, tokenizer_, scripting_, insertion_mode_, open_elements_, cbs_.on_element_closed};
+    Actions actions_{
+            doc_,
+            tokenizer_,
+            scripting_,
+            include_comments_ ? CommentMode::Keep : CommentMode::Discard,
+            insertion_mode_,
+            open_elements_,
+            cbs_.on_element_closed,
+    };
 };
 
 } // namespace html

--- a/html/parser_actions.h
+++ b/html/parser_actions.h
@@ -83,6 +83,10 @@ public:
         insert({token.tag_name, into_dom_attributes(token.attributes)});
     }
 
+    void insert_element_for(html2::CommentToken const &) override {
+        // TODO(robinlinden): Insert comments.
+    }
+
     void pop_current_node() override {
         auto const *current_element = open_elements_.back();
         open_elements_.pop_back();

--- a/html/parser_options.h
+++ b/html/parser_options.h
@@ -14,6 +14,7 @@ namespace html {
 
 struct ParserOptions {
     bool scripting{false};
+    bool include_comments{false};
 };
 
 struct Callbacks {

--- a/html2/iparser_actions.h
+++ b/html2/iparser_actions.h
@@ -31,6 +31,7 @@ public:
     virtual QuirksMode quirks_mode() const = 0;
     virtual bool scripting() const = 0;
     virtual void insert_element_for(html2::StartTagToken const &) = 0;
+    virtual void insert_element_for(html2::CommentToken const &) = 0;
     virtual void pop_current_node() = 0;
     virtual std::string_view current_node_name() const = 0;
     virtual void merge_into_html_node(std::span<html2::Attribute const>) = 0;

--- a/html2/parser_states.cpp
+++ b/html2/parser_states.cpp
@@ -36,6 +36,7 @@ public:
     QuirksMode quirks_mode() const override { return wrapped_.quirks_mode(); }
     bool scripting() const override { return wrapped_.scripting(); }
     void insert_element_for(html2::StartTagToken const &token) override { wrapped_.insert_element_for(token); }
+    void insert_element_for(html2::CommentToken const &token) override { wrapped_.insert_element_for(token); }
     void pop_current_node() override { wrapped_.pop_current_node(); }
     std::string_view current_node_name() const override { return wrapped_.current_node_name(); }
     void merge_into_html_node(std::span<html2::Attribute const> attributes) override {
@@ -388,8 +389,8 @@ std::optional<InsertionMode> Initial::process(IActions &a, html2::Token const &t
         return {};
     }
 
-    if (std::holds_alternative<html2::CommentToken>(token)) {
-        // TODO(robinlinden): Insert as last child.
+    if (auto const *comment = std::get_if<html2::CommentToken>(&token)) {
+        a.insert_element_for(*comment);
         return {};
     }
 
@@ -461,8 +462,8 @@ std::optional<InsertionMode> BeforeHead::process(IActions &a, html2::Token const
         return {};
     }
 
-    if (std::holds_alternative<html2::CommentToken>(token)) {
-        // TODO(robinlinden): Insert a comment.
+    if (auto const *comment = std::get_if<html2::CommentToken>(&token)) {
+        a.insert_element_for(*comment);
         return {};
     }
 
@@ -504,8 +505,8 @@ std::optional<InsertionMode> InHead::process(IActions &a, html2::Token const &to
         return {};
     }
 
-    if (std::holds_alternative<html2::CommentToken>(token)) {
-        // TODO(robinlinden): Insert a comment.
+    if (auto const *comment = std::get_if<html2::CommentToken>(&token)) {
+        a.insert_element_for(*comment);
         return {};
     }
 
@@ -642,8 +643,8 @@ std::optional<InsertionMode> AfterHead::process(IActions &a, html2::Token const 
         return {};
     }
 
-    if (std::holds_alternative<html2::CommentToken>(token)) {
-        // TODO(robinlinden): Insert.
+    if (auto const *comment = std::get_if<html2::CommentToken>(&token)) {
+        a.insert_element_for(*comment);
         return {};
     }
 
@@ -751,8 +752,8 @@ std::optional<InsertionMode> InBody::process(IActions &a, html2::Token const &to
         return {};
     }
 
-    if (std::holds_alternative<html2::CommentToken>(token)) {
-        // TODO(robinlinden): Insert.
+    if (auto const *comment = std::get_if<html2::CommentToken>(&token)) {
+        a.insert_element_for(*comment);
         return {};
     }
 
@@ -1178,8 +1179,8 @@ std::optional<InsertionMode> InTable::process(IActions &a, html2::Token const &t
         return maybe_next.value_or(std::move(table_text));
     }
 
-    if (std::holds_alternative<html2::CommentToken>(token)) {
-        // TODO(robinlinden): Insert.
+    if (auto const *comment = std::get_if<html2::CommentToken>(&token)) {
+        a.insert_element_for(*comment);
         return {};
     }
 
@@ -1274,8 +1275,8 @@ std::optional<InsertionMode> InFrameset::process(IActions &a, html2::Token const
         return {};
     }
 
-    if (std::holds_alternative<html2::CommentToken>(token)) {
-        // TODO(robinlinden): Insert.
+    if (auto const *comment = std::get_if<html2::CommentToken>(&token)) {
+        a.insert_element_for(*comment);
         return {};
     }
 

--- a/html2/parser_states_test.cpp
+++ b/html2/parser_states_test.cpp
@@ -45,7 +45,16 @@ ParseResult parse(std::string_view html, ParseOptions const &opts) {
     html2::InsertionMode mode{opts.initial_insertion_mode};
     std::vector<dom::Element *> open_elements{};
     std::function<void(dom::Element const &)> on_element_closed{};
-    html::Actions actions{res.document, tokenizer, opts.scripting, mode, open_elements, on_element_closed};
+    html::Actions actions{
+            res.document,
+            tokenizer,
+            opts.scripting,
+            // TODO(robinlinden): Update tests to be happy with comments.
+            html::CommentMode::Discard,
+            mode,
+            open_elements,
+            on_element_closed,
+    };
 
     auto on_token = [&](html2::Tokenizer &, html2::Token const &token) {
         mode = std::visit([&](auto &v) { return v.process(actions, token); }, mode).value_or(mode);


### PR DESCRIPTION
This allows us to run more of the spectests without hacking in comment exclusion stuff in our test runner. //style and //layout might need some work to support comments, so this is an default-off option for now.