### PR TITLE
azm: Implement AND and OR reg32,imm32

### DIFF
--- a/azm/amd64/assembler.h
+++ b/azm/amd64/assembler.h
@@ -95,6 +95,21 @@ public:
         emit(imm32);
     }
 
+    // Logical and, but with the wrong name because "and" == && in C++.
+    constexpr void land(Reg32 dst, Imm32 imm32) {
+        if (dst == Reg32::Eax) {
+            emit(0x25);
+            emit(imm32);
+            return;
+        }
+
+        emit(0x81);
+        auto idx = register_index(dst);
+        assert(idx.has_value());
+        mod_rm(0b11, 4, *idx);
+        emit(imm32);
+    }
+
     void jmp(Label &label) {
         // JMP rel32
         if (std::holds_alternative<Label::Linked>(label.v)) {
@@ -123,6 +138,21 @@ public:
         auto idx = register_index(dst);
         assert(idx.has_value());
         emit(0xb8 + idx.value());
+        emit(imm32);
+    }
+
+    // Logical or, but with the wrong name because "or" == || in C++.
+    constexpr void lor(Reg32 dst, Imm32 imm32) {
+        if (dst == Reg32::Eax) {
+            emit(0x0d);
+            emit(imm32);
+            return;
+        }
+
+        emit(0x81);
+        auto idx = register_index(dst);
+        assert(idx.has_value());
+        mod_rm(0b11, 1, *idx);
         emit(imm32);
     }
 

--- a/azm/amd64/assembler_test.cpp
+++ b/azm/amd64/assembler_test.cpp
@@ -43,6 +43,22 @@ int main() {
         a.expect_eq(assembler.take_assembled(), CodeVec{0x81, 0xc3, 0x42, 0, 0, 0});
     });
 
+    s.constexpr_test("AND reg32, imm32", [](etest::IActions &a) {
+        Assembler assembler;
+
+        // AND EAX,imm32 generates slightly shorter asm than AND w/ other registers.
+        assembler.land(Reg32::Eax, Imm32{0x42});
+        a.expect_eq(assembler.take_assembled(), CodeVec{0x25, 0x42, 0, 0, 0});
+
+        // More general mod_rm-encoding for these registers.
+        assembler.land(Reg32::Ecx, Imm32{0x42});
+        a.expect_eq(assembler.take_assembled(), CodeVec{0x81, 0xe1, 0x42, 0, 0, 0});
+        assembler.land(Reg32::Edx, Imm32{0x42});
+        a.expect_eq(assembler.take_assembled(), CodeVec{0x81, 0xe2, 0x42, 0, 0, 0});
+        assembler.land(Reg32::Ebx, Imm32{0x42});
+        a.expect_eq(assembler.take_assembled(), CodeVec{0x81, 0xe3, 0x42, 0, 0, 0});
+    });
+
     s.add_test("JMP, backwards", [](etest::IActions &a) {
         Assembler assembler;
 
@@ -120,6 +136,22 @@ int main() {
 
         assembler.mov(Reg32::Edx, Imm32{0x1234});
         a.expect_eq(assembler.take_assembled(), CodeVec{0xba, 0x34, 0x12, 0, 0});
+    });
+
+    s.constexpr_test("OR r32, imm32", [](etest::IActions &a) {
+        Assembler assembler;
+
+        // OR EAX,imm32 generates slightly shorter asm than OR w/ other registers.
+        assembler.lor(Reg32::Eax, Imm32{0x42});
+        a.expect_eq(assembler.take_assembled(), CodeVec{0x0d, 0x42, 0, 0, 0});
+
+        // More general mod_rm-encoding for these registers.
+        assembler.lor(Reg32::Ecx, Imm32{0x42});
+        a.expect_eq(assembler.take_assembled(), CodeVec{0x81, 0xc9, 0x42, 0, 0, 0});
+        assembler.lor(Reg32::Edx, Imm32{0x42});
+        a.expect_eq(assembler.take_assembled(), CodeVec{0x81, 0xca, 0x42, 0, 0, 0});
+        assembler.lor(Reg32::Ebx, Imm32{0x42});
+        a.expect_eq(assembler.take_assembled(), CodeVec{0x81, 0xcb, 0x42, 0, 0, 0});
     });
 
     s.constexpr_test("RET", [](etest::IActions &a) {


### PR DESCRIPTION
```cpp
    assembler.land(Reg32::Eax, Imm32{0xdeadbeef});
    assembler.land(Reg32::Ecx, Imm32{0x12345678});
    assembler.land(Reg32::Edx, Imm32{0x4321});
    assembler.land(Reg32::Ebx, Imm32{0x5678});

    assembler.lor(Reg32::Eax, Imm32{0xdeadbeef});
    assembler.lor(Reg32::Ecx, Imm32{0x12345678});
    assembler.lor(Reg32::Edx, Imm32{0x4321});
    assembler.lor(Reg32::Ebx, Imm32{0x5678});
```
=>
```
   0:   25 ef be ad de          and    eax,0xdeadbeef
   5:   81 e1 78 56 34 12       and    ecx,0x12345678
   b:   81 e2 21 43 00 00       and    edx,0x4321
  11:   81 e3 78 56 00 00       and    ebx,0x5678
  17:   0d ef be ad de          or     eax,0xdeadbeef
  1c:   81 c9 78 56 34 12       or     ecx,0x12345678
  22:   81 ca 21 43 00 00       or     edx,0x4321
  28:   81 cb 78 56 00 00       or     ebx,0x5678
```