### PR TITLE
browser: Remove unused code, update the UA to match Tor Browser again

### DIFF
--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -272,7 +272,7 @@ std::vector<std::string_view> collect_image_urls(
 
 } // namespace
 
-App::App(std::string browser_title, std::string start_page_hint, bool load_start_page)
+App::App(std::string browser_title, std::string start_page_hint)
     : engine_{create_protocol_handler(),
               create_font_system(),
               [this](std::string_view url) -> std::optional<layout::Size> {
@@ -303,10 +303,8 @@ App::App(std::string browser_title, std::string start_page_hint, bool load_start
 
     canvas_->set_viewport_size(window_.getSize().x, window_.getSize().y);
 
-    if (load_start_page) {
-        ensure_has_scheme(url_buf_);
-        navigate();
-    }
+    ensure_has_scheme(url_buf_);
+    navigate();
 }
 
 App::~App() {

--- a/browser/gui/app.cpp
+++ b/browser/gui/app.cpp
@@ -272,7 +272,6 @@ std::vector<std::string_view> collect_image_urls(
 
 } // namespace
 
-// Latest Firefox ESR user agent (on Windows). This matches what the Tor browser does.
 App::App(std::string browser_title, std::string start_page_hint, bool load_start_page)
     : engine_{create_protocol_handler(),
               create_font_system(),
@@ -426,8 +425,9 @@ void App::step() {
 }
 
 std::unique_ptr<protocol::IProtocolHandler> App::create_protocol_handler() const {
+    // Latest Firefox ESR user agent (on Windows). This matches what the Tor browser does.
     auto handlers = protocol::HandlerFactory::create(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0");
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0");
     auto about_handler = std::make_unique<browser::gui::AboutHandler>(Handlers{
             {
                     "blank",

--- a/browser/gui/app.h
+++ b/browser/gui/app.h
@@ -45,7 +45,7 @@ struct Image {
 
 class App final {
 public:
-    App(std::string browser_title, std::string start_page_hint, bool load_start_page);
+    App(std::string browser_title, std::string start_page_hint);
     ~App();
 
     void set_scale(unsigned scale);

--- a/browser/gui/main.cpp
+++ b/browser/gui/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    browser::gui::App app{kBrowserTitle, std::move(page), true};
+    browser::gui::App app{kBrowserTitle, std::move(page)};
     app.set_scale(scale);
 
     if (!exit_after_load) {

--- a/browser/tui/tui.cpp
+++ b/browser/tui/tui.cpp
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
     }
 
     // Latest Firefox ESR user agent (on Windows). This matches what the Tor browser does.
-    auto user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0"s;
+    auto user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0"s;
     engine::Engine engine{protocol::HandlerFactory::create(std::move(user_agent))};
     auto maybe_page = engine.navigate(*uri);
     if (!maybe_page) {


### PR DESCRIPTION
Tor Browser does less spoofing of its UA these days, so we may want to look into how we deal with ours at some point: https://blog.torproject.org/new-alpha-release-tor-browser-140a4/