### PR TITLE
Wasm interpreter f32const

### DIFF
--- a/wasm/instructions.h
+++ b/wasm/instructions.h
@@ -54,6 +54,7 @@ struct End;
 // Numeric instructions
 struct I32Const;
 struct I64Const;
+struct F32Const;
 struct I64Equal;
 struct I64LessThanSigned;
 struct I64Add;
@@ -147,6 +148,7 @@ using Instruction = std::variant<Select,
         I32RotateLeft,
         I32RotateRight,
         I64Const,
+        F32Const,
         I64Equal,
         I64LessThanSigned,
         I64Add,
@@ -236,6 +238,13 @@ struct I64Const {
     static constexpr std::string_view kMnemonic = "i64.const";
     std::int64_t value{};
     [[nodiscard]] bool operator==(I64Const const &) const = default;
+};
+
+struct F32Const {
+    static constexpr std::uint8_t kOpcode = 0x43;
+    static constexpr std::string_view kMnemonic = "f32.const";
+    float value{};
+    [[nodiscard]] bool operator==(F32Const const &) const = default;
 };
 
 struct I64Equal {

--- a/wasm/instructions.h
+++ b/wasm/instructions.h
@@ -54,6 +54,11 @@ struct End;
 // Numeric instructions
 struct I32Const;
 struct I64Const;
+struct I64Equal;
+struct I64LessThanSigned;
+struct I64Add;
+struct I64Subtract;
+struct I64Multiply;
 struct I32EqualZero;
 struct I32Equal;
 struct I32NotEqual;
@@ -142,6 +147,11 @@ using Instruction = std::variant<Select,
         I32RotateLeft,
         I32RotateRight,
         I64Const,
+        I64Equal,
+        I64LessThanSigned,
+        I64Add,
+        I64Subtract,
+        I64Multiply,
         I32WrapI64,
         I32TruncateF32Signed,
         I32TruncateF32Unsigned,
@@ -226,6 +236,51 @@ struct I64Const {
     static constexpr std::string_view kMnemonic = "i64.const";
     std::int64_t value{};
     [[nodiscard]] bool operator==(I64Const const &) const = default;
+};
+
+struct I64Equal {
+    static constexpr std::uint8_t kOpcode = 0x51;
+    static constexpr std::string_view kMnemonic = "i64.eq";
+
+    static constexpr NumericType kNumericType = NumericType::Relop;
+    using NumType = std::int64_t;
+    [[nodiscard]] bool operator==(I64Equal const &) const = default;
+};
+
+struct I64LessThanSigned {
+    static constexpr std::uint8_t kOpcode = 0x53;
+    static constexpr std::string_view kMnemonic = "i64.lt_s";
+
+    static constexpr NumericType kNumericType = NumericType::Relop;
+    using NumType = std::int64_t;
+    [[nodiscard]] bool operator==(I64LessThanSigned const &) const = default;
+};
+
+struct I64Add {
+    static constexpr std::uint8_t kOpcode = 0x7c;
+    static constexpr std::string_view kMnemonic = "i64.add";
+
+    static constexpr NumericType kNumericType = NumericType::Binop;
+    using NumType = std::int64_t;
+    [[nodiscard]] bool operator==(I64Add const &) const = default;
+};
+
+struct I64Subtract {
+    static constexpr std::uint8_t kOpcode = 0x7d;
+    static constexpr std::string_view kMnemonic = "i64.sub";
+
+    static constexpr NumericType kNumericType = NumericType::Binop;
+    using NumType = std::int64_t;
+    [[nodiscard]] bool operator==(I64Subtract const &) const = default;
+};
+
+struct I64Multiply {
+    static constexpr std::uint8_t kOpcode = 0x7e;
+    static constexpr std::string_view kMnemonic = "i64.mul";
+
+    static constexpr NumericType kNumericType = NumericType::Binop;
+    using NumType = std::int64_t;
+    [[nodiscard]] bool operator==(I64Multiply const &) const = default;
 };
 
 struct I32EqualZero {

--- a/wasm/interpreter.h
+++ b/wasm/interpreter.h
@@ -72,6 +72,31 @@ struct InterpreterInfo<instructions::I32ExclusiveOr> {
     using Operation = std::bit_xor<std::int32_t>;
 };
 
+template<>
+struct InterpreterInfo<instructions::I64Equal> {
+    using Operation = std::equal_to<std::int64_t>;
+};
+
+template<>
+struct InterpreterInfo<instructions::I64LessThanSigned> {
+    using Operation = std::less<std::int64_t>;
+};
+
+template<>
+struct InterpreterInfo<instructions::I64Add> {
+    using Operation = std::plus<std::int64_t>;
+};
+
+template<>
+struct InterpreterInfo<instructions::I64Subtract> {
+    using Operation = std::minus<std::int64_t>;
+};
+
+template<>
+struct InterpreterInfo<instructions::I64Multiply> {
+    using Operation = std::multiplies<std::int64_t>;
+};
+
 } // namespace detail
 
 enum class Trap : std::uint8_t {

--- a/wasm/interpreter.h
+++ b/wasm/interpreter.h
@@ -106,7 +106,7 @@ enum class Trap : std::uint8_t {
 
 class Interpreter {
 public:
-    using Value = std::variant<std::int32_t, std::int64_t>;
+    using Value = std::variant<std::int32_t, std::int64_t, float>;
     std::vector<Value> stack;
     std::vector<Value> locals;
     std::vector<Value> globals;
@@ -143,6 +143,11 @@ public:
     }
 
     tl::expected<void, Trap> interpret(instructions::I64Const const &v) {
+        stack.emplace_back(v.value);
+        return {};
+    }
+
+    tl::expected<void, Trap> interpret(instructions::F32Const const &v) {
         stack.emplace_back(v.value);
         return {};
     }

--- a/wasm/interpreter_test.cpp
+++ b/wasm/interpreter_test.cpp
@@ -92,6 +92,20 @@ int main() {
         a.expect_eq(res, wasm::Interpreter::Value{std::int64_t{3'000'000'000}});
     });
 
+    s.add_test("f32.const: push value", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{F32Const{3.14f}}});
+        a.expect_eq(res, wasm::Interpreter::Value{3.14f});
+    });
+
+    s.add_test("f32.const: negative value", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{F32Const{-1.5f}}});
+        a.expect_eq(res, wasm::Interpreter::Value{-1.5f});
+    });
+
     s.add_test("i64.add", [](etest::IActions &a) {
         // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
         Interpreter i;

--- a/wasm/interpreter_test.cpp
+++ b/wasm/interpreter_test.cpp
@@ -92,6 +92,41 @@ int main() {
         a.expect_eq(res, wasm::Interpreter::Value{std::int64_t{3'000'000'000}});
     });
 
+    s.add_test("i64.add", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{2'000'000'000}}, I64Const{std::int64_t{2'000'000'000}}, I64Add{}}});
+        a.expect_eq(res, wasm::Interpreter::Value{std::int64_t{4'000'000'000}});
+    });
+
+    s.add_test("i64.sub", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{10}}, I64Const{std::int64_t{3}}, I64Subtract{}}});
+        a.expect_eq(res, wasm::Interpreter::Value{std::int64_t{7}});
+    });
+
+    s.add_test("i64.mul", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{3'000'000}}, I64Const{std::int64_t{3'000'000}}, I64Multiply{}}});
+        a.expect_eq(res, wasm::Interpreter::Value{std::int64_t{9'000'000'000'000}});
+    });
+
+    s.add_test("i64.eq", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{42}}, I64Const{std::int64_t{42}}, I64Equal{}}});
+        a.expect_eq(res, wasm::Interpreter::Value{1});
+    });
+
+    s.add_test("i64.lt_s", [](etest::IActions &a) {
+        // https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions
+        Interpreter i;
+        auto res = i.run({{I64Const{std::int64_t{1}}, I64Const{std::int64_t{2}}, I64LessThanSigned{}}});
+        a.expect_eq(res, wasm::Interpreter::Value{1});
+    });
+
     s.add_test("i32.lt_s", [](etest::IActions &a) {
         Interpreter i;
         // Less.

--- a/wasm/serialize.cpp
+++ b/wasm/serialize.cpp
@@ -32,6 +32,7 @@ struct InstructionStringifyVisitor {
     void operator()(Call const &t);
     void operator()(I32Const const &t);
     void operator()(I64Const const &t);
+    void operator()(F32Const const &t);
     void operator()(LocalGet const &t);
     void operator()(LocalSet const &t);
     void operator()(LocalTee const &t);
@@ -79,6 +80,10 @@ void InstructionStringifyVisitor::operator()(I32Const const &t) {
 
 void InstructionStringifyVisitor::operator()(I64Const const &t) {
     out << I64Const::kMnemonic << " " << std::to_string(t.value);
+}
+
+void InstructionStringifyVisitor::operator()(F32Const const &t) {
+    out << F32Const::kMnemonic << " " << std::to_string(t.value);
 }
 
 template<typename T>


### PR DESCRIPTION
Adds `f32.const` to the Wasm interpreter. 🐻‍❄️

Follows #1486, and thus depends on it being merged first. So ignore the i64 commit. It will be dropped when rebasing.