### PR TITLE
build: Drop support for the hermetic llvm toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -230,14 +230,6 @@ build:wasi-wasm --extra_toolchains=@zig_sdk//toolchain:wasip1_wasm
 # https://github.com/WebAssembly/wasi-sdk/tree/f1ebc52a74394cdf885d03bfde13899b3d5c6d2d?tab=readme-ov-file#notable-limitations
 build:wasi-wasm --copt=-fno-exceptions
 
-# Hermetic LLVM toolchain
-# =========================================================
-# Note that these toolchains don't work on Windows:
-# https://github.com/bazel-contrib/toolchains_llvm/issues/395
-
-build:clang-amd64 --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
-build:clang-amd64 --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-
 # Fuzzing options
 # =========================================================
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,11 +66,6 @@ jobs:
             compiler: clang
             version: 20
 
-          - name: clang-20-libc++
-            os: ubuntu-24.04
-            bazel: --config clang-amd64
-            skip-compiler-install: true
-
           - name: clang-19
             os: ubuntu-24.04
             compiler: clang
@@ -109,12 +104,10 @@ jobs:
           sudo apt-add-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${{ matrix.version }} main"
       - uses: actions/checkout@v6
       - name: Install
-        if: ${{ !matrix.skip-compiler-install }}
         run: |
           sudo apt-get update
           sudo apt-get install --assume-yes --no-install-recommends ${{ matrix.compiler }}-${{ matrix.version }} ${{ matrix.apt }} libx11-dev libxi-dev
       - name: Install
-        if: ${{ matrix.skip-compiler-install }}
         run: |
           sudo apt-get update
           sudo apt-get install --assume-yes --no-install-recommends ${{ matrix.apt }} libx11-dev libxi-dev

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -156,24 +156,6 @@ archive_override(
     url = "https://github.com/bazel-contrib/rules_jvm_external/releases/download/{0}/rules_jvm_external-{0}.tar.gz".format(RULES_JVM_EXTERNAL_VERSION),
 )
 
-# https://github.com/bazel-contrib/toolchains_llvm
-TOOLCHAINS_LLVM_VERSION = "1.5.0"
-
-bazel_dep(name = "toolchains_llvm", dev_dependency = True)  # Apache-2.0
-archive_override(
-    module_name = "toolchains_llvm",
-    integrity = "sha256-SeacARvKpMmnJGooerH7T37T/efL1zADdMEDD0DSu5U=",
-    patch_cmds = [
-        """sed -i'' -e '1i\\\nload("@rules_cc//cc:defs.bzl", "cc_import")\\\n' toolchain/BUILD.toolchain.tpl""",
-    ],
-    strip_prefix = "toolchains_llvm-v%s" % TOOLCHAINS_LLVM_VERSION,
-    url = "https://github.com/bazel-contrib/toolchains_llvm/releases/download/v{0}/toolchains_llvm-v{0}.tar.gz".format(TOOLCHAINS_LLVM_VERSION),
-)
-
-llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
-llvm.toolchain(llvm_version = "20.1.8")
-use_repo(llvm, "llvm_toolchain")
-
 # Other Bazel-required dependencies
 # =========================================================
 


### PR DESCRIPTION
Newer versions of this has a lot of dependencies I don't want to deal with.