### PR TITLE
unicode: Generate the composition exclusion data table

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -671,7 +671,12 @@ EOF""",
 bazel_dep(name = "ucd")
 archive_override(
     module_name = "ucd",
-    build_file_content = """exports_files(["UnicodeData.txt"])""",
+    build_file_content = """
+exports_files([
+    "CompositionExclusions.txt",
+    "UnicodeData.txt",
+])
+""",
     integrity = "sha256-IGbRkJsuqTkWzgktocDuSAjqPvhAfJS08U9bfrJj0o4=",
     patch_cmds = [
         """cat <<EOF >MODULE.bazel

--- a/unicode/BUILD
+++ b/unicode/BUILD
@@ -26,6 +26,32 @@ genrule(
 )
 
 cc_binary(
+    name = "composition_exclusion_data_processor",
+    srcs = [
+        "composition_exclusion_data_processor.cpp",
+        ":generate_canonical_combining_class_data",
+    ],
+    copts = HASTUR_COPTS,
+    target_compatible_with = select({
+        # Contains filesystem I/O. Our current wasm/wasi-setup doesn't like that.
+        "@platforms//os:wasi": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = ["//util:string"],
+)
+
+genrule(
+    name = "generate_composition_exclusion_data",
+    srcs = [
+        "@ucd//:CompositionExclusions.txt",
+        "@ucd//:UnicodeData.txt",
+    ],
+    outs = ["composition_exclusion_data.h"],
+    cmd = "$(location :composition_exclusion_data_processor) $(location @ucd//:CompositionExclusions.txt) $(location @ucd//:UnicodeData.txt) >$@",
+    tools = [":composition_exclusion_data_processor"],
+)
+
+cc_binary(
     name = "decomposition_data_processor",
     srcs = ["decomposition_data_processor.cpp"],
     copts = HASTUR_COPTS,
@@ -50,6 +76,7 @@ cc_library(
     srcs = [
         "normalization.cpp",
         ":generate_canonical_combining_class_data",
+        ":generate_composition_exclusion_data",
         ":generate_decomposition_data",
     ],
     hdrs = ["normalization.h"],

--- a/unicode/composition_exclusion_data_processor.cpp
+++ b/unicode/composition_exclusion_data_processor.cpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "unicode/canonical_combining_class_data.h"
+
+#include "util/string.h"
+
+#include <algorithm>
+#include <charconv>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+namespace {
+
+std::uint8_t canonical_combining_class(char32_t code_point) {
+    auto cls = std::ranges::lower_bound(unicode::generated::kCanonicalCombiningClasses,
+            code_point,
+            {},
+            &decltype(unicode::generated::kCanonicalCombiningClasses)::value_type::first);
+
+    // TODO(robinlinden): Generate better mapping table.
+    if (cls->first != code_point) {
+        cls -= 1;
+    }
+
+    return cls->second;
+}
+
+std::uint32_t code_point_from_hex(std::string_view s) {
+    std::uint32_t cp{};
+    auto res = std::from_chars(s.data(), s.data() + s.size(), cp, 16);
+    if (res.ec != std::errc{} || res.ptr != s.data() + s.size()) {
+        std::cerr << "Unable to parse code point: " << s << '\n';
+        std::abort();
+    }
+
+    return cp;
+}
+
+} // namespace
+
+// https://www.unicode.org/reports/tr15/#Primary_Exclusion_List_Table
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        auto const *bin_name = argv[0] != nullptr ? argv[0] : "<bin>";
+        std::cerr << "Usage: " << bin_name << " <CompositionExclusions.txt> <UnicodeData.txt>\n";
+        return 1;
+    }
+
+    std::ifstream ce{argv[1]};
+    if (!ce) {
+        std::cerr << "Unable to open " << argv[1] << " for reading\n";
+        return 1;
+    }
+
+    std::ifstream ud{argv[2]};
+    if (!ud) {
+        std::cerr << "Unable to open " << argv[2] << " for reading\n";
+        return 1;
+    }
+
+    std::cout << R"(// SPDX-FileCopyrightText: 2026 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This file is generated. Do not touch it.
+
+#ifndef UNICODE_COMPOSITION_EXCLUSION_DATA_H_
+#define UNICODE_COMPOSITION_EXCLUSION_DATA_H_
+
+#include <array>
+
+namespace unicode::generated {
+
+constexpr auto kCompositionExclusions = std::to_array<char32_t>({
+)";
+
+    for (std::string line{}; std::getline(ce, line);) {
+        if (line.empty() || !util::is_hex_digit(line.front())) {
+            continue;
+        }
+
+        auto [code_point, _] = util::split_once(line, ' ');
+
+        std::cout << "        0x" << code_point << ",\n";
+    }
+
+    for (std::string line{}; std::getline(ud, line);) {
+        auto fields = util::split(line, ";");
+        if (fields.size() != 15) {
+            std::cerr << "Invalid row '" << line << "' in '" << argv[1] << "'.\n";
+            return 1;
+        }
+
+        // Filter out non-canonical decompositions.
+        auto decomposition_field = fields[5];
+        if (decomposition_field.empty() || decomposition_field[0] == '<') {
+            continue;
+        }
+
+        bool has_single_char_decomposition = !decomposition_field.contains(' ');
+        if (!has_single_char_decomposition) {
+            auto combining_class_field = fields[3];
+
+            auto [first_decomposition_character, _] = util::split_once(decomposition_field, ' ');
+            std::uint32_t code_point = code_point_from_hex(first_decomposition_character);
+            auto decomp_combining_class = canonical_combining_class(code_point);
+
+            if (combining_class_field == "0" && decomp_combining_class == 0) {
+                continue;
+            }
+        }
+
+        std::cout << "        0x" << fields[0] << ",\n";
+    }
+
+    std::cout << "});\n\n"
+              << "} // namespace unicode::generated\n\n"
+              << "#endif\n";
+}

--- a/unicode/normalization.cpp
+++ b/unicode/normalization.cpp
@@ -4,6 +4,9 @@
 
 #include "unicode/normalization.h"
 
+// TODO(robinlinden): Start using this.
+#include "unicode/composition_exclusion_data.h" // IWYU pragma: keep
+
 #include "unicode/canonical_combining_class_data.h"
 #include "unicode/decomposition_data.h"
 #include "unicode/util.h"


### PR DESCRIPTION
This is needed for when we start composing code points for the NFC
normalization.