### PR TITLE
layout: Take line-height into account when layouting text

### DIFF
--- a/css/property_id.cpp
+++ b/css/property_id.cpp
@@ -155,6 +155,9 @@ constexpr auto kInitialValues = std::to_array<std::pair<css::PropertyId, std::st
         // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#formal_definition
         {css::PropertyId::FontWeight, "normal"sv},
 
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#formal_definition
+        {css::PropertyId::LineHeight, "normal"sv},
+
         // https://developer.mozilla.org/en-US/docs/Web/CSS/text-align#formal_definition
         // TODO(robinlinden): start, once supported.
         {css::PropertyId::TextAlign, "left"sv},

--- a/layout/layout.cpp
+++ b/layout/layout.cpp
@@ -409,9 +409,12 @@ void Layouter::layout_anonymous_block(LayoutBox &box, geom::Rect const &bounds, 
 
     auto weight = to_type(box.get_property<css::PropertyId::FontWeight>());
 
+    // TODO(robinlinden): This function should probably be looking at the child-items' height.
+    auto line_height = box.get_property<css::PropertyId::LineHeight>().resolve(font_size.v, resolution_context_);
+
     for (std::size_t i = 0; i < box.children.size(); ++i) {
         auto *child = &box.children[i];
-        layout(*child, box.dimensions.content.translated(last_child_end, current_line * font_size.v), last_block_width);
+        layout(*child, box.dimensions.content.translated(last_child_end, current_line * line_height), last_block_width);
 
         // TODO(robinlinden): This needs to get along better with whitespace
         // collapsing. A <br> followed by a whitespace will be lead to a leading
@@ -428,7 +431,7 @@ void Layouter::layout_anonymous_block(LayoutBox &box, geom::Rect const &bounds, 
             if (child->dimensions.margin_box().x - box.dimensions.margin_box().x > bounds.width) {
                 last_child_end = 0;
                 current_line += 1;
-                layout(*child, box.dimensions.content.translated(0, current_line * font_size.v), last_block_width);
+                layout(*child, box.dimensions.content.translated(0, current_line * line_height), last_block_width);
                 continue;
             }
 
@@ -557,8 +560,9 @@ void Layouter::calculate_width_and_margin(
 void Layouter::calculate_inline_height(LayoutBox &box, int const font_size) const {
     assert(box.node != nullptr);
     if (auto text = box.text()) {
+        auto line_height = box.get_property<css::PropertyId::LineHeight>().resolve(font_size, resolution_context_);
         int lines = static_cast<int>(std::ranges::count(*text, '\n')) + 1;
-        box.dimensions.content.height = lines * font_size;
+        box.dimensions.content.height = lines * line_height;
     }
 }
 

--- a/layout/layout_box_test.cpp
+++ b/layout/layout_box_test.cpp
@@ -54,7 +54,11 @@ int main() {
         };
         auto style_root = style::StyledNode{
                 .node = dom_root,
-                .properties = {{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{
                         {children[0], {{css::PropertyId::Display, "block"}}, {std::move(style_children)}},
                 },
@@ -174,7 +178,11 @@ int main() {
         };
         auto style_root = style::StyledNode{
                 .node = dom_root,
-                .properties = {{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{{std::move(body_style)}},
         };
         set_up_parent_ptrs(style_root);

--- a/layout/layout_test.cpp
+++ b/layout/layout_test.cpp
@@ -69,7 +69,11 @@ void whitespace_collapsing_tests(etest::Suite &s) {
         };
         style::StyledNode style{
                 .node{html},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{std::move(p_style)},
         };
         set_up_parent_ptrs(style);
@@ -124,7 +128,11 @@ void whitespace_collapsing_tests(etest::Suite &s) {
         };
         style::StyledNode style{
                 .node{html},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{std::move(p_style)},
         };
         set_up_parent_ptrs(style);
@@ -191,7 +199,11 @@ void whitespace_collapsing_tests(etest::Suite &s) {
         };
         style::StyledNode style{
                 .node{html},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{std::move(p_style)},
         };
         set_up_parent_ptrs(style);
@@ -261,7 +273,11 @@ void whitespace_collapsing_tests(etest::Suite &s) {
         };
         style::StyledNode style{
                 .node{html},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{std::move(first_style), std::move(block_style), std::move(second_style)},
         };
         set_up_parent_ptrs(style);
@@ -337,7 +353,11 @@ void whitespace_collapsing_tests(etest::Suite &s) {
         };
         style::StyledNode style{
                 .node{html},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{std::move(first_style), std::move(space_style), std::move(second_style)},
         };
         set_up_parent_ptrs(style);
@@ -412,7 +432,11 @@ void whitespace_collapsing_tests(etest::Suite &s) {
         };
         style::StyledNode style{
                 .node{html},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{std::move(first_style), std::move(space_style), std::move(second_style)},
         };
         set_up_parent_ptrs(style);
@@ -494,6 +518,7 @@ void whitespace_collapsing_tests(etest::Suite &s) {
                 .properties{
                         {css::PropertyId::Display, "block"},
                         {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
                         {css::PropertyId::WhiteSpace, "pre"},
                 },
                 .children{std::move(first_style), std::move(space_style), std::move(second_style)},
@@ -561,7 +586,11 @@ void text_transform_tests(etest::Suite &s) {
         };
         style::StyledNode style{
                 .node{html},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{std::move(p_style)},
         };
         set_up_parent_ptrs(style);
@@ -605,7 +634,11 @@ void text_transform_tests(etest::Suite &s) {
         };
         style::StyledNode style{
                 .node{html},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{std::move(p_style)},
         };
         set_up_parent_ptrs(style);
@@ -649,7 +682,11 @@ void text_transform_tests(etest::Suite &s) {
         };
         style::StyledNode style{
                 .node{html},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{std::move(p_style)},
         };
         set_up_parent_ptrs(style);
@@ -988,7 +1025,11 @@ int main() {
         auto const &children = std::get<dom::Element>(dom_root).children;
         auto style_root = style::StyledNode{
             .node = dom_root,
-            .properties = {{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+            .properties = {
+                    {css::PropertyId::Display, "block"},
+                    {css::PropertyId::FontSize, "10px"},
+                    {css::PropertyId::LineHeight, "1"},
+            },
             .children = {
                 {children[0], {{css::PropertyId::Display, "block"}}, {
                     {std::get<dom::Element>(children[0]).children[0], {}, {}},
@@ -1816,6 +1857,7 @@ int main() {
                 .properties{
                         {css::PropertyId::Display, "inline"},
                         {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
                         {css::PropertyId::FontWeight, "bold"},
                 },
                 .children{style::StyledNode{.node{std::get<dom::Element>(dom).children[0]}}},
@@ -1840,7 +1882,11 @@ int main() {
         dom::Node dom = dom::Element{.name{"html"}, .children{dom::Text{"hello"}}};
         style::StyledNode style{
                 .node{dom},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{style::StyledNode{.node{std::get<dom::Element>(dom).children[0]}}},
         };
         set_up_parent_ptrs(style);
@@ -1897,7 +1943,11 @@ int main() {
         dom::Node dom = dom::Element{.name{"html"}, .children{dom::Text{"hi hello"}}};
         style::StyledNode style{
                 .node{dom},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{style::StyledNode{.node{std::get<dom::Element>(dom).children[0]}}},
         };
         set_up_parent_ptrs(style);
@@ -1934,7 +1984,11 @@ int main() {
         dom::Node dom = dom::Element{.name{"html"}, .children{dom::Text{"oh no !! !"}}};
         style::StyledNode style{
                 .node{dom},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{style::StyledNode{.node{std::get<dom::Element>(dom).children[0]}}},
         };
         set_up_parent_ptrs(style);
@@ -1980,6 +2034,7 @@ int main() {
                 .properties{
                         {css::PropertyId::Display, "block"},
                         {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
                 },
                 .children{
                         style::StyledNode{.node{html.children[0]}},
@@ -2037,6 +2092,7 @@ int main() {
                 .properties{
                         {css::PropertyId::Display, "block"},
                         {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
                 },
                 .children{
                         style::StyledNode{.node{html.children[0]}},
@@ -2086,7 +2142,11 @@ int main() {
         dom::Node dom = dom::Element{.name{"html"}, .children{dom::Text{"hello"}}};
         style::StyledNode style{
                 .node{dom},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{style::StyledNode{.node{std::get<dom::Element>(dom).children[0]}}},
         };
         set_up_parent_ptrs(style);
@@ -2122,7 +2182,11 @@ int main() {
 
         style::StyledNode style{
                 .node{dom},
-                .properties{{css::PropertyId::Display, "block"}, {css::PropertyId::FontSize, "10px"}},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{
                         style::StyledNode{.node{children[0]}},
                         style::StyledNode{.node{children[1]}},
@@ -2246,7 +2310,11 @@ int main() {
         auto &span = std::get<dom::Element>(dom).children[0];
         style::StyledNode style{
                 .node{dom},
-                .properties{{css::PropertyId::FontSize, "10px"}, {css::PropertyId::Display, "block"}},
+                .properties{
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::LineHeight, "1"},
+                },
                 .children{
                         style::StyledNode{
                                 .node{span},
@@ -2304,6 +2372,7 @@ int main() {
                 .properties{
                         {css::PropertyId::Display, "block"},
                         {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1"},
                 },
                 .children{
                         style::StyledNode{
@@ -2431,6 +2500,41 @@ int main() {
         };
 
         auto l = layout::create_layout(style, {.viewport_width = 600}).value();
+        a.expect_eq(l, expected);
+    });
+
+    s.add_test("line-height", [](etest::IActions &a) {
+        dom::Node dom = dom::Element{.name{"html"}, .children{dom::Text{"hi"}}};
+        style::StyledNode style{
+                .node{dom},
+                .properties{
+                        {css::PropertyId::Display, "block"},
+                        {css::PropertyId::FontSize, "10px"},
+                        {css::PropertyId::LineHeight, "1.5"},
+                },
+                .children{style::StyledNode{.node{std::get<dom::Element>(dom).children.at(0)}}},
+        };
+        set_up_parent_ptrs(style);
+
+        layout::LayoutBox expected{
+                .node = &style,
+                .dimensions{{0, 0, 25, 15}},
+                .children{
+                        layout::LayoutBox{
+                                .node = nullptr,
+                                .dimensions{{0, 0, 25, 15}},
+                                .children{
+                                        layout::LayoutBox{
+                                                .node = &style.children[0],
+                                                .dimensions{{0, 0, 10, 15}},
+                                                .layout_text = "hi"sv,
+                                        },
+                                },
+                        },
+                },
+        };
+
+        auto l = layout::create_layout(style, {.viewport_width = 25}, NoType{}).value();
         a.expect_eq(l, expected);
     });
 

--- a/style/styled_node.cpp
+++ b/style/styled_node.cpp
@@ -222,6 +222,22 @@ int UnresolvedBorderWidth::resolve(
     return width.resolve(font_size, context, percent_relative_to);
 }
 
+int UnresolvedLineHeight::resolve(int font_size, ResolutionInfo context, std::optional<int> percent_relative_to) const {
+    if (line_height.raw == "normal") {
+        return static_cast<int>(font_size * 1.2f);
+    }
+
+    float maybe_line_height{};
+    auto res = util::from_chars(
+            line_height.raw.data(), line_height.raw.data() + line_height.raw.size(), maybe_line_height);
+    if (res.ec == std::errc{} && line_height.raw.data() + line_height.raw.size() == res.ptr) {
+        return static_cast<int>(font_size * maybe_line_height);
+    }
+
+    return line_height.try_resolve(font_size, context, percent_relative_to)
+            .value_or(static_cast<int>(1.2f * font_size));
+}
+
 // NOLINTNEXTLINE(misc-no-recursion)
 std::string_view StyledNode::get_raw_property(css::PropertyId property) const {
     // We don't support selector specificity yet, so the last property is found

--- a/style/styled_node.h
+++ b/style/styled_node.h
@@ -117,6 +117,14 @@ struct UnresolvedBorderWidth {
     int resolve(int font_size, ResolutionInfo, std::optional<int> percent_relative_to = std::nullopt) const;
 };
 
+struct UnresolvedLineHeight {
+    UnresolvedValue line_height{};
+    [[nodiscard]] bool operator==(UnresolvedLineHeight const &) const = default;
+
+    [[nodiscard]] int resolve(
+            int font_size, ResolutionInfo, std::optional<int> percent_relative_to = std::nullopt) const;
+};
+
 // NOLINTNEXTLINE(misc-no-recursion)
 struct StyledNode {
     dom::Node const &node;
@@ -179,6 +187,8 @@ struct StyledNode {
         } else if constexpr (T == css::PropertyId::BorderBottomWidth || T == css::PropertyId::BorderLeftWidth
                 || T == css::PropertyId::BorderRightWidth || T == css::PropertyId::BorderTopWidth) {
             return UnresolvedBorderWidth{{get_raw_property(T)}};
+        } else if constexpr (T == css::PropertyId::LineHeight) {
+            return UnresolvedLineHeight{{get_raw_property(T)}};
         } else {
             return get_raw_property(T);
         }

--- a/style/styled_node_test.cpp
+++ b/style/styled_node_test.cpp
@@ -669,5 +669,14 @@ int main() {
                 std::vector{style::TextDecorationLine::None});
     });
 
+    s.add_test("line-height", [](etest::IActions &a) {
+        expect_property_eq<css::PropertyId::LineHeight>(a, "normal", style::UnresolvedLineHeight{"normal"});
+        expect_property_eq<css::PropertyId::LineHeight>(a, "1.5", style::UnresolvedLineHeight{"1.5"});
+
+        a.expect_eq(style::UnresolvedLineHeight{"30px"}.resolve(0, {}), 30.f);
+        a.expect_eq(style::UnresolvedLineHeight{"1.5"}.resolve(10, {}), 15.f);
+        a.expect_eq(style::UnresolvedLineHeight{"normal"}.resolve(10, {}), 12.f);
+    });
+
     return s.run();
 }


### PR DESCRIPTION
https://gr.ht, after and before these changes:

<img alt="gr.ht, after and before line-height support" src="https://github.com/user-attachments/assets/ada51753-9750-4442-b8c1-c40b64c4bccc" />

https://seirdy.one, after and before these changes:
<img alt="seridy.one, after and before these changes" src="https://github.com/user-attachments/assets/3236aca8-5769-4b36-9195-d575303e9f4d" />
