### PR TITLE
ci: Allow macOS jobs to take longer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -281,7 +281,7 @@ jobs:
           - os: macos-26
             skip-gui: true
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
       - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >.bazelrc.local


### PR DESCRIPTION
Something (on GitHub's side?) changed and now the macOS jobs take a lot longer than they used to.