### PR TITLE
doc: Recommend a simpler way of generating compile_commands.json

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -247,25 +247,6 @@ use_repo(zig_toolchains, "zig_sdk")
 # Misc tools
 # =========================================================
 
-# HEAD as of 2024-10-28.
-# https://github.com/hedronvision/bazel-compile-commands-extractor
-bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
-archive_override(
-    module_name = "hedron_compile_commands",
-    integrity = "sha256-ZYEiz7HyW+duohKwD16wR9jirci8+SO5GEYfKx43zfI=",
-    patch_cmds = [
-        # .h can also appear as a c_source_extension with the new syntax-checking Bazel does.
-        # See: https://github.com/hedronvision/bazel-compile-commands-extractor/pull/219
-        """sed -i'' -e "s/('.c', '.i')/('.c', '.i', '.h')/" refresh.template.py""",
-        # Fix use of autoloaded Bazel rules.
-        """sed -i'' -e '2i\\\nbazel_dep(name = "rules_python")\\\n' MODULE.bazel""",
-        """sed -i'' -e '59i\\\nload("@rules_python//python:defs.bzl", "py_binary")\\\n' refresh_compile_commands.bzl""",
-        """sed -i'' -e 's/native.py_binary(/py_binary(/' refresh_compile_commands.bzl""",
-    ],
-    strip_prefix = "bazel-compile-commands-extractor-4f28899228fb3ad0126897876f147ca15026151e",
-    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/4f28899228fb3ad0126897876f147ca15026151e.tar.gz",
-)
-
 # HEAD as of 2026-01-05.
 # https://github.com/erenon/bazel_clang_tidy
 BAZEL_CLANG_TIDY_VERSION = "da986512bf1a46831d886fd090393b93b8967a5d"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following assumes that you either have Bazel or Bazelisk under the name
 
 #### Generate json compilation database
 
-`bazel run @hedron_compile_commands//:refresh_all`
+Follow the instructions at [robinlinden/bazel-compile-commands](https://github.com/robinlinden/bazel-compile-commands).
 
 [bazel]: https://bazel.build
 [bazelisk]: https://github.com/bazelbuild/bazelisk


### PR DESCRIPTION
I've been using this for a bit now and it seems to work well, both on Linux and Windows, so let's drop the unmaintained tool I wanted to replace.