### PR TITLE
deps: Add glfw

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -51,8 +51,6 @@ build:macos      --cxxopt='-std=c++2b'
 build:macos --host_cxxopt='-std=c++2b'
 build:macos      --cxxopt='-fno-rtti'
 build:macos --host_cxxopt='-fno-rtti'
-build:macos --objccopt='-ObjC++'
-build:macos --objccopt='-std=c++2b'
 
 build:windows --enable_runfiles
 build:windows --action_env=LOCALAPPDATA # Quirk for running vswhere, remove when icu no-longer needed

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -419,6 +419,28 @@ local_path_override(
     path = "third_party/glad2",
 )
 
+# https://github.com/glfw/glfw
+GLFW_VERSION = "3.4"
+
+bazel_dep(name = "glfw")  # Zlib
+archive_override(
+    module_name = "glfw",
+    build_file = "//third_party:glfw.BUILD",
+    integrity = "sha256-tewASycS/Qjohh3CcUKPBId1IAot9xnM9XUUO6dJo+k=",
+    patch_cmds = [
+        """cat <<EOF >MODULE.bazel
+module(name = "glfw")
+bazel_dep(name = "platforms")
+bazel_dep(name = "rules_cc")
+bazel_dep(name = "xcursor")
+bazel_dep(name = "xext")
+bazel_dep(name = "xrandr")
+EOF""",
+    ],
+    strip_prefix = "glfw-%s" % GLFW_VERSION,
+    url = "https://github.com/glfw/glfw/releases/download/{0}/glfw-{0}.zip".format(GLFW_VERSION),
+)
+
 # HEAD, last updated at 2026-05-09.
 # https://github.com/html5lib/html5lib-tests/
 HTML5LIB_TESTS_VERSION = "85c968aca811edcb5eb6020b5b9184b2c42a86ab"

--- a/third_party/glfw.BUILD
+++ b/third_party/glfw.BUILD
@@ -1,0 +1,162 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
+
+COMMON_SRCS = [
+    "src/context.c",
+    "src/egl_context.c",
+    "src/init.c",
+    "src/input.c",
+    "src/internal.h",
+    "src/mappings.h",
+    "src/monitor.c",
+    "src/null_init.c",
+    "src/null_joystick.c",
+    "src/null_joystick.h",
+    "src/null_monitor.c",
+    "src/null_platform.h",
+    "src/null_window.c",
+    "src/osmesa_context.c",
+    "src/platform.c",
+    "src/platform.h",
+    "src/vulkan.c",
+    "src/window.c",
+    "src/xkb_unicode.c",
+    "src/xkb_unicode.h",
+]
+
+objc_library(
+    name = "glfw_macos",
+    srcs = COMMON_SRCS + [
+        "src/cocoa_joystick.h",
+        "src/cocoa_platform.h",
+        "src/cocoa_time.c",
+        "src/cocoa_time.h",
+        "src/posix_module.c",
+        "src/posix_poll.c",
+        "src/posix_thread.c",
+        "src/posix_thread.h",
+    ],
+    hdrs = [
+        "include/GLFW/glfw3.h",
+        "include/GLFW/glfw3native.h",
+    ],
+    defines = ["_GLFW_COCOA"],
+    includes = ["include/"],
+    non_arc_srcs = [
+        "src/cocoa_init.m",
+        "src/cocoa_joystick.m",
+        "src/cocoa_monitor.m",
+        "src/cocoa_window.m",
+        "src/nsgl_context.m",
+    ],
+    sdk_frameworks = [
+        "Cocoa",
+        "CoreFoundation",
+        "IOKit",
+        "OpenGL",
+    ],
+    target_compatible_with = ["@platforms//os:macos"],
+)
+
+cc_library(
+    name = "glfw_linux",
+    srcs = COMMON_SRCS + [
+        "src/glx_context.c",
+        "src/linux_joystick.c",
+        "src/linux_joystick.h",
+        "src/posix_module.c",
+        "src/posix_poll.c",
+        "src/posix_poll.h",
+        "src/posix_thread.c",
+        "src/posix_thread.h",
+        "src/posix_time.c",
+        "src/posix_time.h",
+        "src/x11_init.c",
+        "src/x11_monitor.c",
+        "src/x11_platform.h",
+        "src/x11_window.c",
+    ],
+    hdrs = [
+        "include/GLFW/glfw3.h",
+        "include/GLFW/glfw3native.h",
+    ],
+    # TODO(robinlinden): Needed until we've ported Xinerama to Bazel.
+    features = ["-layering_check"],
+    linkopts = [
+        "-lX11",
+        "-lXinerama",
+    ],
+    local_defines = ["_GLFW_X11"],
+    strip_include_prefix = "include/",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        "@xcursor",
+        "@xext",
+        "@xrandr",
+    ],
+)
+
+cc_library(
+    name = "glfw_windows",
+    srcs = COMMON_SRCS + [
+        "src/wgl_context.c",
+        "src/win32_init.c",
+        "src/win32_joystick.c",
+        "src/win32_joystick.h",
+        "src/win32_module.c",
+        "src/win32_monitor.c",
+        "src/win32_platform.h",
+        "src/win32_thread.c",
+        "src/win32_thread.h",
+        "src/win32_time.c",
+        "src/win32_time.h",
+        "src/win32_window.c",
+    ],
+    hdrs = [
+        "include/GLFW/glfw3.h",
+        "include/GLFW/glfw3native.h",
+    ],
+    linkopts = [
+        "-DEFAULTLIB:gdi32.lib",
+        "-DEFAULTLIB:shell32.lib",
+        "-DEFAULTLIB:user32.lib",
+    ],
+    local_defines = ["_GLFW_WIN32"],
+    strip_include_prefix = "include/",
+    target_compatible_with = ["@platforms//os:windows"],
+)
+
+alias(
+    name = "glfw",
+    actual = select({
+        "@platforms//os:linux": ":glfw_linux",
+        "@platforms//os:macos": ":glfw_macos",
+        "@platforms//os:windows": ":glfw_windows",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+# Example nonsense.
+
+cc_library(
+    name = "glad",
+    hdrs = ["deps/glad/gl.h"],
+    strip_include_prefix = "deps/",
+)
+
+cc_library(
+    name = "linmath",
+    hdrs = ["deps/linmath.h"],
+    strip_include_prefix = "deps/",
+)
+
+cc_binary(
+    name = "boing_example",
+    srcs = ["examples/boing.c"],
+    deps = [
+        ":glad",
+        ":glfw",
+        ":linmath",
+    ],
+)

--- a/third_party/sfml.BUILD
+++ b/third_party/sfml.BUILD
@@ -159,6 +159,8 @@ objc_library(
     copts = [
         "-Iexternal/sfml+/src/",
         "-frtti",
+        "-ObjC++",
+        "-std=c++2b",
     ],
     defines = SFML_DEFINES,
     implementation_deps = [":sf_glad"],


### PR DESCRIPTION
This has less extra nonsense than SFML, both in functionality and dependencies. glfw is also usable when compiling to wasm, so if we set something up w/ this, we can in theory run it in a browser as well: https://emscripten.org/docs/compiling/Contrib-Ports.html#contrib-glfw3

I verified that I can run the example on both Windows and Linux, and I also checked that everything builds on macOS, but didn't run anything.