### PR TITLE
ci: Update codecov-cli

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -206,7 +206,7 @@ jobs:
       - run: lcov --ignore-errors inconsistent --summary bazel-out/_coverage/_coverage_report.dat
       - name: Upload
         run: |
-          pipx install codecov-cli==10.4.0
+          pipx install codecov-cli==11.2.3
           codecovcli upload-process --fail-on-error --file bazel-out/_coverage/_coverage_report.dat
 
   linux-aarch64-muslc:


### PR DESCRIPTION
codecov-cli randomly decided to break, even though we've pinned it. Updating it seems to fix it. We haven't updated it in a while, because the author of codecov-cli decided to move it to a different repo, so my release watch didn't catch the new releases. :(
<img width="895" height="162" alt="image" src="https://github.com/user-attachments/assets/48bb8661-c8a6-4b80-a3d7-0931185aa9d0" />

```
Run pipx install codecov-cli==10.4.0
  pipx install codecov-cli==10.4.0
  codecovcli upload-process --fail-on-error --file bazel-out/_coverage/_coverage_report.dat
  shell: /usr/bin/bash -e {0}
  env:
    CC: gcc-13
    CXX: g++-13
    GCOV: gcov-13
creating virtual environment...
installing codecov-cli from spec 'codecov-cli==10.4.0'...
done! ✨ 🌟 ✨
  installed package codecov-cli 10.4.0, installed using Python 3.12.3
  These apps are now globally available
    - codecov
    - codecovcli
info - 2025-09-19 15:05:10,538 -- ci service found: github-actions
Usage: codecovcli upload-process [OPTIONS]
Try 'codecovcli upload-process -h' for help.

Error: Missing option '-C' / '--sha' / '--commit-sha'.
Error: Process completed with exit code 2.
```