### PR TITLE
js: Add basic object support

### DIFF
--- a/js/ast.h
+++ b/js/ast.h
@@ -31,6 +31,7 @@ struct MemberExpression;
 struct ExpressionStatement;
 struct FunctionDeclaration;
 struct FunctionExpression;
+struct ObjectExpression;
 struct Identifier;
 struct IfStatement;
 struct NumericLiteral;
@@ -57,7 +58,8 @@ using Expression = std::variant<Identifier,
         CallExpression,
         MemberExpression,
         BinaryExpression,
-        FunctionExpression>;
+        FunctionExpression,
+        ObjectExpression>;
 
 struct ErrorValue;
 using ValueOrException = tl::expected<Value, ErrorValue>;
@@ -175,6 +177,10 @@ struct FunctionDeclaration {
 struct FunctionExpression {
     std::optional<Identifier> id;
     std::shared_ptr<Function> function;
+};
+
+struct ObjectExpression {
+    std::vector<std::pair<Identifier, Expression>> properties;
 };
 
 struct AssignmentExpression {

--- a/js/interpreter.h
+++ b/js/interpreter.h
@@ -122,6 +122,20 @@ public:
 
     ValueOrException operator()(FunctionExpression const &v) { return Value{v.function}; }
 
+    ValueOrException operator()(ObjectExpression const &v) {
+        Object obj;
+        for (auto const &prop : v.properties) {
+            auto value = execute(prop.second);
+            if (!value) {
+                return value;
+            }
+
+            obj[prop.first.name] = *std::move(value);
+        }
+
+        return Value{std::move(obj)};
+    }
+
     ValueOrException operator()(CallExpression const &v) {
         Interpreter scope{*this};
 

--- a/js/interpreter_test.cpp
+++ b/js/interpreter_test.cpp
@@ -557,5 +557,36 @@ int main() {
         a.expect_eq(Interpreter{}.execute(func_expr), Value{func_expr.function});
     });
 
+    s.add_test("object expression", [](etest::IActions &a) {
+        auto obj_expr = ObjectExpression{
+                .properties{
+                        {Identifier{"hello"}, NumericLiteral{5.}},
+                        {Identifier{"world"}, StringLiteral{"hi"}},
+                },
+        };
+
+        a.expect_eq(Interpreter{}.execute(obj_expr),
+                Value{Object{
+                        {"hello", Value{5.}},
+                        {"world", Value{"hi"}},
+                }});
+    });
+
+    s.add_test("object expression, exception in property value", [](etest::IActions &a) {
+        auto obj_expr = ObjectExpression{
+                .properties{
+                        {
+                                Identifier{"hello"},
+                                CallExpression{
+                                        .callee = std::make_shared<Expression>(Identifier{"foo"}),
+                                },
+                        },
+                },
+        };
+
+        auto result = Interpreter{}.execute(obj_expr);
+        a.expect_eq(result.has_value(), false);
+    });
+
     return s.run();
 }

--- a/js/parser.h
+++ b/js/parser.h
@@ -245,6 +245,59 @@ private:
     }
 
     // NOLINTNEXTLINE(misc-no-recursion)
