### PR TITLE
unicode: Implement NFD normalization

### DIFF
--- a/idna/idna_data_processor.cpp
+++ b/idna/idna_data_processor.cpp
@@ -97,9 +97,9 @@ bool last_mapping_was(auto const &mappings, std::optional<T> mapping = std::null
 };
 
 struct Idna {
-    // List of each code point starting a new mapping. I.e. if code point 1
+    // List of each code point ending a mapping. I.e. if code point 1
     // and 2 are disallowed, and 3 is valid, this list will be
-    // `[(1, Disallowed), (3, Valid)]`.
+    // `[(2, Disallowed), (3, Valid)]`.
     std::vector<std::pair<std::uint32_t, Mapping>> mappings;
 
     // https://www.unicode.org/reports/tr46/#Table_Data_File_Fields

--- a/unicode/BUILD
+++ b/unicode/BUILD
@@ -49,6 +49,7 @@ cc_library(
     name = "normalization",
     srcs = [
         "normalization.cpp",
+        ":generate_canonical_combining_class_data",
         ":generate_decomposition_data",
     ],
     hdrs = ["normalization.h"],
@@ -67,10 +68,7 @@ cc_library(
 [cc_test(
     name = src.removesuffix(".cpp"),
     size = "small",
-    srcs = [
-        src,
-        ":generate_canonical_combining_class_data",
-    ],
+    srcs = [src],
     copts = HASTUR_COPTS,
     deps = [
         ":normalization",

--- a/unicode/normalization.cpp
+++ b/unicode/normalization.cpp
@@ -4,15 +4,18 @@
 
 #include "unicode/normalization.h"
 
+#include "unicode/canonical_combining_class_data.h"
 #include "unicode/decomposition_data.h"
 #include "unicode/util.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <ostream>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 namespace unicode {
 namespace {
@@ -35,13 +38,51 @@ void decompose_to(std::ostream &os, char32_t code_point) {
     }
 }
 
+std::uint8_t canonical_combining_class(char32_t code_point) {
+    auto cls = std::ranges::lower_bound(generated::kCanonicalCombiningClasses,
+            code_point,
+            {},
+            &decltype(generated::kCanonicalCombiningClasses)::value_type::first);
+
+    // TODO(robinlinden): Generate better mapping table.
+    if (cls->first != code_point) {
+        cls -= 1;
+    }
+
+    return cls->second;
+}
+
 } // namespace
 
-std::string Normalization::decompose(std::string_view input) {
+// TODO(robinlinden): This is very inefficient. Make it less silly.
+std::string Normalization::nfd(std::string_view input) {
     std::stringstream ss;
 
     for (auto const code_point : CodePointView{input}) {
         decompose_to(ss, code_point);
+    }
+
+    auto decomposed = std::exchange(ss, {}).str();
+    std::vector<decltype(generated::kCanonicalCombiningClasses)::value_type> might_need_rearrangement;
+    for (auto const code_point : CodePointView{decomposed}) {
+        if (auto cls = canonical_combining_class(code_point); cls != 0) {
+            might_need_rearrangement.emplace_back(code_point, cls);
+        } else {
+            std::ranges::stable_sort(
+                    might_need_rearrangement, {}, &decltype(generated::kCanonicalCombiningClasses)::value_type::second);
+            for (auto [c, _] : might_need_rearrangement) {
+                decompose_to(ss, c);
+            }
+
+            decompose_to(ss, code_point);
+            might_need_rearrangement.clear();
+        }
+    }
+
+    std::ranges::stable_sort(
+            might_need_rearrangement, {}, &decltype(generated::kCanonicalCombiningClasses)::value_type::second);
+    for (auto [c, _] : might_need_rearrangement) {
+        decompose_to(ss, c);
     }
 
     return std::move(ss).str();

--- a/unicode/normalization.h
+++ b/unicode/normalization.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2024-2026 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -13,7 +13,7 @@ namespace unicode {
 class Normalization {
 public:
     // Normalizes the input into its canonical decomposition, NFD.
-    static std::string decompose(std::string_view);
+    static std::string nfd(std::string_view);
 };
 
 } // namespace unicode

--- a/unicode/normalization_test.cpp
+++ b/unicode/normalization_test.cpp
@@ -4,33 +4,36 @@
 
 #include "unicode/normalization.h"
 
-// TODO(robinlinden): This is just to check that this compiles for now, but
-// it'll be used soon.
-#include "unicode/canonical_combining_class_data.h" // IWYU pragma: keep
-
 #include "etest/etest2.h"
 
 int main() {
     etest::Suite s{};
 
-    s.add_test("not decomposed", [](etest::IActions &a) {
-        a.expect_eq(unicode::Normalization::decompose("abc123xyz"), "abc123xyz"); //
+    s.add_test("nfd: ascii, unchanged", [](etest::IActions &a) {
+        a.expect_eq(unicode::Normalization::nfd("abc123xyz"), "abc123xyz"); //
     });
 
-    s.add_test("decomposed", [](etest::IActions &a) {
+    s.add_test("nfd: needs decomposition", [](etest::IActions &a) {
         // A + COMBINING RING ABOVE
-        a.expect_eq(unicode::Normalization::decompose("Å"), "A\xcc\x8a");
+        a.expect_eq(unicode::Normalization::nfd("Å"), "A\xcc\x8a");
 
         // s + COMBINING DOT BELOW + COMBINING DOT ABOVE
-        a.expect_eq(unicode::Normalization::decompose("ṩ"), "s\xcc\xa3\xcc\x87");
+        a.expect_eq(unicode::Normalization::nfd("ṩ"), "s\xcc\xa3\xcc\x87");
     });
 
-    s.add_test("mixed", [](etest::IActions &a) {
+    s.add_test("nfd: ascii mixed w/ decomposable", [](etest::IActions &a) {
         // s + COMBINING DOT BELOW + COMBINING DOT ABOVE
-        a.expect_eq(unicode::Normalization::decompose("123ṩ567"),
+        a.expect_eq(unicode::Normalization::nfd("123ṩ567"),
                 "123"
                 "s\xcc\xa3\xcc\x87"
                 "567");
+    });
+
+    s.add_test("nfd: needs reordering", [](etest::IActions &a) {
+        // q + COMBINING CIRCUMFLEX ACCENT + COMBINING DOT BELOW
+        // The circumflex has combining class 230, and the dot has 220, so the
+        // dot should be sorted before the circumflex.
+        a.expect_eq(unicode::Normalization::nfd("q\xCC\x82\xCC\xA3"), "q\xCC\xA3\xCC\x82");
     });
 
     return s.run();


### PR DESCRIPTION
I'm going to redo some of this so we keep the intermediate representation as code points instead of taking a detour via UTF-8 which is a complete waste of time, but this works, so it's not blocking.