### PR TITLE
wasm: Add support for 'Call' in interpreter

### DIFF
--- a/wasm/interpreter.h
+++ b/wasm/interpreter.h
@@ -18,6 +18,7 @@
 #include <optional>
 #include <span>
 #include <tuple>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -107,10 +108,18 @@ enum class Trap : std::uint8_t {
 class Interpreter {
 public:
     using Value = std::variant<std::int32_t, std::int64_t, float>;
+
+    struct Function {
+        std::vector<instructions::Instruction> body;
+        std::uint32_t local_count{};
+        [[nodiscard]] bool operator==(Function const &) const = default;
+    };
+
     std::vector<Value> stack;
     std::vector<Value> locals;
     std::vector<Value> globals;
     std::vector<std::uint8_t> memory;
+    std::vector<Function> functions;
     bool returning{false};
     [[nodiscard]] constexpr bool operator==(Interpreter const &) const = default;
 
@@ -132,6 +141,31 @@ public:
     // Sets the returning flag so run() stops executing further instructions.
     tl::expected<void, Trap> interpret(instructions::Return const &) {
         returning = true;
+        return {};
+    }
+
+    // https://webassembly.github.io/spec/core/exec/instructions.html#function-calls
+    // Invoke function[idx] in its own isolated frame; push its result (if any) onto our stack.
+    tl::expected<void, Trap> interpret(instructions::Call const &call) {
+        assert(call.function_idx < functions.size());
+        auto const &fn = functions[call.function_idx];
+
+        auto saved_locals = std::exchange(locals, std::vector<Value>(fn.local_count));
+        auto saved_returning = std::exchange(returning, false);
+
+        auto result = run(fn.body);
+
+        // Restore caller frame.
+        locals = std::move(saved_locals);
+        returning = saved_returning;
+
+        if (!result) {
+            return tl::unexpected{result.error()};
+        }
+        auto &retval = result.value();
+        if (retval.has_value()) {
+            stack.push_back(*retval);
+        }
         return {};
     }
 

--- a/wasm/interpreter_test.cpp
+++ b/wasm/interpreter_test.cpp
@@ -72,6 +72,41 @@ int main() {
         a.expect_eq(res, std::nullopt);
     });
 
+    s.add_test("call: function invocation", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#function-calls
+        Interpreter i;
+        i.functions = {{{I32Const{42}, End{}}, 0}};
+        auto res = i.run({{Call{0}}});
+        a.expect_eq(res, wasm::Interpreter::Value{42});
+    });
+
+    s.add_test("call: callee gets isolated locals", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#function-calls
+        // Callee writes to local 0; caller's local 0 must be unchanged after the call.
+        Interpreter i;
+        i.locals = {wasm::Interpreter::Value{99}};
+        i.functions = {{{I32Const{42}, LocalSet{0}, LocalGet{0}, End{}}, 1}};
+        auto res = i.run({{Call{0}}});
+        a.expect_eq(res, wasm::Interpreter::Value{42});
+        a.expect_eq(i.locals[0], wasm::Interpreter::Value{99});
+    });
+
+    s.add_test("call: caller resumes after callee returns", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#function-calls
+        Interpreter i;
+        i.functions = {{{I32Const{41}, End{}}, 0}};
+        auto res = i.run({{Call{0}, I32Const{1}, I32Add{}}});
+        a.expect_eq(res, wasm::Interpreter::Value{42});
+    });
+
+    s.add_test("call: trap in callee propagates to caller", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#function-calls
+        Interpreter i;
+        i.functions = {{{Select{}}, 0}};
+        auto res = i.run({{Call{0}}});
+        a.expect_eq(res, tl::unexpected{wasm::Trap::UnhandledInstruction});
+    });
+
     s.add_test("i32.const", [](etest::IActions &a) {
         Interpreter i;
         auto res = i.run({{I32Const{42}}});


### PR DESCRIPTION
## Description:

Adds function call support to the Wasm interpreter.

Introduces a Function struct on Interpreter holding a instruction body and a local count.
interpret(Call) executes the callee in an isolated frame — caller locals and returning state are saved and restored around the call.
The callee's result (if any) is pushed onto the caller's stack, allowing the caller to continue executing with it.

**Three tests cover:* 

- Basic invocation
- Frame isolation (callee writes don't affect caller locals)
- That the caller resumes correctly after the call returns.

**Note:** Suggestions for writing shorter test descriptions that remain understandable are welcome. 😄