+    [[nodiscard]] static std::optional<ast::ObjectExpression> parse_object_expression(std::span<parse::Token> &tokens) {
+        if (!std::holds_alternative<parse::LBrace>(tokens.front())) {
+            return std::nullopt;
+        }
+
+        tokens = tokens.subspan(1); // '{'
+
+        if (tokens.empty()) {
+            return std::nullopt;
+        }
+
+        std::vector<std::pair<ast::Identifier, ast::Expression>> properties;
+
+        while (!std::holds_alternative<parse::RBrace>(tokens.front())) {
+            auto *key = std::get_if<parse::Identifier>(&tokens.front());
+            if (key == nullptr) {
+                return std::nullopt;
+            }
+
+            tokens = tokens.subspan(1); // identifier
+
+            if (!std::holds_alternative<parse::Colon>(tokens.front())) {
+                return std::nullopt;
+            }
+
+            tokens = tokens.subspan(1); // ':'
+
+            auto value = parse_expression(tokens);
+            if (!value) {
+                return std::nullopt;
+            }
+
+            properties.emplace_back(ast::Identifier{.name = std::move(key->name)}, std::move(*value));
+
+            if (tokens.empty()) {
+                return std::nullopt;
+            }
+
+            if (std::holds_alternative<parse::Comma>(tokens.front())) {
+                tokens = tokens.subspan(1); // ','
+
+                if (tokens.empty()) {
+                    return std::nullopt;
+                }
+            }
+        }
+
+        tokens = tokens.subspan(1); // '}'
+
+        return ast::ObjectExpression{.properties{std::move(properties)}};
+    }
+
+    // NOLINTNEXTLINE(misc-no-recursion)
     [[nodiscard]] static std::optional<ast::Expression> parse_expression(std::span<parse::Token> &tokens) {
         if (tokens.empty()) {
             return std::nullopt;
@@ -263,6 +316,8 @@ private:
             expr = ast::Identifier{std::move(std::get<parse::Identifier>(token).name)};
         } else if (std::holds_alternative<parse::Function>(tokens.front())) {
             expr = parse_function_expression(tokens);
+        } else if (std::holds_alternative<parse::LBrace>(tokens.front())) {
+            expr = parse_object_expression(tokens);
         } else {
             return std::nullopt;
         }

--- a/js/parser_test.cpp
+++ b/js/parser_test.cpp
@@ -449,5 +449,72 @@ int main() {
         a.expect(std::holds_alternative<js::ast::EmptyStatement>(second_statement));
     });
 
+    s.add_test("object expression, empty", [](etest::IActions &a) {
+        auto p = js::Parser::parse("a = {};").value();
+
+        a.expect_eq(p.body.size(), std::size_t{1});
+        auto &statement = p.body.at(0);
+        auto &expr_stmt = std::get<js::ast::ExpressionStatement>(statement);
+        auto &assign = std::get<js::ast::AssignmentExpression>(expr_stmt.expression);
+        a.expect_eq(std::get<js::ast::Identifier>(*assign.left).name, "a");
+
+        auto &obj_expr = std::get<js::ast::ObjectExpression>(*assign.right);
+        a.expect_eq(obj_expr.properties.size(), std::size_t{0});
+    });
+
+    s.add_test("object expression, with properties", [](etest::IActions &a) {
+        auto p = js::Parser::parse("a = { a: 1, b: 'hello', };").value();
+
+        a.expect_eq(p.body.size(), std::size_t{1});
+        auto &statement = p.body.at(0);
+        auto &expr_stmt = std::get<js::ast::ExpressionStatement>(statement);
+        auto &assign = std::get<js::ast::AssignmentExpression>(expr_stmt.expression);
+        a.expect_eq(std::get<js::ast::Identifier>(*assign.left).name, "a");
+
+        auto &obj_expr = std::get<js::ast::ObjectExpression>(*assign.right);
+        a.expect_eq(obj_expr.properties.size(), std::size_t{2});
+
+        auto &first_property = obj_expr.properties.at(0);
+        a.expect_eq(first_property.first.name, "a");
+        a.expect_eq(std::get<js::ast::NumericLiteral>(std::get<js::ast::Literal>(first_property.second)).value, 1.);
+
+        auto &second_property = obj_expr.properties.at(1);
+        a.expect_eq(second_property.first.name, "b");
+        a.expect_eq(
+                std::get<js::ast::StringLiteral>(std::get<js::ast::Literal>(second_property.second)).value, "hello");
+    });
+
+    s.add_test("object expression, nested objects", [](etest::IActions &a) {
+        auto p = js::Parser::parse("a = { a: { b: 2 } };").value();
+
+        a.expect_eq(p.body.size(), std::size_t{1});
+        auto &statement = p.body.at(0);
+        auto &expr_stmt = std::get<js::ast::ExpressionStatement>(statement);
+        auto &assign = std::get<js::ast::AssignmentExpression>(expr_stmt.expression);
+        a.expect_eq(std::get<js::ast::Identifier>(*assign.left).name, "a");
+
+        auto &obj_expr = std::get<js::ast::ObjectExpression>(*assign.right);
+        a.expect_eq(obj_expr.properties.size(), std::size_t{1});
+
+        auto &first_property = obj_expr.properties.at(0);
+        a.expect_eq(first_property.first.name, "a");
+
+        auto &nested_obj_expr = std::get<js::ast::ObjectExpression>(first_property.second);
+        a.expect_eq(nested_obj_expr.properties.size(), std::size_t{1});
+
+        auto &nested_property = nested_obj_expr.properties.at(0);
+        a.expect_eq(nested_property.first.name, "b");
+        a.expect_eq(std::get<js::ast::NumericLiteral>(std::get<js::ast::Literal>(nested_property.second)).value, 2.);
+    });
+
+    s.add_test("object expression, bad", [](etest::IActions &a) {
+        a.expect_eq(js::Parser::parse("a = {").has_value(), false);
+        a.expect_eq(js::Parser::parse("a = { a: 1").has_value(), false);
+        a.expect_eq(js::Parser::parse("a = { a: 1,").has_value(), false);
+        a.expect_eq(js::Parser::parse("a = { a: 1, b }").has_value(), false);
+        a.expect_eq(js::Parser::parse("a = { a: 1, : 2 }").has_value(), false);
+        a.expect_eq(js::Parser::parse("a = { a: 1, b: }").has_value(), false);
+    });
+
     return s.run();
 }

