### PR TITLE
ci: Drop support for Clang 18 w/ libstdc++

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,22 +42,23 @@ jobs:
             version: 16
             apt: g++-16
 
-          - name: clang-18-tsan
-            os: ubuntu-24.04
+          - name: clang-19-tsan
+            os: ubuntu-26.04
             compiler: clang
-            version: 18
-            bazel: -c dbg --config tsan --test_env=TSAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18
-            apt: libclang-rt-18-dev llvm-18
+            version: 19
+            bazel: -c dbg --config tsan --test_env=TSAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-19
+            apt: libclang-rt-19-dev llvm-19
 
           # TODO(robinlinden): icu breaks w/ Clang 19 + asan/ubsan:
           # external/icu+/_objs/common/udata.o:udata.cpp:function openCommonData(char const*, int, UErrorCode*):(.text._ZL14openCommonDataPKciP10UErrorCode+0x4a0): error: undefined reference to 'icudt78_dat'
-          - name: clang-18-asan-ubsan
-            os: ubuntu-24.04
+          - name: clang-19-asan-ubsan
+            os: ubuntu-26.04
             compiler: clang
-            version: 18
-            bazel: -c dbg --config asan --config ubsan --test_env=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 --config libfuzzer
-            apt: libclang-rt-18-dev llvm-18
+            version: 19
+            bazel: -c dbg --config asan --config ubsan --test_env=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-19 --config libfuzzer --build_tag_filters=-no-asan --test_tag_filters=-no-asan
+            apt: libclang-rt-19-dev llvm-19
             fuzz: true
+            fuzz-tag: -no-asan
 
           - name: clang-20-libc++
             os: ubuntu-24.04
@@ -75,11 +76,6 @@ jobs:
             os: ubuntu-26.04
             compiler: clang
             version: 22
-
-          - name: clang-19
-            os: ubuntu-26.04
-            compiler: clang
-            version: 19
 
           - name: clang-21-libc++
             os: ubuntu-26.04
@@ -144,6 +140,8 @@ jobs:
           ./bzl/run_fuzz_tests ... \
             ${{ matrix.bazel }} \
             -- --timeout_secs=10
+        env:
+          FUZZ_TAG: ${{ matrix.fuzz-tag }}
 
   coverage:
     name: linux-${{ matrix.compiler }}-${{ matrix.version }}-coverage

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### Compiler
 
-Right now GCC 13, Clang 18, and MSVC are tested against. The project makes use
+Right now GCC 13, Clang 19, and MSVC are tested against. The project makes use
 of C++23 features, so a reasonably recent compiler is required.
 
 #### Build system

--- a/bzl/run_fuzz_tests
+++ b/bzl/run_fuzz_tests
@@ -1,18 +1,35 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: 2024 Robin Lindén <dev@robinlinden.eu>
+# SPDX-FileCopyrightText: 2024-2026 Robin Lindén <dev@robinlinden.eu>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
 # Run all fuzz tests under a given pattern.
+#
+# If set, FUZZ_TAG can be used to filter fuzz tests by tag. If FUZZ_TAG starts
+# with a dash, it will exclude tests with that tag.
 #
 # Example usage:
 # ./bzl/run_fuzz_tests wasm/... --config libfuzzer -c dbg -- --timeout_secs=3
 
 set -euo pipefail
 
-TARGETS=$(bazel query "filter(.*_fuzz_test_run$, $1)")
+PATTERN="$1"
 shift
+
+BASE_QUERY="filter(.*_fuzz_test_run\$, $PATTERN)"
+QUERY="$BASE_QUERY"
+
+if [[ -n "${FUZZ_TAG:-}" ]]; then
+  if [[ "$FUZZ_TAG" == -* ]]; then
+    TAG="${FUZZ_TAG#-}"
+    QUERY="$BASE_QUERY except attr(tags, \"$TAG\", $BASE_QUERY)"
+  else
+    QUERY="attr(tags, \"$FUZZ_TAG\", $BASE_QUERY)"
+  fi
+fi
+
+TARGETS=$(bazel query "$QUERY")
 
 for tgt in ${TARGETS}; do
   bazel run "$tgt" "$@"

