### PR TITLE
Target Unicode 17

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -778,13 +778,13 @@ bazel_dep(name = "ucd")
 archive_override(
     module_name = "ucd",
     build_file_content = """exports_files(["UnicodeData.txt"])""",
-    integrity = "sha256-yG3YHysUpDsMwGSqX4mqckE4aAHjXFnHmE5XmDJjTrI=",
+    integrity = "sha256-IGbRkJsuqTkWzgktocDuSAjqPvhAfJS08U9bfrJj0o4=",
     patch_cmds = [
         """cat <<EOF >MODULE.bazel
 module(name = "ucd")
 EOF""",
     ],
-    url = "https://www.unicode.org/Public/16.0.0/ucd/UCD.zip",
+    url = "https://www.unicode.org/Public/17.0.0/ucd/UCD.zip",
 )
 
 # https://github.com/illiliti/libudev-zero


### PR DESCRIPTION
No changes to the uts46-bits this time: https://www.unicode.org/reports/tr46/#Modifications 
<img width="694" height="174" alt="image" src="https://github.com/user-attachments/assets/76ba715d-36e5-4796-97d2-ecfa57d97417" />

And the ucd bits is all lookup table stuff, so no code changes there either.