--- a/js/token.cpp
+++ b/js/token.cpp
@@ -24,6 +24,7 @@ struct StringifyVisitor {
     std::string operator()(Semicolon const &) { return "Semicolon"; }
     std::string operator()(Comma const &) { return "Comma"; }
     std::string operator()(Period const &) { return "Period"; }
+    std::string operator()(Colon const &) { return "Colon"; }
     std::string operator()(Equals const &) { return "Equals"; }
     std::string operator()(Plus const &) { return "Plus"; }
     std::string operator()(Asterisk const &) { return "Asterisk"; }

--- a/js/token.h
+++ b/js/token.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2025 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2026 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -66,6 +66,10 @@ struct Comma {
 
 struct Period {
     bool operator==(Period const &) const = default;
+};
+
+struct Colon {
+    bool operator==(Colon const &) const = default;
 };
 
 struct Equals {
@@ -253,6 +257,7 @@ using Token = std::variant< //
         Semicolon,
         Comma,
         Period,
+        Colon,
         Equals,
         Plus,
         Asterisk,

--- a/js/tokenizer.h
+++ b/js/tokenizer.h
@@ -76,6 +76,8 @@ public:
                 return Comma{};
             case '.':
                 return Period{};
+            case ':':
+                return Colon{};
             case '=':
                 return Equals{};
             case '+':

--- a/js/tokenizer_test.cpp
+++ b/js/tokenizer_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2025 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2026 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -89,7 +89,7 @@ int main() {
 
     s.add_test("braces", [](etest::IActions &a) {
         expect_tokens(a, "{}", {LBrace{}, RBrace{}});
-        expect_tokens(a, "{ }", {LBrace{}, RBrace{}});
+        expect_tokens(a, "{ : }", {LBrace{}, Colon{}, RBrace{}});
         expect_tokens(a, "{ hello }", {LBrace{}, Identifier{"hello"}, RBrace{}});
         expect_tokens(a, "{ hello; }", {LBrace{}, Identifier{"hello"}, Semicolon{}, RBrace{}});
     });


### PR DESCRIPTION
Also seems fine in the repl, even if parts of the interpreter need tweaking for full support:
```
INFO: Running command line: bazel-bin/js/repl/repl
'/quit' to quit.
> a = { b: 3 };
[Object]
> a.b;
3.000000
```