### PR TITLE
js: Allow creating native-fn values directly from lambdas

### DIFF
--- a/js/ast.h
+++ b/js/ast.h
@@ -66,6 +66,7 @@ public:
     explicit Value(std::vector<Value> value) : value_{std::move(value)} {}
     explicit Value(Object value) : value_{std::move(value)} {}
     explicit Value(NativeFunction value) : value_{std::move(value)} {}
+    explicit Value(std::function<Value(std::vector<Value> const &)> f) : value_{NativeFunction{std::move(f)}} {}
 
     bool is_undefined() const { return std::holds_alternative<Undefined>(value_); }
     bool is_number() const { return std::holds_alternative<double>(value_); }

--- a/js/integration_test.cpp
+++ b/js/integration_test.cpp
@@ -16,9 +16,9 @@ int main() {
 
     s.add_test("foo()", [](etest::IActions &a) {
         js::ast::Interpreter e;
-        e.variables["foo"] = js::ast::Value{js::ast::NativeFunction{[](auto const &) {
+        e.variables["foo"] = js::ast::Value{[](auto const &) {
             return js::ast::Value{42}; //
-        }}};
+        }};
 
         auto p = js::Parser::parse("foo()").value();
         a.expect_eq(e.execute(p), js::ast::Value{42});
@@ -26,9 +26,9 @@ int main() {
 
     s.add_test("foo();", [](etest::IActions &a) {
         js::ast::Interpreter e;
-        e.variables["foo"] = js::ast::Value{js::ast::NativeFunction{[](auto const &) {
+        e.variables["foo"] = js::ast::Value{[](auto const &) {
             return js::ast::Value{42}; //
-        }}};
+        }};
 
         auto p = js::Parser::parse("foo();").value();
         a.expect_eq(e.execute(p), js::ast::Value{42});
@@ -36,9 +36,9 @@ int main() {
 
     s.add_test("foo(1, 2)", [](etest::IActions &a) {
         js::ast::Interpreter e;
-        e.variables["foo"] = js::ast::Value{js::ast::NativeFunction{[](auto const &args) {
+        e.variables["foo"] = js::ast::Value{[](auto const &args) {
             return js::ast::Value{args.at(0).as_number() + args.at(1).as_number()}; //
-        }}};
+        }};
 
         auto p = js::Parser::parse("foo(1, 2)").value();
         a.expect_eq(e.execute(p), js::ast::Value{3.});
@@ -46,9 +46,9 @@ int main() {
 
     s.add_test("foo('bar')", [](etest::IActions &a) {
         js::ast::Interpreter e;
-        e.variables["foo"] = js::ast::Value{js::ast::NativeFunction{[](auto const &args) {
+        e.variables["foo"] = js::ast::Value{[](auto const &args) {
             return js::ast::Value{args.at(0).as_string()}; //
-        }}};
+        }};
 
         auto p = js::Parser::parse("foo('bar')").value();
         a.expect_eq(e.execute(p), js::ast::Value{"bar"});
@@ -56,11 +56,11 @@ int main() {
 
     s.add_test("foo(1, \"bar\")", [](etest::IActions &a) {
         js::ast::Interpreter e;
-        e.variables["foo"] = js::ast::Value{js::ast::NativeFunction{[](auto const &args) {
+        e.variables["foo"] = js::ast::Value{[](auto const &args) {
             return js::ast::Value{
                     std::format("{}: {}", args.at(1).as_string(), args.at(0).as_number()),
             };
-        }}};
+        }};
 
         auto p = js::Parser::parse("foo(1, \"bar\")").value();
         a.expect_eq(e.execute(p), js::ast::Value{"bar: 1"});
@@ -68,9 +68,9 @@ int main() {
 
     s.add_test("foo(hello)", [](etest::IActions &a) {
         js::ast::Interpreter e;
-        e.variables["foo"] = js::ast::Value{js::ast::NativeFunction{[](auto const &args) {
+        e.variables["foo"] = js::ast::Value{[](auto const &args) {
             return js::ast::Value{args.at(0).as_string()}; //
-        }}};
+        }};
         e.variables["hello"] = js::ast::Value{"fantastic"};
 
         auto p = js::Parser::parse("foo(hello)").value();
@@ -80,14 +80,14 @@ int main() {
     s.add_test("foo(1, 2); bar(3, 4)", [](etest::IActions &a) {
         int i = 0; // Hack to check that the functions are called in order.
         js::ast::Interpreter e;
-        e.variables["add"] = js::ast::Value{js::ast::NativeFunction{[&](auto const &args) {
+        e.variables["add"] = js::ast::Value{[&](auto const &args) {
             i = 7;
             return js::ast::Value{args.at(0).as_number() + args.at(1).as_number()};
-        }}};
-        e.variables["mul"] = js::ast::Value{js::ast::NativeFunction{[&](auto const &args) {
+        }};
+        e.variables["mul"] = js::ast::Value{[&](auto const &args) {
             i *= 2;
             return js::ast::Value{args.at(0).as_number() * args.at(1).as_number()};
-        }}};
+        }};
 
         auto p = js::Parser::parse("add(1, 2); mul(3, 4)").value();
         a.expect_eq(e.execute(p), js::ast::Value{12.});
@@ -97,14 +97,14 @@ int main() {
     s.add_test("foo(1, 2); bar(3, 4);", [](etest::IActions &a) {
         int i = 0; // Hack to check that the functions are called in order.
         js::ast::Interpreter e;
-        e.variables["add"] = js::ast::Value{js::ast::NativeFunction{[&](auto const &args) {
+        e.variables["add"] = js::ast::Value{[&](auto const &args) {
             i = 7;
             return js::ast::Value{args.at(0).as_number() + args.at(1).as_number()};
-        }}};
-        e.variables["mul"] = js::ast::Value{js::ast::NativeFunction{[&](auto const &args) {
+        }};
+        e.variables["mul"] = js::ast::Value{[&](auto const &args) {
             i *= 2;
             return js::ast::Value{args.at(0).as_number() * args.at(1).as_number()};
-        }}};
+        }};
 
         auto p = js::Parser::parse("add(1, 2); mul(3, 4);").value();
         a.expect_eq(e.execute(p), js::ast::Value{12.});


### PR DESCRIPTION
This is just a convenience that I was missing when setting up JS stdlib bits.