### PR TITLE
meta/gitlint: Switch to the non-deprecated match behaviour

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,6 @@
 [general]
 ignore=body-is-missing
+regex-style-search=true
 
 # TODO(robinlinden): Better way of documenting and setting this up.
 # Each commit must start with the main area it affects.


### PR DESCRIPTION
We're getting this warning printed in CI when running gitlint:

> WARNING: I3 - ignore-body-lines: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-body-lines.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details: https://jorisroovers.github.io/gitlint/configuration/#regex-style-search