### PR TITLE
engine: Support 303 redirects

### DIFF
--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -242,7 +242,8 @@ Engine::LoadResult Engine::load(uri::Uri uri) {
     static constexpr int kMaxRedirects = 10;
 
     auto is_redirect = [](int status_code) {
-        return status_code == 301 || status_code == 302 || status_code == 307 || status_code == 308;
+        return status_code == 301 || status_code == 302 || status_code == 303 || status_code == 307
+                || status_code == 308;
     };
 
     int redirect_count = 0;


### PR DESCRIPTION
This is in use on https://srctree.gr.ht for issue links.

> A 303 response to a GET request indicates that the origin server does not have a representation of the [target resource](https://www.rfc-editor.org/rfc/rfc9110#target.resource) that can be transferred by the server over HTTP. However, the [Location](https://www.rfc-editor.org/rfc/rfc9110#field.location) field value refers to a resource that is descriptive of the target resource, such that making a retrieval request on that other resource might result in a representation that is useful to recipients without implying that it represents the original target resource. Note that answers to the questions of what can be represented, what representations are adequate, and what might be a useful description are outside the scope of HTTP.
> https://www.rfc-editor.org/rfc/rfc9110#status.303