### PR TITLE
layout/test: Enable clang-format for everything

### DIFF
--- a/idna/idna_data_processor.cpp
+++ b/idna/idna_data_processor.cpp
@@ -238,7 +238,6 @@ int main(int argc, char **argv) {
 
 #ifndef IDNA_IDNA_DATA_H_
 #define IDNA_IDNA_DATA_H_
-// clang-format off
 
 #include <array>
 #include <string_view>
@@ -298,7 +297,6 @@ constexpr std::array<std::pair<char32_t, Mapping>, )"
 
 } // namespace idna::uts46
 
-// clang-format on
 #endif
 )";
 }

--- a/unicode/unicode_data_processor.cpp
+++ b/unicode/unicode_data_processor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2024-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    std::cout << R"(// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+    std::cout << R"(// SPDX-FileCopyrightText: 2024-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -34,7 +34,6 @@ int main(int argc, char **argv) {
 
 #ifndef UNICODE_UNICODE_DATA_H_
 #define UNICODE_UNICODE_DATA_H_
-// clang-format off
 
 #include <array>
 #include <string_view>
@@ -82,6 +81,5 @@ constexpr auto kDecompositions = std::to_array<Decomposition>({
 
     std::cout << "});\n\n"
               << "} // namespace unicode::generated\n\n"
-              << "// clang-format on\n"
               << "#endif\n";
 }


### PR DESCRIPTION
This was mostly adding commas, removing `=` from `children = {`, and replacing create_element_node with just creating the nodes directly.