### PR TITLE
bzl: Split up the xfail rules into separate .bzl files

### DIFF
--- a/bzl/cc_xfail_test.bzl
+++ b/bzl/cc_xfail_test.bzl
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2022-2026 Robin Lindén <dev@robinlinden.eu>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""cc_xfail_test rule definition."""
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("//bzl:xfail_test.bzl", "xfail_test")
+
+def cc_xfail_test(**kwargs):
+    xfail_test(binary_rule = cc_binary, **kwargs)

--- a/bzl/sh_xfail_test.bzl
+++ b/bzl/sh_xfail_test.bzl
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2022-2026 Robin Lindén <dev@robinlinden.eu>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""sh_xfail_test rule definition."""
+
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("//bzl:xfail_test.bzl", "xfail_test")
+
+def sh_xfail_test(**kwargs):
+    xfail_test(binary_rule = sh_binary, **kwargs)

--- a/bzl/xfail_test.bzl
+++ b/bzl/xfail_test.bzl
@@ -4,11 +4,9 @@
 
 """Starlark rules for creating xfail tests."""
 
-load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
-def _xfail_test(
+def xfail_test(
         binary_rule,
         name,
         size = None,
@@ -32,9 +30,3 @@ def _xfail_test(
         args = ["$(location :%s_bin)" % name] + args,
         tags = tags,
     )
-
-def cc_xfail_test(**kwargs):
-    _xfail_test(binary_rule = cc_binary, **kwargs)
-
-def sh_xfail_test(**kwargs):
-    _xfail_test(binary_rule = sh_binary, **kwargs)

--- a/etest/BUILD
+++ b/etest/BUILD
@@ -1,6 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bzl:cc_xfail_test.bzl", "cc_xfail_test")
 load("//bzl:copts.bzl", "HASTUR_COPTS")
-load("//bzl:defs.bzl", "cc_xfail_test")
 
 cc_library(
     name = "etest",

--- a/html/BUILD
+++ b/html/BUILD
@@ -2,7 +2,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//bzl:copts.bzl", "HASTUR_COPTS", "HASTUR_FUZZ_PLATFORMS")
-load("//bzl:defs.bzl", "sh_xfail_test")
+load("//bzl:sh_xfail_test.bzl", "sh_xfail_test")
 
 cc_library(
     name = "html",


### PR DESCRIPTION
This seems to be what a lot of other rules do, and it also allows using `sh_xfail_test` without requiring `@rules_cc` to exist.