### PR TITLE
css: Handle more kinds of nested rules

### DIFF
--- a/css/parser.h
+++ b/css/parser.h
@@ -41,6 +41,7 @@ private:
     constexpr std::optional<char> consume_char();
 
     constexpr std::optional<std::string_view> consume_while(std::predicate<char> auto const &);
+    constexpr std::optional<std::string> consume_while_ignoring_comments(std::predicate<char> auto const &);
 
     constexpr void skip_whitespace();
 
@@ -51,7 +52,7 @@ private:
 
     [[nodiscard]] bool parse_rule(
             StyleSheet &, std::optional<MediaQuery> const &active_media_query, Rule const *parent);
-    std::optional<std::pair<std::string_view, std::string_view>> parse_declaration(std::string_view name);
+    static std::optional<std::pair<std::string_view, std::string_view>> parse_declaration(std::string_view declaration);
 
     static void add_declaration(Declarations &, std::string_view name, std::string_view value);
 

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -1358,6 +1358,19 @@ int main() {
                 });
     });
 
+    s.add_test("parser: nested rule, colon in child selector", [](etest::IActions &a) {
+        a.expect_eq(css::parse("foo { bar:baz { font-size: 3em; } }").rules, //
+                std::vector{
+                        css::Rule{
+                                .selectors = {{"foo bar:baz"}},
+                                .declarations{
+                                        {css::PropertyId::FontSize, "3em"},
+                                },
+                        },
+                        css::Rule{.selectors = {{"foo"}}},
+                });
+    });
+
     s.add_test("parser: nested rule, nesting selector", [](etest::IActions &a) {
         a.expect_eq(css::parse("p { color: green; &:hover { font-size: 3px; } font-size: 5px; }").rules, //
                 std::vector{


### PR DESCRIPTION
This fixes issues w/ child-selectors not being able to have `:` in the
name, as well as no longer assuming that anything starting w/ any of
`.#>&[|+~:` must be a child-selector.

With this change, https://srctree.gr.ht is usable on Hastur. 🥂 Still lots to do, especially related to not handling the various `display`-values, but we'll get there.

<img width="561" height="623" alt="image" src="https://github.com/user-attachments/assets/622f5a88-b5b5-437d-8d9d-b3a27701b9f7" />
<img width="885" height="799" alt="image" src="https://github.com/user-attachments/assets/65e04d41-a5e4-466b-8609-4713a785c5e4" />
<img width="778" height="640" alt="image" src="https://github.com/user-attachments/assets/d1db2574-c168-450e-bde0-bb86485cd7da" />
