### PR TITLE
wasm: Add interpreter support for 'i64.const'

### DIFF
--- a/wasm/instructions.h
+++ b/wasm/instructions.h
@@ -53,6 +53,7 @@ struct End;
 
 // Numeric instructions
 struct I32Const;
+struct I64Const;
 struct I32EqualZero;
 struct I32Equal;
 struct I32NotEqual;
@@ -140,6 +141,7 @@ using Instruction = std::variant<Select,
         I32ShiftRightUnsigned,
         I32RotateLeft,
         I32RotateRight,
+        I64Const,
         I32WrapI64,
         I32TruncateF32Signed,
         I32TruncateF32Unsigned,
@@ -217,6 +219,13 @@ struct I32Const {
     static constexpr std::string_view kMnemonic = "i32.const";
     std::int32_t value{};
     [[nodiscard]] bool operator==(I32Const const &) const = default;
+};
+
+struct I64Const {
+    static constexpr std::uint8_t kOpcode = 0x42;
+    static constexpr std::string_view kMnemonic = "i64.const";
+    std::int64_t value{};
+    [[nodiscard]] bool operator==(I64Const const &) const = default;
 };
 
 struct I32EqualZero {

--- a/wasm/interpreter.h
+++ b/wasm/interpreter.h
@@ -81,7 +81,7 @@ enum class Trap : std::uint8_t {
 
 class Interpreter {
 public:
-    using Value = std::variant<std::int32_t>;
+    using Value = std::variant<std::int32_t, std::int64_t>;
     std::vector<Value> stack;
     std::vector<Value> locals;
     std::vector<Value> globals;
@@ -113,6 +113,11 @@ public:
     // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
     // t.const c
     tl::expected<void, Trap> interpret(instructions::I32Const const &v) {
+        stack.emplace_back(v.value);
+        return {};
+    }
+
+    tl::expected<void, Trap> interpret(instructions::I64Const const &v) {
         stack.emplace_back(v.value);
         return {};
     }

--- a/wasm/interpreter_test.cpp
+++ b/wasm/interpreter_test.cpp
@@ -78,6 +78,20 @@ int main() {
         a.expect_eq(res, wasm::Interpreter::Value{42});
     });
 
+    s.add_test("i64.const: push value", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{42}}}});
+        a.expect_eq(res, wasm::Interpreter::Value{std::int64_t{42}});
+    });
+
+    s.add_test("i64.const: value exceeds i32 range", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{3'000'000'000}}}});
+        a.expect_eq(res, wasm::Interpreter::Value{std::int64_t{3'000'000'000}});
+    });
+
     s.add_test("i32.lt_s", [](etest::IActions &a) {
         Interpreter i;
         // Less.

--- a/wasm/serialize.cpp
+++ b/wasm/serialize.cpp
@@ -31,6 +31,7 @@ struct InstructionStringifyVisitor {
     void operator()(BranchIf const &t);
     void operator()(Call const &t);
     void operator()(I32Const const &t);
+    void operator()(I64Const const &t);
     void operator()(LocalGet const &t);
     void operator()(LocalSet const &t);
     void operator()(LocalTee const &t);
@@ -74,6 +75,10 @@ void InstructionStringifyVisitor::operator()(Call const &t) {
 
 void InstructionStringifyVisitor::operator()(I32Const const &t) {
     out << I32Const::kMnemonic << " " << std::to_string(t.value);
+}
+
+void InstructionStringifyVisitor::operator()(I64Const const &t) {
+    out << I64Const::kMnemonic << " " << std::to_string(t.value);
 }
 
 template<typename T>


### PR DESCRIPTION
Adds i64.const support to the Wasm interpreter.