### PR TITLE
idna: Support encoding text as punycode

### DIFF
--- a/etest/constexpr_test.cpp
+++ b/etest/constexpr_test.cpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "etest/etest2.h"
+
+int main() {
+    etest::Suite s{};
+
+    // This only tests success since failures in constexpr tests are detected at
+    // compile-time, and we want our code to compile.
+    s.constexpr_test("secret meme goes here", [](etest::IActions &a) {
+        a.expect(true);
+        a.expect_eq(1, 1);
+        a.require(true);
+        a.require_eq(1, 1);
+    });
+
+    return s.run();
+}

--- a/etest/etest2.h
+++ b/etest/etest2.h
@@ -71,7 +71,7 @@ public:
             std::optional<std::string_view> log_message, std::source_location const &) noexcept = 0;
 
     // Weak test requirement. Allows the test to continue even if the check fails.
-    void expect(bool expectation,
+    constexpr void expect(bool expectation,
             std::optional<std::string_view> log_message = std::nullopt,
             std::source_location const &loc = std::source_location::current()) noexcept {
         if (expectation) {
@@ -82,7 +82,7 @@ public:
     }
 
     // Hard test requirement. Stops the test (using an exception) if the check fails.
-    void require(bool requirement,
+    constexpr void require(bool requirement,
             std::optional<std::string_view> log_message = std::nullopt,
             std::source_location const &loc = std::source_location::current()) {
         if (requirement) {

--- a/idna/punycode.h
+++ b/idna/punycode.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2026 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -8,6 +8,9 @@
 #include "unicode/util.h"
 
 #include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <string>
@@ -84,6 +87,87 @@ public:
         return unicode_to_utf8(output);
     }
 
+    static constexpr std::optional<std::string> to_punycode(std::string_view utf8_text) {
+        auto code_points = utf8_to_unicode(utf8_text);
+        return to_punycode(code_points);
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc3492#section-6.3
+    static constexpr std::optional<std::string> to_punycode(std::u32string_view input) {
+        std::string out;
+
+        char32_t n = kInitialN;
+        int delta = 0;
+        int bias = kInitialBias;
+        std::size_t h = 0;
+
+        for (std::uint32_t c : input) {
+            if (unicode::is_ascii(c)) {
+                ++h;
+                out.push_back(static_cast<char>(c));
+            }
+        }
+
+        std::size_t b = h;
+        if (b > 0) {
+            out.push_back(kDelimiter);
+        }
+
+        while (h < input.size()) {
+            char32_t m = kHighestBasicCodePoint;
+            for (auto code_point : input) {
+                if (code_point >= n && code_point < m) {
+                    m = code_point;
+                }
+            }
+
+            // TODO(robinlinden): Fail on overflow.
+            delta += (m - n) * static_cast<int>(h + 1);
+            n = m;
+
+            for (auto c : input) {
+                if (c < n) {
+                    // TODO(robinlinden): Fail on overflow.
+                    ++delta;
+                }
+
+                if (c == n) {
+                    int q = delta;
+                    for (int k = kBase;; k += kBase) {
+                        int t = [&] {
+                            if (k <= bias) {
+                                return kTMin;
+                            }
+
+                            if (k >= bias + kTMax) {
+                                return kTMax;
+                            }
+
+                            return k - bias;
+                        }();
+
+                        if (q < t) {
+                            break;
+                        }
+
+                        out.push_back(digit_to_char(t + ((q - t) % (kBase - t))));
+                        q = (q - t) / (kBase - t);
+                    }
+
+                    out.push_back(digit_to_char(q));
+                    bias = adapt(delta, static_cast<int>(h + 1), h == b);
+                    delta = 0;
+                    ++h;
+                }
+            }
+
+            ++delta;
+            ++n;
+        }
+
+        return out;
+    }
+
 private:
     // Parameter values for Punycode
     // https://datatracker.ietf.org/doc/html/rfc3492#section-5
@@ -94,6 +178,8 @@ private:
     static constexpr int kDamp = 700;
     static constexpr int kInitialBias = 72;
     static constexpr int kInitialN = 128;
+
+    static constexpr char32_t kHighestBasicCodePoint = 0x10FFFF;
 
     static constexpr bool is_basic_code_point(char32_t cp) { return cp < 0x80; }
 
@@ -115,6 +201,15 @@ private:
         return std::nullopt;
     }
 
+    static constexpr char digit_to_char(std::uint32_t digit) {
+        if (digit < 26) {
+            return static_cast<char>(digit + 'a');
+        }
+
+        assert(unicode::is_ascii(digit + '0' - 26));
+        return static_cast<char>(digit + '0' - 26);
+    }
+
     // https://datatracker.ietf.org/doc/html/rfc3492#section-6.1
     static constexpr int adapt(int delta, int numpoints, bool firsttime) {
         delta = firsttime ? delta / kDamp : delta / 2;
@@ -133,6 +228,16 @@ private:
         std::string result;
         for (auto const code_point : code_points) {
             result += unicode::to_utf8(code_point);
+        }
+
+        return result;
+    }
+
+    static constexpr std::u32string utf8_to_unicode(std::string_view utf8_text) {
+        std::u32string result;
+        auto u32_view = unicode::CodePointView{utf8_text};
+        for (auto const code_point : u32_view) {
+            result += char32_t{code_point};
         }
 
         return result;

--- a/idna/punycode_test.cpp
+++ b/idna/punycode_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2026 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -29,7 +29,7 @@ int main() {
         // u+0644 u+064A u+0647 u+0645 u+0627 u+0628 u+062A u+0643 u+0644
         // u+0645 u+0648 u+0634 u+0639 u+0631 u+0628 u+064A u+061F
         // Punycode: egbpdaj6bu4bxfgehfvwxn
-        std::string expected = unicode_as_utf8_string({0x0644,
+        std::string utf8 = unicode_as_utf8_string({0x0644,
                 0x064A,
                 0x0647,
                 0x0645,
@@ -46,7 +46,11 @@ int main() {
                 0x0628,
                 0x064A,
                 0x061F});
-        a.expect_eq(idna::Punycode::to_utf8("egbpdaj6bu4bxfgehfvwxn").value(), expected);
+
+        static constexpr auto kPunycode = "egbpdaj6bu4bxfgehfvwxn";
+
+        a.expect_eq(idna::Punycode::to_utf8(kPunycode).value(), utf8);
+        a.expect_eq(idna::Punycode::to_punycode(utf8), kPunycode);
     });
 
     s.constexpr_test("(M) <amuro><namie>-with-SUPER-MONKEYS", [](etest::IActions &a) {
@@ -54,7 +58,7 @@ int main() {
         // u+0068 u+002D U+0053 U+0055 U+0050 U+0045 U+0052 u+002D U+004D
         // U+004F U+004E U+004B U+0045 U+0059 U+0053
         // Punycode: -with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n
-        std::string expected = unicode_as_utf8_string({0x5B89,
+        std::string utf8 = unicode_as_utf8_string({0x5B89,
                 0x5BA4,
                 0x5948,
                 0x7F8E,
@@ -78,16 +82,22 @@ int main() {
                 'E',
                 'Y',
                 'S'});
-        a.expect_eq(idna::Punycode::to_utf8("-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n").value(), expected);
+        static constexpr auto kPunycode = "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n";
+
+        a.expect_eq(idna::Punycode::to_utf8(kPunycode).value(), utf8);
+        a.expect_eq(idna::Punycode::to_punycode(utf8).value(), kPunycode);
     });
 
     s.constexpr_test("(P) Maji<de>Koi<suru>5<byou><mae>", [](etest::IActions &a) {
         // U+004D u+0061 u+006A u+0069 u+3067 U+004B u+006F u+0069 u+3059
         // u+308B u+0035 u+79D2 u+524D
         // Punycode: MajiKoi5-783gue6qz075azm5e
-        std::string expected = unicode_as_utf8_string(
+        std::string utf8 = unicode_as_utf8_string(
                 {'M', 'a', 'j', 'i', 0x3067, 'K', 'o', 'i', 0x3059, 0x308B, '5', 0x79D2, 0x524D});
-        a.expect_eq(idna::Punycode::to_utf8("MajiKoi5-783gue6qz075azm5e").value(), expected);
+        static constexpr auto kPunycode = "MajiKoi5-783gue6qz075azm5e";
+
+        a.expect_eq(idna::Punycode::to_utf8(kPunycode).value(), utf8);
+        a.expect_eq(idna::Punycode::to_punycode(utf8).value(), kPunycode);
     });
 
     // Error handling.


### PR DESCRIPTION
The punycode stuff still needs better handling for bad input (especially the CodePointView), but this has all the functionality in place. I ran the uts46 spectests and the url wpt tests against it, and they seemed happy with all ascii-punycode-related bits.

I didn't end up needing the constexpr expect and require things in this PR, but it's a tiny change and makes sense on its own.