--- a/css/parser.cpp
+++ b/css/parser.cpp
@@ -420,6 +420,7 @@ StyleSheet Parser::parse_rules() {
         }
 
         if (!parse_rule(style, media_query, nullptr)) {
+            // TODO(robinlinden): There are non-eof cases where we end up here.
             spdlog::error("Eof while parsing rule");
             return style;
         }
@@ -590,7 +591,7 @@ bool Parser::parse_rule(StyleSheet &style, std::optional<MediaQuery> const &acti
 
 std::optional<std::pair<std::string_view, std::string_view>> Parser::parse_declaration(std::string_view declaration) {
     auto sep = declaration.find(':');
-    if (sep == std::string_view::npos) {
+    if (sep == 0 || sep == std::string_view::npos) {
         return std::nullopt;
     }
 

--- a/css/parser_test.cpp
+++ b/css/parser_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2026 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021 Mikael Larsson <c.mikael.larsson@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -1483,6 +1483,13 @@ int main() {
                         css::Rule{{"p"}, {{css::PropertyId::FontSize, "3px"}}},
                         css::Rule{{"a"}, {{css::PropertyId::Color, "green"}}},
                 });
+    });
+
+    s.add_test("parser: no declaration name", [](etest::IActions &a) {
+        // We currently don't try very hard to recover from rule-parsing
+        // failures, so we never get to the second rule here.
+        auto rules = css::parse("p { : 3px; } a { color: green; }").rules;
+        a.expect_eq(rules, std::vector<css::Rule>{});
     });
 
     return s.run();

--- a/url/BUILD
+++ b/url/BUILD
@@ -2,6 +2,9 @@ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 load("//bzl:copts.bzl", "HASTUR_COPTS", "HASTUR_FUZZ_PLATFORMS")
 
+# TODO(robinlinden): icu breaks w/ Clang 19 + asan/ubsan, so asan is disabled here for now.
+# external/icu+/_objs/common/udata.o:udata.cpp:function openCommonData(char const*, int, UErrorCode*):(.text._ZL14openCommonDataPKciP10UErrorCode+0x4a0): error: undefined reference to 'icudt78_dat'
+
 cc_library(
     name = "rtti_hack",
     srcs = ["rtti_hack.cpp"],
@@ -10,6 +13,7 @@ cc_library(
         "@platforms//os:windows": ["/GR"],
         "//conditions:default": ["-frtti"],
     }),
+    tags = ["no-asan"],
     deps = ["@icu//:common"],
 )
 
@@ -67,7 +71,10 @@ cc_library(
         "@icu//:common",
         "@icu//:icudata",
     ],
-    tags = ["no-cross"],
+    tags = [
+        "no-asan",
+        "no-cross",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -76,7 +83,10 @@ cc_test(
     size = "small",
     srcs = ["url_test.cpp"],
     copts = HASTUR_COPTS,
-    tags = ["no-cross"],
+    tags = [
+        "no-asan",
+        "no-cross",
+    ],
     deps = [
         ":url",
         "//etest",
@@ -91,7 +101,10 @@ cc_test(
     args = ["$(location @wpt_urltestdata//file)"],
     copts = HASTUR_COPTS,
     data = ["@wpt_urltestdata//file"],
-    tags = ["no-cross"],
+    tags = [
+        "no-asan",
+        "no-cross",
+    ],
     deps = [
         ":url",
         "//etest",
@@ -107,7 +120,10 @@ cc_fuzz_test(
     srcs = ["url_fuzz_test.cpp"],
     copts = HASTUR_COPTS,
     corpus = glob(["url_fuzz_test_corpus/**"]),
-    tags = ["no-cross"],
+    tags = [
+        "no-asan",
+        "no-cross",
+    ],
     target_compatible_with = HASTUR_FUZZ_PLATFORMS,
     deps = [":url"],
 )


### PR DESCRIPTION
This combination doesn't support std::expected.

Our fuzzing setup also found some new things after the update from LLVM 18 to 19.