### PR TITLE
ci: Run jobs on Ubuntu 26.04 where it makes sense

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,7 @@ build --sandbox_default_allow_network=false
 
 build --incompatible_autoload_externally=
 build --incompatible_config_setting_private_default_visibility
+build --incompatible_remote_local_fallback_for_remote_cache
 
 # Third-party configuration
 # =========================================================
@@ -153,6 +154,7 @@ build:buildbuddy-cache-common --config=buildbuddy-bes
 build:buildbuddy-cache-common --remote_cache=grpcs://remote.buildbuddy.io
 build:buildbuddy-cache-common --remote_timeout=3600
 build:buildbuddy-cache-common --remote_cache_compression
+build:buildbuddy-cache-common --remote_local_fallback
 build:buildbuddy-cache-common --experimental_remote_cache_compression_threshold=100
 build:buildbuddy-cache-common --nolegacy_important_outputs
 build:buildbuddy-cache-common --noslim_profile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,15 +31,13 @@ jobs:
             apt: valgrind
 
           - name: gcc-15
-            os: ubuntu-24.04
-            container: ubuntu:25.04
+            os: ubuntu-26.04
             compiler: gcc
             version: 15
             apt: g++-15
 
           - name: gcc-16
-            os: ubuntu-24.04
-            container: ubuntu:26.04
+            os: ubuntu-26.04
             compiler: gcc
             version: 16
             apt: g++-16
@@ -69,22 +67,22 @@ jobs:
             apt: libc++abi-18-dev libc++-18-dev libclang-rt-18-dev
 
           - name: clang-20
-            os: ubuntu-24.04
+            os: ubuntu-26.04
             compiler: clang
             version: 20
 
           - name: clang-22
-            os: ubuntu-24.04
+            os: ubuntu-26.04
             compiler: clang
             version: 22
 
           - name: clang-19
-            os: ubuntu-24.04
+            os: ubuntu-26.04
             compiler: clang
             version: 19
 
           - name: clang-21-libc++
-            os: ubuntu-24.04
+            os: ubuntu-26.04
             compiler: clang
             version: 21
             bazel: --config libc++
@@ -109,11 +107,6 @@ jobs:
         run: |
           echo "CC=clang-${{ matrix.version }}" >> $GITHUB_ENV
           echo "CXX=clang++-${{ matrix.version }}" >> $GITHUB_ENV
-      - name: Set up the llvm repository
-        if: startsWith(matrix.compiler, 'clang') && matrix.version >= 19
-        run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${{ matrix.version }} main"
       - uses: actions/checkout@v6
       - name: Install
         run: |
@@ -368,7 +361,7 @@ jobs:
       - run: git diff --exit-code
 
   clang-tidy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
@@ -382,10 +375,6 @@ jobs:
         with:
           path: ~/.cache/bazel
           key: clang_tidy-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'third_party/**') }}
-      - name: Set up the llvm repository
-        run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main"
       - run: sudo apt-get update && sudo apt-get install --no-install-recommends clang-tidy-22 libc++abi-22-dev libc++-22-dev
       - run: echo "CC=clang-22" >>$GITHUB_ENV && echo "CXX=clang++-22" >>$GITHUB_ENV
       - run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -329,7 +329,10 @@ jobs:
       - run: echo "build --config=buildbuddy-cache-upload --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >>.bazelrc.local
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
-        if: env.BUILDBUDDY_API_KEY != ''
+        # TODO(robinlinden): Bazel's fallback to local when the remote cache is
+        # broken seems to be broken, and the remote cache seems to be very
+        # broken in the clang-cl job.
+        if: env.BUILDBUDDY_API_KEY != '' && matrix.compiler != 'clang-cl'
       - run: bazel test ...
       - name: Run tui
         run: |


### PR DESCRIPTION
The clang-cl job was very upset about
``` 
ERROR: D:/a/hastur/hastur/img/BUILD:105:10: Linking img/img_example.exe failed: Failed to fetch blobs because of a remote cache error.: C:\users\runneradmin\_bazel_runneradmin\425h7iu3\execroot\_main\bazel-out\x64_windows-fastbuild\bin\img\_objs\img_example\img_example.obj (Permission denied)
```
(on ~every binary) so there are some attempts at fixes and workarounds for that in here as well.