### PR TITLE
js/test: Add fuzz testing of the interpreter

### DIFF
--- a/js/interpreter_fuzz_test.cpp
+++ b/js/interpreter_fuzz_test.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "js/interpreter.h"
+
+#include "js/parser.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+
+extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *data, std::size_t size);
+
+extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *data, std::size_t size) {
+    auto ast = js::Parser::parse({reinterpret_cast<char const *>(data), size});
+    if (!ast) {
+        return 0;
+    }
+
+    auto interpreter = js::ast::Interpreter{};
+    std::ignore = interpreter.execute(*ast);
+    return 0;
+}


### PR DESCRIPTION
The interpreter has a few cases where you can blow it up, but nothing's currently reachable due to the current limitations of the parser.