### PR TITLE
js: Fix UB in object expression error handling

### DIFF
--- a/js/parser.h
+++ b/js/parser.h
@@ -266,7 +266,7 @@ private:
 
             tokens = tokens.subspan(1); // identifier
 
-            if (!std::holds_alternative<parse::Colon>(tokens.front())) {
+            if (tokens.empty() || !std::holds_alternative<parse::Colon>(tokens.front())) {
                 return std::nullopt;
             }
 

--- a/js/parser_test.cpp
+++ b/js/parser_test.cpp
@@ -509,6 +509,7 @@ int main() {
 
     s.add_test("object expression, bad", [](etest::IActions &a) {
         a.expect_eq(js::Parser::parse("a = {").has_value(), false);
+        a.expect_eq(js::Parser::parse("a = { a").has_value(), false);
         a.expect_eq(js::Parser::parse("a = { a: 1").has_value(), false);
         a.expect_eq(js::Parser::parse("a = { a: 1,").has_value(), false);
         a.expect_eq(js::Parser::parse("a = { a: 1, b }").has_value(), false);


### PR DESCRIPTION
This was found by our fuzzing setup when updating from LLVM 18 to 19.