### PR TITLE
wasm: Add interpreter support for i64 arithmetic

### DIFF
--- a/wasm/instructions.h
+++ b/wasm/instructions.h
@@ -54,6 +54,11 @@ struct End;
 // Numeric instructions
 struct I32Const;
 struct I64Const;
+struct I64Equal;
+struct I64LessThanSigned;
+struct I64Add;
+struct I64Subtract;
+struct I64Multiply;
 struct I32EqualZero;
 struct I32Equal;
 struct I32NotEqual;
@@ -142,6 +147,11 @@ using Instruction = std::variant<Select,
         I32RotateLeft,
         I32RotateRight,
         I64Const,
+        I64Equal,
+        I64LessThanSigned,
+        I64Add,
+        I64Subtract,
+        I64Multiply,
         I32WrapI64,
         I32TruncateF32Signed,
         I32TruncateF32Unsigned,
@@ -226,6 +236,51 @@ struct I64Const {
     static constexpr std::string_view kMnemonic = "i64.const";
     std::int64_t value{};
     [[nodiscard]] bool operator==(I64Const const &) const = default;
+};
+
+struct I64Equal {
+    static constexpr std::uint8_t kOpcode = 0x51;
+    static constexpr std::string_view kMnemonic = "i64.eq";
+
+    static constexpr NumericType kNumericType = NumericType::Relop;
+    using NumType = std::int64_t;
+    [[nodiscard]] bool operator==(I64Equal const &) const = default;
+};
+
+struct I64LessThanSigned {
+    static constexpr std::uint8_t kOpcode = 0x53;
+    static constexpr std::string_view kMnemonic = "i64.lt_s";
+
+    static constexpr NumericType kNumericType = NumericType::Relop;
+    using NumType = std::int64_t;
+    [[nodiscard]] bool operator==(I64LessThanSigned const &) const = default;
+};
+
+struct I64Add {
+    static constexpr std::uint8_t kOpcode = 0x7c;
+    static constexpr std::string_view kMnemonic = "i64.add";
+
+    static constexpr NumericType kNumericType = NumericType::Binop;
+    using NumType = std::int64_t;
+    [[nodiscard]] bool operator==(I64Add const &) const = default;
+};
+
+struct I64Subtract {
+    static constexpr std::uint8_t kOpcode = 0x7d;
+    static constexpr std::string_view kMnemonic = "i64.sub";
+
+    static constexpr NumericType kNumericType = NumericType::Binop;
+    using NumType = std::int64_t;
+    [[nodiscard]] bool operator==(I64Subtract const &) const = default;
+};
+
+struct I64Multiply {
+    static constexpr std::uint8_t kOpcode = 0x7e;
+    static constexpr std::string_view kMnemonic = "i64.mul";
+
+    static constexpr NumericType kNumericType = NumericType::Binop;
+    using NumType = std::int64_t;
+    [[nodiscard]] bool operator==(I64Multiply const &) const = default;
 };
 
 struct I32EqualZero {

--- a/wasm/interpreter.h
+++ b/wasm/interpreter.h
@@ -72,6 +72,31 @@ struct InterpreterInfo<instructions::I32ExclusiveOr> {
     using Operation = std::bit_xor<std::int32_t>;
 };
 
+template<>
+struct InterpreterInfo<instructions::I64Equal> {
+    using Operation = std::equal_to<std::int64_t>;
+};
+
+template<>
+struct InterpreterInfo<instructions::I64LessThanSigned> {
+    using Operation = std::less<std::int64_t>;
+};
+
+template<>
+struct InterpreterInfo<instructions::I64Add> {
+    using Operation = std::plus<std::int64_t>;
+};
+
+template<>
+struct InterpreterInfo<instructions::I64Subtract> {
+    using Operation = std::minus<std::int64_t>;
+};
+
+template<>
+struct InterpreterInfo<instructions::I64Multiply> {
+    using Operation = std::multiplies<std::int64_t>;
+};
+
 } // namespace detail
 
 enum class Trap : std::uint8_t {

--- a/wasm/interpreter_test.cpp
+++ b/wasm/interpreter_test.cpp
@@ -92,6 +92,41 @@ int main() {
         a.expect_eq(res, wasm::Interpreter::Value{std::int64_t{3'000'000'000}});
     });
 
+    s.add_test("i64.add", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{2'000'000'000}}, I64Const{std::int64_t{2'000'000'000}}, I64Add{}}});
+        a.expect_eq(res, wasm::Interpreter::Value{std::int64_t{4'000'000'000}});
+    });
+
+    s.add_test("i64.sub", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{10}}, I64Const{std::int64_t{3}}, I64Subtract{}}});
+        a.expect_eq(res, wasm::Interpreter::Value{std::int64_t{7}});
+    });
+
+    s.add_test("i64.mul", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{3'000'000}}, I64Const{std::int64_t{3'000'000}}, I64Multiply{}}});
+        a.expect_eq(res, wasm::Interpreter::Value{std::int64_t{9'000'000'000'000}});
+    });
+
+    s.add_test("i64.eq", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{42}}, I64Const{std::int64_t{42}}, I64Equal{}}});
+        a.expect_eq(res, wasm::Interpreter::Value{1});
+    });
+
+    s.add_test("i64.lt_s", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{1}}, I64Const{std::int64_t{2}}, I64LessThanSigned{}}});
+        a.expect_eq(res, wasm::Interpreter::Value{1});
+    });
+
     s.add_test("i32.lt_s", [](etest::IActions &a) {
         Interpreter i;
         // Less.


### PR DESCRIPTION
Adds five i64 instructions to the interpreter: i64.eq, i64.lt_s, i64.add, i64.sub, and i64.mul.

This time with short test names. 😉

