### PR TITLE
ci: Build w/ VS2026 in Windows jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -296,7 +296,7 @@ jobs:
         include:
           - compiler: clang-cl
           - compiler: msvc
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
This will be enforced by GitHub in a month, but we may as well switch right away to make sure we don't hit any annoying problems when we're forced to switch.